### PR TITLE
10130 - Images in the Slider block are  compressed

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/slider_card.html
+++ b/network-api/networkapi/mozfest/templates/fragments/slider_card.html
@@ -1,6 +1,12 @@
+{% load wagtailimages_tags %}
 <div class="tw-border tw-border-gray-60/20 tw-p-8 large:tw-p-24 tw-h-full tw-flex tw-flex-col tw-items-start tw-text-black">
     {% if image %}
-        <img class="tw-w-full tw-h-auto tw-aspect-video tw-object-cover" src="{{ image }}" alt="{{ image_alt }}">
+        <img 
+            class="tw-w-full tw-h-auto tw-aspect-video tw-object-cover"
+            src="{% image_url image "fill-429x241" %}"
+            srcset="{% image_url image "fill-858x482" %} 2x, {% image_url image "fill-1287x723" %} 3x"
+            alt="{{ image_alt }}"
+        >
         <div class="tw-mt-2">
             <span class="tw-font-sans  tw-font-normal tw-text-xs">{{ detail }}</span>
         </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/foundation_slider_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/foundation_slider_block.html
@@ -16,9 +16,8 @@
             {% block slides %}
                 <div class="swiper-wrapper">
                     {% for slide in self.slides %}
-                        {% image slide.value.image fill-429x241 as img %}
                         <div class="swiper-slide">
-                            {% include 'fragments/slider_card.html' with title=slide.value.title detail=slide.value.image_detail buttons=slide.value.buttons image=img.url text=slide.value.body %}
+                            {% include 'fragments/slider_card.html' with title=slide.value.title detail=slide.value.image_detail buttons=slide.value.buttons image=slide.value.image text=slide.value.body %}
                         </div>
                     {% endfor %}
                 </div>


### PR DESCRIPTION
# Description

1. Edit a page by adding a foundation slider streamfield. 
2. Add at least one slide with an image
3. Inspect the image and see that scrset supports 2x display and 3x

Link to sample test page:
Related PRs/issues: #10130

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
