### PR TITLE
#9266 Detail page - Link not required

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/detail_page.py
@@ -64,7 +64,7 @@ class ResearchDetailPage(research_base.ResearchHubBasePage):
 
     content_panels = wagtail_models.Page.content_panels + [
         image_handlers.FieldPanel("cover_image"),
-        edit_handlers.InlinePanel("research_links", heading="Research links", min_num=1),
+        edit_handlers.InlinePanel("research_links", heading="Research links"),
         edit_handlers.FieldPanel("original_publication_date"),
         edit_handlers.FieldPanel("introduction"),
         edit_handlers.FieldPanel("overview"),


### PR DESCRIPTION
# Description

Follow-up PR to #10360 

This PR removes the requirement for the detail pages to have a link defined. 

The requirement has become cumbersome, because the detail pages are often used as the parent page of the article or publication page that the link should go to. With the link being required, we create a logical loop where the detail page can not be created because we can not link to the child and we can not create the child until the detail page exists. 

Removing the requirement for a link breaks this logical loop. The editors can now create a detail page without a link, create the child page and then come back to the detail page to add the link. They do have to remember to come back to add the link though. 

We could consider updating this to automatically link to the first child if no link is defined. But this needs to be checked with stakeholders and design if that is desirable. 

While testing I also noticed that we should limit the types of child pages we can create on a detail page. #10361 will deal with that. 


Link to sample test page: http://localhost:8000/cms/pages/add/wagtailpages/researchdetailpage/179/
Related PRs/issues: #9266

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~Is the code I'm adding covered by tests?~~ I could not find a good way to test this. 

**Changes in Models:**
- ~~Did I update or add new fake data?~~
- ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~
