### PR TITLE
10339 move research hub factories

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/research_hub.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub.py
@@ -1,7 +1,6 @@
 import random
 
 import factory
-import factory.fuzzy
 import wagtail_factories
 
 from networkapi.utility.faker import helpers as faker_helpers

--- a/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
@@ -7,21 +7,7 @@ from networkapi.wagtailpages.factory.research_hub import author_index as author_
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
 from networkapi.wagtailpages.factory.research_hub import library_page as library_page_factory
-
-
-class ResearchRegionFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchRegion
-
-    name = factory.Faker("text", max_nb_chars=25)
-
-
-class ResearchTopicFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchTopic
-
-    name = factory.Faker("text", max_nb_chars=25)
-    description = factory.Faker("paragraph")
+from networkapi.wagtailpages.factory.research_hub import taxonomies as taxonomies_factory
 
 
 class ResearchAuthorRelationFactory(factory.django.DjangoModelFactory):
@@ -37,7 +23,7 @@ class ResearchDetailPageResearchRegionRelationFactory(factory.django.DjangoModel
         model = wagtailpage_models.ResearchDetailPageResearchRegionRelation
 
     research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
-    research_region = factory.SubFactory(ResearchRegionFactory)
+    research_region = factory.SubFactory(taxonomies_factory.ResearchRegionFactory)
 
 
 class ResearchDetailPageResearchTopicRelationFactory(factory.django.DjangoModelFactory):
@@ -45,7 +31,7 @@ class ResearchDetailPageResearchTopicRelationFactory(factory.django.DjangoModelF
         model = wagtailpage_models.ResearchDetailPageResearchTopicRelation
 
     research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
-    research_topic = factory.SubFactory(ResearchTopicFactory)
+    research_topic = factory.SubFactory(taxonomies_factory.ResearchTopicFactory)
 
 
 class ResearchLandingPageResearchTopicRelationFactory(factory.django.DjangoModelFactory):
@@ -53,7 +39,7 @@ class ResearchLandingPageResearchTopicRelationFactory(factory.django.DjangoModel
         model = wagtailpage_models.ResearchLandingPageFeaturedResearchTopicRelation
 
     research_landing_page = factory.SubFactory(landing_page_factory.ResearchLandingPageFactory)
-    research_topic = factory.SubFactory(ResearchTopicFactory)
+    research_topic = factory.SubFactory(taxonomies_factory.ResearchTopicFactory)
 
 
 def generate(seed):
@@ -78,8 +64,8 @@ def generate(seed):
         research_authors_index_page = author_index_factory.ResearchAuthorsIndexPageFactory.create(parent=research_landing_page)
 
     for _ in range(4):
-        ResearchRegionFactory.create()
-        ResearchTopicFactory.create()
+        taxonomies_factory.ResearchRegionFactory.create()
+        taxonomies_factory.ResearchTopicFactory.create()
 
     for _ in range(13):
         research_detail_page = detail_page_factory.ResearchDetailPageFactory.create(

--- a/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
@@ -1,13 +1,11 @@
-import random
-
 import factory
 import wagtail_factories
 
 from networkapi.utility.faker import helpers as faker_helpers
 from networkapi.wagtailpages import models as wagtailpage_models
-from networkapi.wagtailpages.factory import documents as documents_factory
 from networkapi.wagtailpages.factory import image_factory
 from networkapi.wagtailpages.factory import profiles as profiles_factory
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 
 
 class ResearchLandingPageFactory(wagtail_factories.PageFactory):
@@ -35,68 +33,6 @@ class ResearchAuthorsIndexPageFactory(wagtail_factories.PageFactory):
     banner_image = factory.SubFactory(image_factory.ImageFactory)
 
 
-class ResearchDetailLinkFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchDetailLink
-
-    label = factory.Faker("text", max_nb_chars=30)
-    url = ""
-    document = None
-
-    class Params:
-        with_url = factory.Trait(
-            url=factory.Faker("uri"),
-        )
-        with_document = factory.Trait(document=factory.SubFactory(documents_factory.DocumentFactory))
-
-
-class ResearchDetailPageFactory(wagtail_factories.PageFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchDetailPage
-
-    title = factory.Faker("text", max_nb_chars=50)
-    cover_image = factory.SubFactory(image_factory.ImageFactory)
-    research_links = factory.RelatedFactoryList(
-        factory=ResearchDetailLinkFactory,
-        factory_related_name="research_detail_page",
-        size=lambda: random.randint(1, 2),
-        with_url=True,
-    )
-    original_publication_date = factory.Faker("date_object")
-    introduction = factory.Faker("text", max_nb_chars=300)
-
-    @factory.lazy_attribute
-    def overview(self):
-        faker = faker_helpers.get_faker()
-        return "\n\n".join(faker.paragraphs(nb=3))
-
-    @factory.lazy_attribute
-    def collaborators(self):
-        faker = faker_helpers.get_faker()
-        names = []
-        for _ in range(random.randint(1, 5)):
-            names.append(faker.name())
-        return "; ".join(names)
-
-    research_authors = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.ResearchAuthorRelationFactory",
-        factory_related_name="research_detail_page",
-        size=1,
-    )
-
-    related_topics = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.ResearchDetailPageResearchTopicRelationFactory",
-        factory_related_name="research_detail_page",
-        size=1,
-    )
-
-    related_regions = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.ResearchDetailPageResearchRegionRelationFactory",
-        factory_related_name="research_detail_page",
-        size=1,
-    )
-
-
 class ResearchRegionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = wagtailpage_models.ResearchRegion
@@ -116,7 +52,7 @@ class ResearchAuthorRelationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = wagtailpage_models.ResearchAuthorRelation
 
-    research_detail_page = factory.SubFactory(ResearchDetailPageFactory)
+    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
     author_profile = factory.SubFactory(profiles_factory.ProfileFactory)
 
 
@@ -124,7 +60,7 @@ class ResearchDetailPageResearchRegionRelationFactory(factory.django.DjangoModel
     class Meta:
         model = wagtailpage_models.ResearchDetailPageResearchRegionRelation
 
-    research_detail_page = factory.SubFactory(ResearchDetailPageFactory)
+    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
     research_region = factory.SubFactory(ResearchRegionFactory)
 
 
@@ -132,7 +68,7 @@ class ResearchDetailPageResearchTopicRelationFactory(factory.django.DjangoModelF
     class Meta:
         model = wagtailpage_models.ResearchDetailPageResearchTopicRelation
 
-    research_detail_page = factory.SubFactory(ResearchDetailPageFactory)
+    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
     research_topic = factory.SubFactory(ResearchTopicFactory)
 
 
@@ -170,7 +106,7 @@ def generate(seed):
         ResearchTopicFactory.create()
 
     for _ in range(13):
-        research_detail_page = ResearchDetailPageFactory.create(
+        research_detail_page = detail_page_factory.ResearchDetailPageFactory.create(
             parent=research_library_page,
             research_authors=None,
             related_topics=None,

--- a/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
@@ -1,28 +1,12 @@
 import factory
-import wagtail_factories
 
 from networkapi.utility.faker import helpers as faker_helpers
 from networkapi.wagtailpages import models as wagtailpage_models
-from networkapi.wagtailpages.factory import image_factory
 from networkapi.wagtailpages.factory import profiles as profiles_factory
+from networkapi.wagtailpages.factory.research_hub import author_index as author_index_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
-
-
-class ResearchLibraryPageFactory(wagtail_factories.PageFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchLibraryPage
-
-    title = "Library"
-    banner_image = factory.SubFactory(image_factory.ImageFactory)
-
-
-class ResearchAuthorsIndexPageFactory(wagtail_factories.PageFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchAuthorsIndexPage
-
-    title = "Authors"
-    banner_image = factory.SubFactory(image_factory.ImageFactory)
+from networkapi.wagtailpages.factory.research_hub import library_page as library_page_factory
 
 
 class ResearchRegionFactory(factory.django.DjangoModelFactory):
@@ -86,12 +70,12 @@ def generate(seed):
     # Only one library page can exist
     research_library_page = wagtailpage_models.ResearchLibraryPage.objects.first()
     if not research_library_page:
-        research_library_page = ResearchLibraryPageFactory.create(parent=research_landing_page)
+        research_library_page = library_page_factory.ResearchLibraryPageFactory.create(parent=research_landing_page)
 
     # Only one authors index page can exist
     research_authors_index_page = wagtailpage_models.ResearchAuthorsIndexPage.objects.first()
     if not research_authors_index_page:
-        research_authors_index_page = ResearchAuthorsIndexPageFactory.create(parent=research_landing_page)
+        research_authors_index_page = author_index_factory.ResearchAuthorsIndexPageFactory.create(parent=research_landing_page)
 
     for _ in range(4):
         ResearchRegionFactory.create()

--- a/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
@@ -1,11 +1,21 @@
 from networkapi.utility.faker import helpers as faker_helpers
 from networkapi.wagtailpages import models as wagtailpage_models
-from networkapi.wagtailpages.factory.research_hub import author_index as author_index_factory
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
-from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
-from networkapi.wagtailpages.factory.research_hub import library_page as library_page_factory
-from networkapi.wagtailpages.factory.research_hub import taxonomies as taxonomies_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    author_index as author_index_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    landing_page as landing_page_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    library_page as library_page_factory,
+)
 from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    taxonomies as taxonomies_factory,
+)
 
 
 def generate(seed):
@@ -27,7 +37,9 @@ def generate(seed):
     # Only one authors index page can exist
     research_authors_index_page = wagtailpage_models.ResearchAuthorsIndexPage.objects.first()
     if not research_authors_index_page:
-        research_authors_index_page = author_index_factory.ResearchAuthorsIndexPageFactory.create(parent=research_landing_page)
+        research_authors_index_page = author_index_factory.ResearchAuthorsIndexPageFactory.create(
+            parent=research_landing_page
+        )
 
     for _ in range(4):
         taxonomies_factory.ResearchRegionFactory.create()

--- a/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
@@ -6,15 +6,7 @@ from networkapi.wagtailpages import models as wagtailpage_models
 from networkapi.wagtailpages.factory import image_factory
 from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
-
-
-class ResearchLandingPageFactory(wagtail_factories.PageFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchLandingPage
-
-    title = "Research"
-    banner_image = factory.SubFactory(image_factory.ImageFactory)
-    intro = factory.Faker("text", max_nb_chars=250)
+from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
 
 
 class ResearchLibraryPageFactory(wagtail_factories.PageFactory):
@@ -76,7 +68,7 @@ class ResearchLandingPageResearchTopicRelationFactory(factory.django.DjangoModel
     class Meta:
         model = wagtailpage_models.ResearchLandingPageFeaturedResearchTopicRelation
 
-    research_landing_page = factory.SubFactory(ResearchLandingPageFactory)
+    research_landing_page = factory.SubFactory(landing_page_factory.ResearchLandingPageFactory)
     research_topic = factory.SubFactory(ResearchTopicFactory)
 
 
@@ -89,7 +81,7 @@ def generate(seed):
     # Only one landing page can exist
     research_landing_page = wagtailpage_models.ResearchLandingPage.objects.first()
     if not research_landing_page:
-        research_landing_page = ResearchLandingPageFactory.create(parent=home_page)
+        research_landing_page = landing_page_factory.ResearchLandingPageFactory.create(parent=home_page)
 
     # Only one library page can exist
     research_library_page = wagtailpage_models.ResearchLibraryPage.objects.first()

--- a/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/__init__.py
@@ -1,45 +1,11 @@
-import factory
-
 from networkapi.utility.faker import helpers as faker_helpers
 from networkapi.wagtailpages import models as wagtailpage_models
-from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory.research_hub import author_index as author_index_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
 from networkapi.wagtailpages.factory.research_hub import library_page as library_page_factory
 from networkapi.wagtailpages.factory.research_hub import taxonomies as taxonomies_factory
-
-
-class ResearchAuthorRelationFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchAuthorRelation
-
-    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
-    author_profile = factory.SubFactory(profiles_factory.ProfileFactory)
-
-
-class ResearchDetailPageResearchRegionRelationFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchDetailPageResearchRegionRelation
-
-    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
-    research_region = factory.SubFactory(taxonomies_factory.ResearchRegionFactory)
-
-
-class ResearchDetailPageResearchTopicRelationFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchDetailPageResearchTopicRelation
-
-    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
-    research_topic = factory.SubFactory(taxonomies_factory.ResearchTopicFactory)
-
-
-class ResearchLandingPageResearchTopicRelationFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchLandingPageFeaturedResearchTopicRelation
-
-    research_landing_page = factory.SubFactory(landing_page_factory.ResearchLandingPageFactory)
-    research_topic = factory.SubFactory(taxonomies_factory.ResearchTopicFactory)
+from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 
 
 def generate(seed):
@@ -76,26 +42,26 @@ def generate(seed):
         )
 
         for profile in faker_helpers.get_random_objects(source=wagtailpage_models.Profile, max_count=3):
-            ResearchAuthorRelationFactory.create(
+            relations_factory.ResearchAuthorRelationFactory.create(
                 research_detail_page=research_detail_page,
                 author_profile=profile,
             )
 
         for region in faker_helpers.get_random_objects(source=wagtailpage_models.ResearchRegion, max_count=2):
-            ResearchDetailPageResearchRegionRelationFactory.create(
+            relations_factory.ResearchDetailPageResearchRegionRelationFactory.create(
                 research_detail_page=research_detail_page,
                 research_region=region,
             )
 
         for topic in faker_helpers.get_random_objects(source=wagtailpage_models.ResearchTopic, max_count=2):
-            ResearchDetailPageResearchTopicRelationFactory.create(
+            relations_factory.ResearchDetailPageResearchTopicRelationFactory.create(
                 research_detail_page=research_detail_page,
                 research_topic=topic,
             )
 
     # Populating research landing page with featured research topics
     for topic in faker_helpers.get_random_objects(source=wagtailpage_models.ResearchTopic, max_count=3):
-        ResearchLandingPageResearchTopicRelationFactory.create(
+        relations_factory.ResearchLandingPageResearchTopicRelationFactory.create(
             research_landing_page=research_landing_page,
             research_topic=topic,
         )

--- a/network-api/networkapi/wagtailpages/factory/research_hub/author_index.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/author_index.py
@@ -1,0 +1,13 @@
+import factory
+import wagtail_factories
+
+from networkapi.wagtailpages import models as wagtailpage_models
+from networkapi.wagtailpages.factory import image_factory
+
+
+class ResearchAuthorsIndexPageFactory(wagtail_factories.PageFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchAuthorsIndexPage
+
+    title = "Authors"
+    banner_image = factory.SubFactory(image_factory.ImageFactory)

--- a/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
@@ -52,19 +52,19 @@ class ResearchDetailPageFactory(wagtail_factories.PageFactory):
         return "; ".join(names)
 
     research_authors = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.ResearchAuthorRelationFactory",
+        factory="networkapi.wagtailpages.factory.research_hub.relations.ResearchAuthorRelationFactory",
         factory_related_name="research_detail_page",
         size=1,
     )
 
     related_topics = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.ResearchDetailPageResearchTopicRelationFactory",
+        factory="networkapi.wagtailpages.factory.research_hub.relations.ResearchDetailPageResearchTopicRelationFactory",
         factory_related_name="research_detail_page",
         size=1,
     )
 
     related_regions = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.ResearchDetailPageResearchRegionRelationFactory",
+        factory="networkapi.wagtailpages.factory.research_hub.relations.ResearchDetailPageResearchRegionRelationFactory",
         factory_related_name="research_detail_page",
         size=1,
     )

--- a/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
@@ -1,0 +1,70 @@
+import random
+
+import factory
+import wagtail_factories
+
+from networkapi.utility.faker import helpers as faker_helpers
+from networkapi.wagtailpages import models as wagtailpage_models
+from networkapi.wagtailpages.factory import documents as documents_factory, image_factory
+
+
+class ResearchDetailLinkFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchDetailLink
+
+    label = factory.Faker("text", max_nb_chars=30)
+    url = ""
+    document = None
+
+    class Params:
+        with_url = factory.Trait(
+            url=factory.Faker("uri"),
+        )
+        with_document = factory.Trait(document=factory.SubFactory(documents_factory.DocumentFactory))
+
+
+class ResearchDetailPageFactory(wagtail_factories.PageFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchDetailPage
+
+    title = factory.Faker("text", max_nb_chars=50)
+    cover_image = factory.SubFactory(image_factory.ImageFactory)
+    research_links = factory.RelatedFactoryList(
+        factory=ResearchDetailLinkFactory,
+        factory_related_name="research_detail_page",
+        size=lambda: random.randint(1, 2),
+        with_url=True,
+    )
+    original_publication_date = factory.Faker("date_object")
+    introduction = factory.Faker("text", max_nb_chars=300)
+
+    @factory.lazy_attribute
+    def overview(self):
+        faker = faker_helpers.get_faker()
+        return "\n\n".join(faker.paragraphs(nb=3))
+
+    @factory.lazy_attribute
+    def collaborators(self):
+        faker = faker_helpers.get_faker()
+        names = []
+        for _ in range(random.randint(1, 5)):
+            names.append(faker.name())
+        return "; ".join(names)
+
+    research_authors = factory.RelatedFactoryList(
+        factory="networkapi.wagtailpages.factory.research_hub.ResearchAuthorRelationFactory",
+        factory_related_name="research_detail_page",
+        size=1,
+    )
+
+    related_topics = factory.RelatedFactoryList(
+        factory="networkapi.wagtailpages.factory.research_hub.ResearchDetailPageResearchTopicRelationFactory",
+        factory_related_name="research_detail_page",
+        size=1,
+    )
+
+    related_regions = factory.RelatedFactoryList(
+        factory="networkapi.wagtailpages.factory.research_hub.ResearchDetailPageResearchRegionRelationFactory",
+        factory_related_name="research_detail_page",
+        size=1,
+    )

--- a/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
@@ -5,7 +5,8 @@ import wagtail_factories
 
 from networkapi.utility.faker import helpers as faker_helpers
 from networkapi.wagtailpages import models as wagtailpage_models
-from networkapi.wagtailpages.factory import documents as documents_factory, image_factory
+from networkapi.wagtailpages.factory import documents as documents_factory
+from networkapi.wagtailpages.factory import image_factory
 
 
 class ResearchDetailLinkFactory(factory.django.DjangoModelFactory):
@@ -58,13 +59,17 @@ class ResearchDetailPageFactory(wagtail_factories.PageFactory):
     )
 
     related_topics = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.relations.ResearchDetailPageResearchTopicRelationFactory",
+        factory=(
+            "networkapi.wagtailpages.factory.research_hub.relations.ResearchDetailPageResearchTopicRelationFactory"
+        ),
         factory_related_name="research_detail_page",
         size=1,
     )
 
     related_regions = factory.RelatedFactoryList(
-        factory="networkapi.wagtailpages.factory.research_hub.relations.ResearchDetailPageResearchRegionRelationFactory",
+        factory=(
+            "networkapi.wagtailpages.factory.research_hub.relations.ResearchDetailPageResearchRegionRelationFactory"
+        ),
         factory_related_name="research_detail_page",
         size=1,
     )

--- a/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/detail_page.py
@@ -9,21 +9,6 @@ from networkapi.wagtailpages.factory import documents as documents_factory
 from networkapi.wagtailpages.factory import image_factory
 
 
-class ResearchDetailLinkFactory(factory.django.DjangoModelFactory):
-    class Meta:
-        model = wagtailpage_models.ResearchDetailLink
-
-    label = factory.Faker("text", max_nb_chars=30)
-    url = ""
-    document = None
-
-    class Params:
-        with_url = factory.Trait(
-            url=factory.Faker("uri"),
-        )
-        with_document = factory.Trait(document=factory.SubFactory(documents_factory.DocumentFactory))
-
-
 class ResearchDetailPageFactory(wagtail_factories.PageFactory):
     class Meta:
         model = wagtailpage_models.ResearchDetailPage
@@ -31,7 +16,7 @@ class ResearchDetailPageFactory(wagtail_factories.PageFactory):
     title = factory.Faker("text", max_nb_chars=50)
     cover_image = factory.SubFactory(image_factory.ImageFactory)
     research_links = factory.RelatedFactoryList(
-        factory=ResearchDetailLinkFactory,
+        factory="networkapi.wagtailpages.factory.research_hub.detail_page.ResearchDetailLinkFactory",
         factory_related_name="research_detail_page",
         size=lambda: random.randint(1, 2),
         with_url=True,
@@ -73,3 +58,18 @@ class ResearchDetailPageFactory(wagtail_factories.PageFactory):
         factory_related_name="research_detail_page",
         size=1,
     )
+
+
+class ResearchDetailLinkFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchDetailLink
+
+    label = factory.Faker("text", max_nb_chars=30)
+    url = ""
+    document = None
+
+    class Params:
+        with_url = factory.Trait(
+            url=factory.Faker("uri"),
+        )
+        with_document = factory.Trait(document=factory.SubFactory(documents_factory.DocumentFactory))

--- a/network-api/networkapi/wagtailpages/factory/research_hub/landing_page.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/landing_page.py
@@ -1,0 +1,14 @@
+import factory
+import wagtail_factories
+
+from networkapi.wagtailpages import models as wagtailpage_models
+from networkapi.wagtailpages.factory import image_factory
+
+
+class ResearchLandingPageFactory(wagtail_factories.PageFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchLandingPage
+
+    title = "Research"
+    banner_image = factory.SubFactory(image_factory.ImageFactory)
+    intro = factory.Faker("text", max_nb_chars=250)

--- a/network-api/networkapi/wagtailpages/factory/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/library_page.py
@@ -1,0 +1,13 @@
+import factory
+import wagtail_factories
+
+from networkapi.wagtailpages import models as wagtailpage_models
+from networkapi.wagtailpages.factory import image_factory
+
+
+class ResearchLibraryPageFactory(wagtail_factories.PageFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchLibraryPage
+
+    title = "Library"
+    banner_image = factory.SubFactory(image_factory.ImageFactory)

--- a/network-api/networkapi/wagtailpages/factory/research_hub/relations.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/relations.py
@@ -2,8 +2,15 @@ import factory
 
 from networkapi.wagtailpages import models as wagtailpage_models
 from networkapi.wagtailpages.factory import profiles as profiles_factory
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory, \
-    taxonomies as taxonomies_factory, landing_page as landing_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    landing_page as landing_page_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    taxonomies as taxonomies_factory,
+)
 
 
 class ResearchAuthorRelationFactory(factory.django.DjangoModelFactory):

--- a/network-api/networkapi/wagtailpages/factory/research_hub/relations.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/relations.py
@@ -1,0 +1,38 @@
+import factory
+
+from networkapi.wagtailpages import models as wagtailpage_models
+from networkapi.wagtailpages.factory import profiles as profiles_factory
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory, \
+    taxonomies as taxonomies_factory, landing_page as landing_page_factory
+
+
+class ResearchAuthorRelationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchAuthorRelation
+
+    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
+    author_profile = factory.SubFactory(profiles_factory.ProfileFactory)
+
+
+class ResearchDetailPageResearchRegionRelationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchDetailPageResearchRegionRelation
+
+    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
+    research_region = factory.SubFactory(taxonomies_factory.ResearchRegionFactory)
+
+
+class ResearchDetailPageResearchTopicRelationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchDetailPageResearchTopicRelation
+
+    research_detail_page = factory.SubFactory(detail_page_factory.ResearchDetailPageFactory)
+    research_topic = factory.SubFactory(taxonomies_factory.ResearchTopicFactory)
+
+
+class ResearchLandingPageResearchTopicRelationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchLandingPageFeaturedResearchTopicRelation
+
+    research_landing_page = factory.SubFactory(landing_page_factory.ResearchLandingPageFactory)
+    research_topic = factory.SubFactory(taxonomies_factory.ResearchTopicFactory)

--- a/network-api/networkapi/wagtailpages/factory/research_hub/taxonomies.py
+++ b/network-api/networkapi/wagtailpages/factory/research_hub/taxonomies.py
@@ -1,0 +1,18 @@
+import factory
+
+from networkapi.wagtailpages import models as wagtailpage_models
+
+
+class ResearchRegionFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchRegion
+
+    name = factory.Faker("text", max_nb_chars=25)
+
+
+class ResearchTopicFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = wagtailpage_models.ResearchTopic
+
+    name = factory.Faker("text", max_nb_chars=25)
+    description = factory.Faker("paragraph")

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/detail_page.py
@@ -18,65 +18,6 @@ from networkapi.wagtailpages.pagemodels.research_hub import authors_index
 from networkapi.wagtailpages.pagemodels.research_hub import base as research_base
 
 
-class ResearchDetailLink(wagtail_models.TranslatableMixin, wagtail_models.Orderable):
-    research_detail_page = cluster_fields.ParentalKey(
-        "ResearchDetailPage",
-        null=False,
-        blank=False,
-        on_delete=models.CASCADE,
-        related_name="research_links",
-    )
-
-    label = models.CharField(null=False, blank=False, max_length=50)
-
-    url = models.URLField(null=False, blank=True)
-    document = models.ForeignKey(
-        wagtail_docs.get_document_model_string(),
-        null=True,
-        blank=True,
-        on_delete=models.CASCADE,
-    )
-
-    panels = [
-        edit_handlers.HelpPanel(
-            content=(
-                "Please provide an external link to the original source or upload a document and select it here. "
-                'If you wish to provide both, please create two separate "research links"'
-            )
-        ),
-        edit_handlers.FieldPanel("label"),
-        edit_handlers.FieldPanel("url"),
-        docs_handlers.FieldPanel("document"),
-    ]
-
-    class Meta(wagtail_models.TranslatableMixin.Meta, wagtail_models.Orderable.Meta):
-        ordering = ["sort_order"]
-
-    def __str__(self):
-        return self.label
-
-    def clean(self):
-        super().clean()
-        if self.url and self.document:
-            error_message = "Please provide either a URL or a document, not both."
-            raise exceptions.ValidationError(
-                {"url": error_message, "document": error_message},
-                code="invalid",
-            )
-        elif not self.url and not self.document:
-            error_message = "Please provide a URL or a document."
-            raise exceptions.ValidationError(
-                {"url": error_message, "document": error_message},
-                code="required",
-            )
-
-    def get_url(self):
-        if self.url:
-            return self.url
-        elif self.document:
-            return self.document.url
-
-
 class ResearchDetailPage(research_base.ResearchHubBasePage):
     parent_page_types = ["ResearchLibraryPage"]
 
@@ -198,3 +139,62 @@ class ResearchDetailPage(research_base.ResearchHubBasePage):
 
     def get_banner(self):
         return self.get_parent().specific.get_banner()
+
+
+class ResearchDetailLink(wagtail_models.TranslatableMixin, wagtail_models.Orderable):
+    research_detail_page = cluster_fields.ParentalKey(
+        "ResearchDetailPage",
+        null=False,
+        blank=False,
+        on_delete=models.CASCADE,
+        related_name="research_links",
+    )
+
+    label = models.CharField(null=False, blank=False, max_length=50)
+
+    url = models.URLField(null=False, blank=True)
+    document = models.ForeignKey(
+        wagtail_docs.get_document_model_string(),
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+    )
+
+    panels = [
+        edit_handlers.HelpPanel(
+            content=(
+                "Please provide an external link to the original source or upload a document and select it here. "
+                'If you wish to provide both, please create two separate "research links"'
+            )
+        ),
+        edit_handlers.FieldPanel("label"),
+        edit_handlers.FieldPanel("url"),
+        docs_handlers.FieldPanel("document"),
+    ]
+
+    class Meta(wagtail_models.TranslatableMixin.Meta, wagtail_models.Orderable.Meta):
+        ordering = ["sort_order"]
+
+    def __str__(self):
+        return self.label
+
+    def clean(self):
+        super().clean()
+        if self.url and self.document:
+            error_message = "Please provide either a URL or a document, not both."
+            raise exceptions.ValidationError(
+                {"url": error_message, "document": error_message},
+                code="invalid",
+            )
+        elif not self.url and not self.document:
+            error_message = "Please provide a URL or a document."
+            raise exceptions.ValidationError(
+                {"url": error_message, "document": error_message},
+                code="required",
+            )
+
+    def get_url(self):
+        if self.url:
+            return self.url
+        elif self.document:
+            return self.document.url

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,5 +1,6 @@
+from networkapi.wagtailpages.factory.research_hub import author_index as author_index_factory
 from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
-from networkapi.wagtailpages.factory import research_hub as research_factory
+from networkapi.wagtailpages.factory.research_hub import library_page as library_page_factory
 from networkapi.wagtailpages.tests import base as test_base
 
 
@@ -14,10 +15,10 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
         cls.landing_page = landing_page_factory.ResearchLandingPageFactory(
             parent=homepage,
         )
-        cls.library_page = research_factory.ResearchLibraryPageFactory(
+        cls.library_page = library_page_factory.ResearchLibraryPageFactory(
             parent=cls.landing_page,
         )
-        cls.author_index = research_factory.ResearchAuthorsIndexPageFactory(
+        cls.author_index = author_index_factory.ResearchAuthorsIndexPageFactory(
             parent=cls.landing_page,
             title="Authors",
         )

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,3 +1,4 @@
+from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
 from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.tests import base as test_base
 
@@ -10,7 +11,7 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
 
     @classmethod
     def _setup_research_hub_structure(cls, homepage):
-        cls.landing_page = research_factory.ResearchLandingPageFactory(
+        cls.landing_page = landing_page_factory.ResearchLandingPageFactory(
             parent=homepage,
         )
         cls.library_page = research_factory.ResearchLibraryPageFactory(

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,6 +1,12 @@
-from networkapi.wagtailpages.factory.research_hub import author_index as author_index_factory
-from networkapi.wagtailpages.factory.research_hub import landing_page as landing_page_factory
-from networkapi.wagtailpages.factory.research_hub import library_page as library_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    author_index as author_index_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    landing_page as landing_page_factory,
+)
+from networkapi.wagtailpages.factory.research_hub import (
+    library_page as library_page_factory,
+)
 from networkapi.wagtailpages.tests import base as test_base
 
 

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -6,6 +6,7 @@ from wagtail_localize import synctree
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory import research_hub as research_factory
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
 
@@ -14,7 +15,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.detail_page = research_factory.ResearchDetailPageFactory(
+        cls.detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=cls.library_page,
             original_publication_date=(research_test_utils.days_ago(n=14)),
         )
@@ -134,7 +135,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             self.detail_page,
             self.fr_locale,
         )
-        extra_detail_page = research_factory.ResearchDetailPageFactory(
+        extra_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         research_factory.ResearchAuthorRelationFactory(
@@ -167,7 +168,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             self.detail_page,
             self.fr_locale,
         )
-        extra_detail_page = research_factory.ResearchDetailPageFactory(
+        extra_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         research_factory.ResearchAuthorRelationFactory(
@@ -195,15 +196,15 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         self.assertIn(fr_extra_detail_page, context["latest_research"])
 
     def test_get_latest_research(self):
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=(research_test_utils.days_ago(n=3)),
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=(research_test_utils.days_ago(n=2)),
         )
-        detail_page_3 = research_factory.ResearchDetailPageFactory(
+        detail_page_3 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=(research_test_utils.days_ago(n=1)),
         )

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -5,8 +5,8 @@ from django.utils import translation
 from wagtail_localize import synctree
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
-from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
 
@@ -20,7 +20,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             original_publication_date=(research_test_utils.days_ago(n=14)),
         )
         cls.research_profile = profiles_factory.ProfileFactory()
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=cls.detail_page,
             author_profile=cls.research_profile,
         )
@@ -138,7 +138,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         extra_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=extra_detail_page,
             author_profile=self.research_profile,
         )
@@ -171,7 +171,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         extra_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=extra_detail_page,
             author_profile=self.research_profile,
         )
@@ -208,15 +208,15 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             parent=self.library_page,
             original_publication_date=(research_test_utils.days_ago(n=1)),
         )
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_1,
             author_profile=self.research_profile,
         )
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_2,
             author_profile=self.research_profile,
         )
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_3,
             author_profile=self.research_profile,
         )

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -5,7 +5,9 @@ from django.utils import translation
 from wagtail_localize import synctree
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
 from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
@@ -1,7 +1,9 @@
 from django import test
 from django.core import exceptions
 
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 
 

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
@@ -5,6 +5,22 @@ from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 
 
+class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
+    def test_research_detail_page_breadcrumbs(self):
+        detail_page = research_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+        )
+        response = self.client.get(detail_page.url)
+        breadcrumbs = response.context["breadcrumbs"]
+        expected_breadcrumbs = [
+            {"title": "Research", "url": "/en/research/"},
+            {"title": "Library", "url": "/en/research/library/"},
+        ]
+
+        self.assertEqual(len(breadcrumbs), 2)
+        self.assertEqual(breadcrumbs, expected_breadcrumbs)
+
+
 class TestResearchDetailLink(test.TestCase):
     def test_clean_with_url(self):
         link = research_factory.ResearchDetailLinkFactory.build(with_url=True)
@@ -36,19 +52,3 @@ class TestResearchDetailLink(test.TestCase):
 
         with self.assertRaises(exceptions.ValidationError):
             link.clean()
-
-
-class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
-    def test_research_detail_page_breadcrumbs(self):
-        detail_page = research_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-        )
-        response = self.client.get(detail_page.url)
-        breadcrumbs = response.context["breadcrumbs"]
-        expected_breadcrumbs = [
-            {"title": "Research", "url": "/en/research/"},
-            {"title": "Library", "url": "/en/research/library/"},
-        ]
-
-        self.assertEqual(len(breadcrumbs), 2)
-        self.assertEqual(breadcrumbs, expected_breadcrumbs)

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
@@ -1,13 +1,13 @@
 from django import test
 from django.core import exceptions
 
-from networkapi.wagtailpages.factory import research_hub as research_factory
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 
 
 class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
     def test_research_detail_page_breadcrumbs(self):
-        detail_page = research_factory.ResearchDetailPageFactory(
+        detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         response = self.client.get(detail_page.url)
@@ -23,7 +23,7 @@ class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
 
 class TestResearchDetailLink(test.TestCase):
     def test_clean_with_url(self):
-        link = research_factory.ResearchDetailLinkFactory.build(with_url=True)
+        link = detail_page_factory.ResearchDetailLinkFactory.build(with_url=True)
 
         link.clean()
 
@@ -31,7 +31,7 @@ class TestResearchDetailLink(test.TestCase):
         self.assertFalse(link.document)
 
     def test_clean_with_doc(self):
-        link = research_factory.ResearchDetailLinkFactory.build(with_document=True)
+        link = detail_page_factory.ResearchDetailLinkFactory.build(with_document=True)
 
         link.clean()
 
@@ -39,7 +39,7 @@ class TestResearchDetailLink(test.TestCase):
         self.assertFalse(link.url)
 
     def test_clean_with_url_and_doc(self):
-        link = research_factory.ResearchDetailLinkFactory.build(
+        link = detail_page_factory.ResearchDetailLinkFactory.build(
             with_url=True,
             with_document=True,
         )
@@ -48,7 +48,7 @@ class TestResearchDetailLink(test.TestCase):
             link.clean()
 
     def test_clean_with_neither_url_nor_doc(self):
-        link = research_factory.ResearchDetailLinkFactory.build()
+        link = detail_page_factory.ResearchDetailLinkFactory.build()
 
         with self.assertRaises(exceptions.ValidationError):
             link.clean()

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
@@ -6,8 +6,8 @@ from django.utils import timezone, translation
 from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
-from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 from networkapi.wagtailpages.factory.research_hub import taxonomies as taxonomies_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
@@ -181,7 +181,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             tagline="",
             introduction="",
         )
-        research_factory.ResearchAuthorRelationFactory(research_detail_page=apple_page, author_profile=apple_profile)
+        relations_factory.ResearchAuthorRelationFactory(research_detail_page=apple_page, author_profile=apple_profile)
         banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
@@ -194,7 +194,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             tagline="",
             introduction="",
         )
-        research_factory.ResearchAuthorRelationFactory(research_detail_page=banana_page, author_profile=banana_profile)
+        relations_factory.ResearchAuthorRelationFactory(research_detail_page=banana_page, author_profile=banana_profile)
         self.update_index()
 
         response = self.client.get(self.library_page.url, data={"search": "Apple"})
@@ -217,7 +217,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             name="Apple",
             description="",
         )
-        research_factory.ResearchDetailPageResearchTopicRelationFactory(
+        relations_factory.ResearchDetailPageResearchTopicRelationFactory(
             research_detail_page=apple_page, research_topic=apple_topic
         )
         banana_page = detail_page_factory.ResearchDetailPageFactory(
@@ -231,7 +231,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             name="banana",
             description="",
         )
-        research_factory.ResearchDetailPageResearchTopicRelationFactory(
+        relations_factory.ResearchDetailPageResearchTopicRelationFactory(
             research_detail_page=banana_page, research_topic=banana_topic
         )
         self.update_index()
@@ -253,7 +253,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             collaborators="",
         )
         apple_region = taxonomies_factory.ResearchRegionFactory(name="Apple")
-        research_factory.ResearchDetailPageResearchRegionRelationFactory(
+        relations_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=apple_page, research_region=apple_region
         )
         banana_page = detail_page_factory.ResearchDetailPageFactory(
@@ -264,7 +264,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             collaborators="",
         )
         banana_region = taxonomies_factory.ResearchRegionFactory(name="banana")
-        research_factory.ResearchDetailPageResearchRegionRelationFactory(
+        relations_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=banana_page, research_region=banana_region
         )
         self.update_index()
@@ -480,7 +480,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         )
         profile_b = detail_page_2.research_authors.first().author_profile
         # Make author of first page also an author of the second page
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_2,
             author_profile=profile_a,
         )
@@ -611,7 +611,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             parent=self.library_page,
             related_topics__research_topic=topic_A,
         )
-        research_factory.ResearchDetailPageResearchTopicRelationFactory(
+        relations_factory.ResearchDetailPageResearchTopicRelationFactory(
             research_detail_page=detail_page_1, research_topic=topic_B
         )
         detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
@@ -742,7 +742,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             parent=self.library_page,
             related_regions__research_region=region_A,
         )
-        research_factory.ResearchDetailPageResearchRegionRelationFactory(
+        relations_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=detail_page_1, research_region=region_B
         )
         detail_page_2 = detail_page_factory.ResearchDetailPageFactory(

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
@@ -8,6 +8,7 @@ from wagtail import models as wagtail_models
 from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import taxonomies as taxonomies_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
 
@@ -212,7 +213,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             overview="",
             collaborators="",
         )
-        apple_topic = research_factory.ResearchTopicFactory(
+        apple_topic = taxonomies_factory.ResearchTopicFactory(
             name="Apple",
             description="",
         )
@@ -226,7 +227,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             overview="",
             collaborators="",
         )
-        banana_topic = research_factory.ResearchTopicFactory(
+        banana_topic = taxonomies_factory.ResearchTopicFactory(
             name="banana",
             description="",
         )
@@ -251,7 +252,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             overview="",
             collaborators="",
         )
-        apple_region = research_factory.ResearchRegionFactory(name="Apple")
+        apple_region = taxonomies_factory.ResearchRegionFactory(name="Apple")
         research_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=apple_page, research_region=apple_region
         )
@@ -262,7 +263,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             overview="",
             collaborators="",
         )
-        banana_region = research_factory.ResearchRegionFactory(name="banana")
+        banana_region = taxonomies_factory.ResearchRegionFactory(name="banana")
         research_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=banana_page, research_region=banana_region
         )
@@ -535,8 +536,8 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_2, research_detail_pages)
 
     def test_research_topics_in_options(self):
-        topic_1 = research_factory.ResearchTopicFactory()
-        topic_2 = research_factory.ResearchTopicFactory()
+        topic_1 = taxonomies_factory.ResearchTopicFactory()
+        topic_2 = taxonomies_factory.ResearchTopicFactory()
 
         response = self.client.get(self.library_page.url)
 
@@ -546,7 +547,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(topic_2.id, topic_option_values)
 
     def test_topic_in_options_matches_active_locale(self):
-        topic_en = research_factory.ResearchTopicFactory()
+        topic_en = taxonomies_factory.ResearchTopicFactory()
         topic_fr = topic_en.copy_for_translation(self.fr_locale)
         topic_fr.save()
 
@@ -571,10 +572,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         topic.
 
         """
-        topic_1_en = research_factory.ResearchTopicFactory()
+        topic_1_en = taxonomies_factory.ResearchTopicFactory()
         topic_1_fr = topic_1_en.copy_for_translation(self.fr_locale)
         topic_1_fr.save()
-        topic_2_en = research_factory.ResearchTopicFactory()
+        topic_2_en = taxonomies_factory.ResearchTopicFactory()
         translation.activate(self.fr_locale.language_code)
 
         response = self.client.get(self.library_page.localized.url)
@@ -586,12 +587,12 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(topic_2_en.id, topic_option_values)
 
     def test_filter_topic(self):
-        topic_A = research_factory.ResearchTopicFactory()
+        topic_A = taxonomies_factory.ResearchTopicFactory()
         detail_page_A = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_A,
         )
-        topic_B = research_factory.ResearchTopicFactory()
+        topic_B = taxonomies_factory.ResearchTopicFactory()
         detail_page_B = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_B,
@@ -604,8 +605,8 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_B, research_detail_pages)
 
     def test_filter_multiple_topics(self):
-        topic_A = research_factory.ResearchTopicFactory()
-        topic_B = research_factory.ResearchTopicFactory()
+        topic_A = taxonomies_factory.ResearchTopicFactory()
+        topic_B = taxonomies_factory.ResearchTopicFactory()
         detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_A,
@@ -635,7 +636,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         is not associated with the translated topic, but we still want to see it in
         the results.
         """
-        topic = research_factory.ResearchTopicFactory()
+        topic = taxonomies_factory.ResearchTopicFactory()
         detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic,
@@ -666,8 +667,8 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_2, research_detail_pages)
 
     def test_research_regions_in_options(self):
-        region_1 = research_factory.ResearchRegionFactory()
-        region_2 = research_factory.ResearchRegionFactory()
+        region_1 = taxonomies_factory.ResearchRegionFactory()
+        region_2 = taxonomies_factory.ResearchRegionFactory()
 
         response = self.client.get(self.library_page.url)
 
@@ -677,7 +678,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(region_2.id, region_option_values)
 
     def test_region_in_options_matches_active_locale(self):
-        region_en = research_factory.ResearchRegionFactory()
+        region_en = taxonomies_factory.ResearchRegionFactory()
         region_fr = region_en.copy_for_translation(self.fr_locale)
         region_fr.save()
 
@@ -702,10 +703,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         region.
 
         """
-        region_1_en = research_factory.ResearchRegionFactory()
+        region_1_en = taxonomies_factory.ResearchRegionFactory()
         region_1_fr = region_1_en.copy_for_translation(self.fr_locale)
         region_1_fr.save()
-        region_2_en = research_factory.ResearchRegionFactory()
+        region_2_en = taxonomies_factory.ResearchRegionFactory()
         translation.activate(self.fr_locale.language_code)
 
         response = self.client.get(self.library_page.localized.url)
@@ -717,12 +718,12 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(region_2_en.id, region_option_values)
 
     def test_filter_region(self):
-        region_A = research_factory.ResearchRegionFactory()
+        region_A = taxonomies_factory.ResearchRegionFactory()
         detail_page_A = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_A,
         )
-        region_B = research_factory.ResearchRegionFactory()
+        region_B = taxonomies_factory.ResearchRegionFactory()
         detail_page_B = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_B,
@@ -735,8 +736,8 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_B, research_detail_pages)
 
     def test_filter_multiple_regions(self):
-        region_A = research_factory.ResearchRegionFactory()
-        region_B = research_factory.ResearchRegionFactory()
+        region_A = taxonomies_factory.ResearchRegionFactory()
+        region_B = taxonomies_factory.ResearchRegionFactory()
         detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_A,
@@ -766,7 +767,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         is not associated with the translated region, but we still want to see it in
         the results.
         """
-        region = research_factory.ResearchRegionFactory()
+        region = taxonomies_factory.ResearchRegionFactory()
         detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region,

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
@@ -7,6 +7,7 @@ from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory import research_hub as research_factory
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
 
@@ -17,10 +18,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             management.call_command("update_index", verbosity=0, stdout=f)
 
     def test_detail_pages_in_context(self):
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
 
@@ -32,10 +33,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(detail_page_2, research_detail_pages)
 
     def test_detail_pages_in_context_with_translation_aliases(self):
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         self.synchronize_tree()
@@ -52,10 +53,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(fr_detail_page_2, research_detail_pages)
 
     def test_private_detail_pages_not_in_context(self):
-        public_detail_page = research_factory.ResearchDetailPageFactory(
+        public_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        private_detail_page = research_factory.ResearchDetailPageFactory(
+        private_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         wagtail_models.PageViewRestriction.objects.create(
@@ -74,14 +75,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
     def test_search_by_detail_page_title(self):
         # Fields other than title are empty to avoid accidental test failures due to
         # fake data generation.
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Apple",
             introduction="",
             overview="",
             collaborators="",
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Banana",
             introduction="",
@@ -97,14 +98,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(banana_page, research_detail_pages)
 
     def test_search_by_detail_page_introduction(self):
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Cherry",
             introduction="Apple",
             overview="",
             collaborators="",
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
             introduction="Banana",
@@ -120,14 +121,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(banana_page, research_detail_pages)
 
     def test_search_by_detail_page_overview(self):
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Cherry",
             introduction="",
             overview="Apple",
             collaborators="",
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
             introduction="",
@@ -143,14 +144,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(banana_page, research_detail_pages)
 
     def test_search_by_detail_page_collaborators(self):
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Cherry",
             introduction="",
             overview="",
             collaborators="Apple",
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
             introduction="",
@@ -167,7 +168,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
     def test_search_by_detail_page_author_name(self):
         """Test detail page can be searched by author profile name."""
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Cherry",
             introduction="",
@@ -180,7 +181,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             introduction="",
         )
         research_factory.ResearchAuthorRelationFactory(research_detail_page=apple_page, author_profile=apple_profile)
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
             introduction="",
@@ -204,7 +205,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
     def test_search_by_detail_page_topic_name(self):
         """Test detail page can be searched by topic name."""
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Cherry",
             introduction="",
@@ -218,7 +219,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         research_factory.ResearchDetailPageResearchTopicRelationFactory(
             research_detail_page=apple_page, research_topic=apple_topic
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
             introduction="",
@@ -243,7 +244,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
     def test_search_by_detail_page_region_name(self):
         """Test detail page can be searched by region name."""
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Cherry",
             introduction="",
@@ -254,7 +255,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         research_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=apple_page, research_region=apple_region
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Also cherry",
             introduction="",
@@ -275,11 +276,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(banana_page, research_detail_pages)
 
     def test_sort_newest_first(self):
-        oldest_page = research_factory.ResearchDetailPageFactory(
+        oldest_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=research_test_utils.days_ago(2),
         )
-        newest_page = research_factory.ResearchDetailPageFactory(
+        newest_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=research_test_utils.days_ago(1),
         )
@@ -295,11 +296,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertLess(newest_page_index, oldest_page_index)
 
     def test_sort_oldest_first(self):
-        oldest_page = research_factory.ResearchDetailPageFactory(
+        oldest_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=research_test_utils.days_ago(2),
         )
-        newest_page = research_factory.ResearchDetailPageFactory(
+        newest_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=research_test_utils.days_ago(1),
         )
@@ -315,11 +316,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertLess(oldest_page_index, newest_page_index)
 
     def test_sort_alphabetical(self):
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Apple",
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Banana",
         )
@@ -335,11 +336,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertLess(apple_page_index, banana_page_index)
 
     def test_sort_alphabetical_reversed(self):
-        apple_page = research_factory.ResearchDetailPageFactory(
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Apple",
         )
-        banana_page = research_factory.ResearchDetailPageFactory(
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             title="Banana",
         )
@@ -355,11 +356,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertLess(banana_page_index, apple_page_index)
 
     def test_get_research_detail_pages_sort_default(self):
-        research_factory.ResearchDetailPageFactory(
+        detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=research_test_utils.days_ago(2),
         )
-        research_factory.ResearchDetailPageFactory(
+        detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=research_test_utils.days_ago(1),
         )
@@ -375,7 +376,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertEqual(default_sort_detail_pages, newest_first_detail_pages)
 
     def test_research_author_profile_in_options(self):
-        detail_page = research_factory.ResearchDetailPageFactory(
+        detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
 
@@ -404,7 +405,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         before the pages are translated (a manual action) the related models like author
         are still the ones from the default locale.
         """
-        detail_page_en = research_factory.ResearchDetailPageFactory(
+        detail_page_en = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         profile_en = detail_page_en.research_authors.first().author_profile
@@ -425,7 +426,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         Profiles are not necessarily people, so they might have translated names.
         """
-        detail_page_en = research_factory.ResearchDetailPageFactory(
+        detail_page_en = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         profile_en = detail_page_en.research_authors.first().author_profile
@@ -447,10 +448,10 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         )
 
     def test_filter_author_profile(self):
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         author_profile = detail_page_1.research_authors.first().author_profile
@@ -469,11 +470,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertNotIn(detail_page_2, research_detail_pages)
 
     def test_filter_multiple_author_profiles(self):
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         profile_a = detail_page_1.research_authors.first().author_profile
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         profile_b = detail_page_2.research_authors.first().author_profile
@@ -505,11 +506,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         the results.
         """
         profile = profiles_factory.ProfileFactory()
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             research_authors__author_profile=profile,
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             research_authors__author_profile=profile,
         )
@@ -586,12 +587,12 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
     def test_filter_topic(self):
         topic_A = research_factory.ResearchTopicFactory()
-        detail_page_A = research_factory.ResearchDetailPageFactory(
+        detail_page_A = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_A,
         )
         topic_B = research_factory.ResearchTopicFactory()
-        detail_page_B = research_factory.ResearchDetailPageFactory(
+        detail_page_B = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_B,
         )
@@ -605,14 +606,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
     def test_filter_multiple_topics(self):
         topic_A = research_factory.ResearchTopicFactory()
         topic_B = research_factory.ResearchTopicFactory()
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_A,
         )
         research_factory.ResearchDetailPageResearchTopicRelationFactory(
             research_detail_page=detail_page_1, research_topic=topic_B
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic_A,
         )
@@ -635,11 +636,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         the results.
         """
         topic = research_factory.ResearchTopicFactory()
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic,
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_topics__research_topic=topic,
         )
@@ -717,12 +718,12 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
     def test_filter_region(self):
         region_A = research_factory.ResearchRegionFactory()
-        detail_page_A = research_factory.ResearchDetailPageFactory(
+        detail_page_A = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_A,
         )
         region_B = research_factory.ResearchRegionFactory()
-        detail_page_B = research_factory.ResearchDetailPageFactory(
+        detail_page_B = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_B,
         )
@@ -736,14 +737,14 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
     def test_filter_multiple_regions(self):
         region_A = research_factory.ResearchRegionFactory()
         region_B = research_factory.ResearchRegionFactory()
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_A,
         )
         research_factory.ResearchDetailPageResearchRegionRelationFactory(
             research_detail_page=detail_page_1, research_region=region_B
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region_A,
         )
@@ -766,11 +767,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         the results.
         """
         region = research_factory.ResearchRegionFactory()
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region,
         )
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             related_regions__research_region=region,
         )
@@ -798,11 +799,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
     def test_years_in_options(self):
         year_1 = timezone.now().year
         year_2 = year_1 - 1
-        research_factory.ResearchDetailPageFactory(
+        detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=datetime.date(year=year_1, month=1, day=1),
         )
-        research_factory.ResearchDetailPageFactory(
+        detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=datetime.date(year=year_2, month=1, day=1),
         )
@@ -816,11 +817,11 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(year_2, year_option_values)
 
     def test_filter_for_year(self):
-        detail_page_1 = research_factory.ResearchDetailPageFactory(
+        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
         year_1 = detail_page_1.original_publication_date.year
-        detail_page_2 = research_factory.ResearchDetailPageFactory(
+        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=datetime.date(year_1 + 1, 6, 1),
         )
@@ -843,7 +844,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.library_page.results_count = 4
         self.library_page.save()
         for _ in range(6):
-            research_factory.ResearchDetailPageFactory(parent=self.library_page)
+            detail_page_factory.ResearchDetailPageFactory(parent=self.library_page)
 
         first_page_response = self.client.get(self.library_page.url, data={"page": 1})
         second_page_response = self.client.get(self.library_page.url, data={"page": 2})

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
@@ -6,9 +6,13 @@ from django.utils import timezone, translation
 from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
 from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
-from networkapi.wagtailpages.factory.research_hub import taxonomies as taxonomies_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    taxonomies as taxonomies_factory,
+)
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
 
@@ -194,7 +198,9 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
             tagline="",
             introduction="",
         )
-        relations_factory.ResearchAuthorRelationFactory(research_detail_page=banana_page, author_profile=banana_profile)
+        relations_factory.ResearchAuthorRelationFactory(
+            research_detail_page=banana_page, author_profile=banana_profile
+        )
         self.update_index()
 
         response = self.client.get(self.library_page.url, data={"search": "Apple"})

--- a/network-api/networkapi/wagtailpages/tests/test_profiles.py
+++ b/network-api/networkapi/wagtailpages/tests/test_profiles.py
@@ -3,6 +3,7 @@ from django import test
 from networkapi.wagtailpages.factory import blog as blog_factories
 from networkapi.wagtailpages.factory import profiles as profile_factories
 from networkapi.wagtailpages.factory import research_hub as research_factory
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.pagemodels import profiles as profile_models
 from networkapi.wagtailpages.pagemodels.blog.blog import BlogAuthors
 
@@ -15,7 +16,7 @@ class ProfileTest(test.TestCase):
     def test_filter_research_authors(self):
         research_author_profile = profile_factories.ProfileFactory()
         research_factory.ResearchAuthorRelationFactory(
-            research_detail_page=research_factory.ResearchDetailPageFactory(),
+            research_detail_page=detail_page_factory.ResearchDetailPageFactory(),
             author_profile=research_author_profile,
         )
         not_research_author_profile = profile_factories.ProfileFactory()
@@ -41,11 +42,11 @@ class ProfileTest(test.TestCase):
 
         research_author_profile = profile_factories.ProfileFactory()
         research_factory.ResearchAuthorRelationFactory(
-            research_detail_page=research_factory.ResearchDetailPageFactory(),
+            research_detail_page=detail_page_factory.ResearchDetailPageFactory(),
             author_profile=research_author_profile,
         )
         research_factory.ResearchAuthorRelationFactory(
-            research_detail_page=research_factory.ResearchDetailPageFactory(),
+            research_detail_page=detail_page_factory.ResearchDetailPageFactory(),
             author_profile=research_author_profile,
         )
 

--- a/network-api/networkapi/wagtailpages/tests/test_profiles.py
+++ b/network-api/networkapi/wagtailpages/tests/test_profiles.py
@@ -2,8 +2,8 @@ from django import test
 
 from networkapi.wagtailpages.factory import blog as blog_factories
 from networkapi.wagtailpages.factory import profiles as profile_factories
-from networkapi.wagtailpages.factory import research_hub as research_factory
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 from networkapi.wagtailpages.pagemodels import profiles as profile_models
 from networkapi.wagtailpages.pagemodels.blog.blog import BlogAuthors
 
@@ -15,7 +15,7 @@ class ProfileTest(test.TestCase):
 
     def test_filter_research_authors(self):
         research_author_profile = profile_factories.ProfileFactory()
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_factory.ResearchDetailPageFactory(),
             author_profile=research_author_profile,
         )
@@ -41,11 +41,11 @@ class ProfileTest(test.TestCase):
         """Return research author profile only once"""
 
         research_author_profile = profile_factories.ProfileFactory()
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_factory.ResearchDetailPageFactory(),
             author_profile=research_author_profile,
         )
-        research_factory.ResearchAuthorRelationFactory(
+        relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_factory.ResearchDetailPageFactory(),
             author_profile=research_author_profile,
         )

--- a/network-api/networkapi/wagtailpages/tests/test_profiles.py
+++ b/network-api/networkapi/wagtailpages/tests/test_profiles.py
@@ -2,7 +2,9 @@ from django import test
 
 from networkapi.wagtailpages.factory import blog as blog_factories
 from networkapi.wagtailpages.factory import profiles as profile_factories
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
 from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 from networkapi.wagtailpages.pagemodels import profiles as profile_models
 from networkapi.wagtailpages.pagemodels.blog.blog import BlogAuthors


### PR DESCRIPTION
# Description

This PR is only in preparation of the work for the Responsible Computing Challenge Playbook. 

This PR does not make any functional changes. It only moves the research hub related factories from one single module into a module structure that follows the module structure used for the models. 

This PR also changes the order of classes in the "detail page" modules, to make sure that the more important page class is listed above the link class. 

I hope this change makes working with the different modules a little more consistent. 


Related PRs/issues: #10339 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [x] Did I update or add new fake data?
- ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~
