### PR TITLE
Fix PNI uncaught TypeError related to commento GA tracking

### DIFF
--- a/source/js/buyers-guide/template-js-handler/product-page-comment-handler.js
+++ b/source/js/buyers-guide/template-js-handler/product-page-comment-handler.js
@@ -18,7 +18,7 @@ export default () => {
       // New comments are appended in the form of: <div><div class='commento-card'/></div>
       // If comment tracking ever breaks, this logic would be a good place to check first.
       // For more context, see: https://github.com/mozilla/foundation.mozilla.org/pull/9414
-      if (mutation.addedNodes[0]?.firstChild.matches(".commento-card")) {
+      if (mutation.addedNodes[0]?.firstChild?.matches(".commento-card")) {
         window.dataLayer = window.dataLayer || [];
         window.dataLayer.push({
           event: "form_submission",


### PR DESCRIPTION
Related PRs/issues: #10158

### Problem: 
TypeError raised from `mutation.addedNodes[0]?.firstChild.matches(".commento-card")` was because we can't guarantee that `mutation.addedNodes[0]?` always has a `firstChild` property. 

### Fix:
Using optional chaining to make sure that line doesn't raise error even when `mutation.addedNodes[0]?.firstChild` is undefined.

### Steps to test

1. Go to any PNI product page, e.g., http://localhost:8000/en/privacynotincluded/threema/
2. Open up dev tool console
3. Enter the following code one by one to test all scenarios
    1. `document.querySelector("#view-product-page #commento").innerHTML = "<div></div>";`
    2. `document.querySelector("#view-product-page #commento").innerHTML = "<div><div class='commento-card1'/></div>"`;
    3. `document.querySelector("#view-product-page #commento").innerHTML = "<div><div class='commento-card'/></div>"`;
    4. `document.querySelector("#view-product-page #commento").innerHTML = "123";`
 
If none of the above rasied TypeError then we are good!
