### PR TITLE
change the active color to black from the dark-blue

### DIFF
--- a/source/sass/components/primary-nav.scss
+++ b/source/sass/components/primary-nav.scss
@@ -42,7 +42,7 @@
       &:hover {
         text-decoration: wavy $pni-wavy-blue 2px underline;
         text-underline-offset: 0.5rem;
-        color: $dark-blue;
+        color: $black;
       }
     }
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
I've change the selection color for the navbar for PNI to black from the default dark-blue

Link to sample test page:
Related PRs/issues: #
for the issue #9669
asking @beccaklam for reviews

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
