### PR TITLE
Update elements to use '.tw-form-control' instead of Bootstrap's '.form-control'

### DIFF
--- a/network-api/networkapi/templates/fragments/language_switcher.html
+++ b/network-api/networkapi/templates/fragments/language_switcher.html
@@ -7,7 +7,7 @@
     <input name="next" type="hidden" value="{% get_unlocalized_url page current_language %}" />
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-center mb-md-0">
         <label class="tw-h5-heading mb-0 d-flex align-items-center tw-globe-glyph" for="language-switcher">{% trans "Language" %}</label>
-        <select name="language" id="language-switcher" class="mt-3 mt-md-0 ml-md-3 w-100 form-control">
+        <select name="language" id="language-switcher" class="mt-3 mt-md-0 ml-md-3 w-100 tw-form-control">
             {% for language_code, language_name in languages %}
                 <option value="{{ language_code }}"{% if language_code == current_language %} selected{% endif %}>
                     {{ language_name | capfirst }}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/search_bar.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/search_bar.html
@@ -2,7 +2,7 @@
 <div class="tw-relative">
     <label for="{{ id|default:'search' }}" class="tw-sr-only">{% translate 'Search' context 'Button' %}</label>
     {% trans "Search…" as search_placeholder %}
-    <input type="text" value="{{ search_query }}" name="{{ name|default:'search' }}" id="{{ id|default:'search' }}" placeholder="{{ placeholder_text|default:search_placeholder }}" class="tw-w-full form-control tw-h-auto tw-p-8 tw-pr-24 tw-rounded-none {{ input_styles|default:"tw-text-xl tw-border-black focus:tw-border-blue-40 placeholder:tw-text-gray-20" }}" />
+    <input type="text" value="{{ search_query }}" name="{{ name|default:'search' }}" id="{{ id|default:'search' }}" placeholder="{{ placeholder_text|default:search_placeholder }}" class="tw-w-full tw-form-control tw-h-auto tw-p-8 tw-pr-24 tw-rounded-none {{ input_styles|default:"tw-text-xl tw-border-black focus:tw-border-blue-40 placeholder:tw-text-gray-20" }}" />
     <button type="submit" class="tw-absolute -tw-translate-y-1/2 tw-top-1/2 tw-right-6 tw-bg-transparent">
         <svg class="{{ icon_styles }} -tw-scale-x-100 " fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" stroke="currentColor"><g stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="-14.5" cy="9" r="8" transform="scale(-1 1)"/><path d="m8.682 14.818-7.682 7.682" transform="matrix(-1 0 0 -1 9.682 37.318)"/></g></svg>
     </button>


### PR DESCRIPTION
# Description

- Ensures the old `.form-control` elements are now using `.tw-form-control`
- Fixes the visual regression issue with footer language dropdown  (it should look like the language dropdown in the newsletter signup form in nav bar)

Related PRs/issues: #10347 
Review app: https://foundation-s-10347-tw-f-pb4keb.herokuapp.com
