### PR TITLE
10158 - Uncaught TypeError on product review pages

### DIFF
--- a/source/js/buyers-guide/template-js-handler/product-page-comment-handler.js
+++ b/source/js/buyers-guide/template-js-handler/product-page-comment-handler.js
@@ -18,7 +18,7 @@ export default () => {
       // New comments are appended in the form of: <div><div class='commento-card'/></div>
       // If comment tracking ever breaks, this logic would be a good place to check first.
       // For more context, see: https://github.com/mozilla/foundation.mozilla.org/pull/9414
-      if (mutation.addedNodes[0].firstChild.matches(".commento-card")) {
+      if (mutation.addedNodes[0]?.firstChild.matches(".commento-card")) {
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
           event: "form_submission",


### PR DESCRIPTION
# Description

optional value check for commento mutation

Link to sample test page:
Related PRs/issues: #10158

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
