### PR TITLE
9552 - Product Reviews scrolls too low

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
@@ -1,6 +1,6 @@
 {% load bg_nav_tags localization i18n static wagtailroutablepage_tags wagtailmetadata_tags %}
 <nav id="multipage-nav" class="pni-category-nav text-center d-none d-md-block tw-no-scrollbar" title="{% trans "site navigation" context "Tooltip on menu items" %}">
-    <div class="container tw-py-2" id="product-review">
+    <div class="container tw-py-2" id="buyersguide-category-container">
       <div class="row">
         <div class="col">
           <div id="pni-category-wrapper" class="tw-flex tw-items-center tw-w-max tw-min-w-full">

--- a/source/js/buyers-guide/search/member-functions.js
+++ b/source/js/buyers-guide/search/member-functions.js
@@ -217,6 +217,7 @@ export function setupReviewLinks(instance) {
         nav.classList.add("active");
         location.hash = "product-review";
         editorialContent.classList.add("tw-hidden");
+        window.scrollTo(0, 0);
         if (burger && burger.classList.contains("menu-open")) {
           document.querySelector(".burger").click();
         }

--- a/source/js/buyers-guide/search/member-functions.js
+++ b/source/js/buyers-guide/search/member-functions.js
@@ -209,7 +209,9 @@ export function setupReviewLinks(instance) {
 
   for (const nav of navLinks) {
     nav.addEventListener("click", (evt) => {
-      const editorialContent = document.querySelector(".editorial-content");
+      const editorialContent = document.querySelector(
+        ".editorial-content:not(.tw-hidden)"
+      );
       const burger = document.querySelector(".burger");
       if (editorialContent) {
         evt.preventDefault();

--- a/source/js/buyers-guide/template-js-handler/pni-category-dropdown.js
+++ b/source/js/buyers-guide/template-js-handler/pni-category-dropdown.js
@@ -9,7 +9,7 @@ export default () => {
   // Needed for calculating which items go into the dropdown
   const navLinkMargin = 20;
   const categoryWrapper = document.querySelector("#pni-category-wrapper");
-  const categoryNav = document.querySelector("#product-review");
+  const categoryNav = document.querySelector("#buyersguide-category-container");
 
   const calculateWidthAndMargin = (ele) => ele.clientWidth + navLinkMargin;
 


### PR DESCRIPTION
# Description

`window.scrollTo(0,0)` Seems to be missing when `product-review` link gets clicked!

Link to sample test page: /en/privacynotincluded -> click on `product review`
Related PRs/issues: #9552 
