### PR TITLE
#10128 Hide protected detail pages

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -105,7 +105,7 @@ class ResearchAuthorsIndexPage(
 
     @staticmethod
     def get_author_research(author_profile):
-        author_research = detail_page.ResearchDetailPage.objects.all()
+        author_research = detail_page.ResearchDetailPage.objects.live().public()
 
         # During tree sync, an alias is created for every detail page. But, these
         # aliases are still associated with the profile in the default locale. So, when
@@ -119,8 +119,6 @@ class ResearchAuthorsIndexPage(
         )
         # And then we fitler for the active locale.
         author_research = author_research.filter(locale=wagtail_models.Locale.get_active())
-
-        author_research = author_research.live().public()
 
         return author_research
 

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -103,7 +103,8 @@ class ResearchAuthorsIndexPage(
     def get_author_research_count(self, author_profile):
         return self.get_author_research(author_profile).count()
 
-    def get_author_research(self, author_profile):
+    @staticmethod
+    def get_author_research(author_profile):
         author_research = detail_page.ResearchDetailPage.objects.all()
 
         # During tree sync, an alias is created for every detail page. But, these
@@ -114,7 +115,7 @@ class ResearchAuthorsIndexPage(
         # `translation_key` as the current locale's author. So, instead of filtering
         # for the author `id`, we filter by `translation_key`.
         author_research = author_research.filter(
-            research_authors__author_profile__translation_key=(author_profile.translation_key)
+            research_authors__author_profile__translation_key=author_profile.translation_key
         )
         # And then we fitler for the active locale.
         author_research = author_research.filter(locale=wagtail_models.Locale.get_active())

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -101,6 +101,7 @@ class ResearchAuthorsIndexPage(
     def get_latest_research(self, author_profile):
         LATEST_RESEARCH_COUNT_LIMIT = 3
         author_research = self.get_author_research(author_profile)
+        author_research = author_research.live().public()
         author_research = author_research.order_by("-original_publication_date")
         latest_research = author_research[:LATEST_RESEARCH_COUNT_LIMIT]
         return latest_research

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -89,11 +89,11 @@ class ResearchAuthorsIndexPage(
             "author_research_count": self.get_author_research_count(author_profile=author_profile),
             # On author detail pages to include the link to the authors index.
             "breadcrumbs": self.get_breadcrumbs(include_self=True),
-            "latest_research": self.get_latest_research(author_profile=author_profile),
+            "latest_research": self.get_latest_author_research(author_profile=author_profile),
             "library_page": library_page.ResearchLibraryPage.objects.first(),
         }
 
-    def get_latest_research(self, author_profile):
+    def get_latest_author_research(self, author_profile):
         LATEST_RESEARCH_COUNT_LIMIT = 3
         author_research = self.get_author_research(author_profile)
         author_research = author_research.order_by("-original_publication_date")

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -84,17 +84,12 @@ class ResearchAuthorsIndexPage(
             id=profile_id,
         )
 
-        author_research_count = self.get_author_research(author_profile).count()
-        latest_research = self.get_latest_research(author_profile)
-
-        # On author detail pages to include the link to the authors index.
-        detail_page_breadcrumbs = self.get_breadcrumbs(include_self=True)
-
         return {
             "author_profile": author_profile,
-            "author_research_count": author_research_count,
-            "breadcrumbs": detail_page_breadcrumbs,
-            "latest_research": latest_research,
+            "author_research_count": self.get_author_research_count(author_profile=author_profile),
+            # On author detail pages to include the link to the authors index.
+            "breadcrumbs": self.get_breadcrumbs(include_self=True),
+            "latest_research": self.get_latest_research(author_profile=author_profile),
             "library_page": library_page.ResearchLibraryPage.objects.first(),
         }
 
@@ -104,6 +99,9 @@ class ResearchAuthorsIndexPage(
         author_research = author_research.order_by("-original_publication_date")
         latest_research = author_research[:LATEST_RESEARCH_COUNT_LIMIT]
         return latest_research
+
+    def get_author_research_count(self, author_profile):
+        return self.get_author_research(author_profile).count()
 
     def get_author_research(self, author_profile):
         author_research = detail_page.ResearchDetailPage.objects.all()

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/authors_index.py
@@ -101,13 +101,13 @@ class ResearchAuthorsIndexPage(
     def get_latest_research(self, author_profile):
         LATEST_RESEARCH_COUNT_LIMIT = 3
         author_research = self.get_author_research(author_profile)
-        author_research = author_research.live().public()
         author_research = author_research.order_by("-original_publication_date")
         latest_research = author_research[:LATEST_RESEARCH_COUNT_LIMIT]
         return latest_research
 
     def get_author_research(self, author_profile):
         author_research = detail_page.ResearchDetailPage.objects.all()
+
         # During tree sync, an alias is created for every detail page. But, these
         # aliases are still associated with the profile in the default locale. So, when
         # displaying the author page for a non-default locale author, we also want to
@@ -120,6 +120,9 @@ class ResearchAuthorsIndexPage(
         )
         # And then we fitler for the active locale.
         author_research = author_research.filter(locale=wagtail_models.Locale.get_active())
+
+        author_research = author_research.live().public()
+
         return author_research
 
     def get_banner(self):

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/landing_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/landing_page.py
@@ -57,7 +57,7 @@ class ResearchLandingPage(research_base.ResearchHubBasePage):
         active_locale = wagtail_models.Locale.get_active()
 
         ResearchDetailPage = apps.get_model("wagtailpages", "ResearchDetailPage")
-        research_detail_pages = ResearchDetailPage.objects.live()
+        research_detail_pages = ResearchDetailPage.objects.live().public()
         research_detail_pages = research_detail_pages.filter(locale=active_locale)
         research_detail_pages = research_detail_pages.order_by("-original_publication_date")
         research_detail_pages = research_detail_pages[:3]

--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/landing_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/landing_page.py
@@ -52,7 +52,8 @@ class ResearchLandingPage(research_base.ResearchHubBasePage):
         context["latest_research_detail_pages"] = self.get_latest_research_pages
         return context
 
-    def get_latest_research_pages(self):
+    @staticmethod
+    def get_latest_research_pages():
         active_locale = wagtail_models.Locale.get_active()
 
         ResearchDetailPage = apps.get_model("wagtailpages", "ResearchDetailPage")

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,6 +1,7 @@
 from networkapi.wagtailpages.factory.research_hub import (
     author_index as author_index_factory,
 )
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.factory.research_hub import (
     landing_page as landing_page_factory,
 )
@@ -8,6 +9,7 @@ from networkapi.wagtailpages.factory.research_hub import (
     library_page as library_page_factory,
 )
 from networkapi.wagtailpages.tests import base as test_base
+from networkapi.wagtailpages.tests.research_hub import utils
 
 
 class ResearchHubTestCase(test_base.WagtailpagesTestCase):
@@ -27,6 +29,13 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
         cls.author_index = author_index_factory.ResearchAuthorsIndexPageFactory(
             parent=cls.landing_page,
             title="Authors",
+        )
+
+    def create_research_detail_page(self, days_ago=0):
+        publication_date = utils.days_ago(n=days_ago)
+        return detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=publication_date,
         )
 
     def setUp(self):

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,3 +1,5 @@
+from wagtail import models as wagtail_models
+
 from networkapi.wagtailpages.factory.research_hub import (
     author_index as author_index_factory,
 )
@@ -38,6 +40,14 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
         return detail_page_factory.ResearchDetailPageFactory(
             parent=parent,
             original_publication_date=publication_date,
+        )
+
+    @staticmethod
+    def make_page_private(page):
+        wagtail_models.PageViewRestriction.objects.create(
+            page=page,
+            restriction_type=wagtail_models.PageViewRestriction.PASSWORD,
+            password="test",
         )
 
     def create_research_detail_page(self, days_ago=0):

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,5 +1,3 @@
-from wagtail import models as wagtail_models
-
 from networkapi.wagtailpages.factory.research_hub import (
     author_index as author_index_factory,
 )
@@ -44,11 +42,7 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
 
     @staticmethod
     def make_page_private(page):
-        wagtail_models.PageViewRestriction.objects.create(
-            page=page,
-            restriction_type=wagtail_models.PageViewRestriction.PASSWORD,
-            password="test",
-        )
+        utils.make_page_private(page)
 
     def create_research_detail_page(self, days_ago=0):
         return self.create_research_detail_page_on_parent(

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -31,11 +31,19 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
             title="Authors",
         )
 
-    def create_research_detail_page(self, days_ago=0):
+
+    @staticmethod
+    def create_research_detail_page_on_parent(*, parent, days_ago=0):
         publication_date = utils.days_ago(n=days_ago)
         return detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
+            parent=parent,
             original_publication_date=publication_date,
+        )
+
+    def create_research_detail_page(self, days_ago=0):
+        return self.create_research_detail_page_on_parent(
+            parent=self.library_page,
+            days_ago=days_ago,
         )
 
     def setUp(self):

--- a/network-api/networkapi/wagtailpages/tests/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/base.py
@@ -1,7 +1,9 @@
 from networkapi.wagtailpages.factory.research_hub import (
     author_index as author_index_factory,
 )
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.factory.research_hub import (
+    detail_page as detail_page_factory,
+)
 from networkapi.wagtailpages.factory.research_hub import (
     landing_page as landing_page_factory,
 )
@@ -30,7 +32,6 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
             parent=cls.landing_page,
             title="Authors",
         )
-
 
     @staticmethod
     def create_research_detail_page_on_parent(*, parent, days_ago=0):

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -5,9 +5,6 @@ from django.utils import translation
 from wagtail_localize import synctree
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
-from networkapi.wagtailpages.factory.research_hub import (
-    detail_page as detail_page_factory,
-)
 from networkapi.wagtailpages.factory.research_hub import relations as relations_factory
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -198,22 +198,10 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         self.assertIn(fr_extra_detail_page, context["latest_research"])
 
     def test_get_latest_research(self):
-        detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=(research_test_utils.days_ago(n=3)),
-        )
-        detail_page_2 = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=(research_test_utils.days_ago(n=2)),
-        )
-        detail_page_3 = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=(research_test_utils.days_ago(n=1)),
-        )
-        relations_factory.ResearchAuthorRelationFactory(
-            research_detail_page=detail_page_1,
-            author_profile=self.research_profile,
-        )
+        detail_page_1 = self.detail_page
+        detail_page_2 = self.create_research_detail_page(days_ago=3)
+        detail_page_3 = self.create_research_detail_page(days_ago=2)
+        detail_page_4 = self.create_research_detail_page(days_ago=1)
         relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=detail_page_2,
             author_profile=self.research_profile,
@@ -222,16 +210,20 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             research_detail_page=detail_page_3,
             author_profile=self.research_profile,
         )
+        relations_factory.ResearchAuthorRelationFactory(
+            research_detail_page=detail_page_4,
+            author_profile=self.research_profile,
+        )
 
         latest_research = self.author_index.get_latest_research(
             author_profile=self.research_profile,
         )
 
         self.assertEqual(len(latest_research), 3)
-        self.assertIn(detail_page_1, latest_research)
-        self.assertIn(detail_page_2, latest_research)
+        self.assertIn(detail_page_4, latest_research)
         self.assertIn(detail_page_3, latest_research)
-        self.assertNotIn(self.detail_page, latest_research)
+        self.assertIn(detail_page_2, latest_research)
+        self.assertNotIn(detail_page_1, latest_research)
 
     def test_get_author_research(self):
         # Locale and detail pages.

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -17,10 +17,8 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.detail_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=cls.library_page,
-            original_publication_date=(research_test_utils.days_ago(n=14)),
-        )
+
+        cls.detail_page = cls.create_research_detail_page_on_parent(parent=cls.library_page, days_ago=14)
         cls.research_profile = profiles_factory.ProfileFactory()
         relations_factory.ResearchAuthorRelationFactory(
             research_detail_page=cls.detail_page,

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -143,13 +143,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             self.detail_page,
             self.fr_locale,
         )
-        extra_detail_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-        )
-        relations_factory.ResearchAuthorRelationFactory(
-            research_detail_page=extra_detail_page,
-            author_profile=self.research_profile,
-        )
+        extra_detail_page = self.create_research_detail_page_with_author(author_profile=self.research_profile)
         self.synchronize_tree()
         # Grab the alias page. Note: This page is not really translated, so it is still
         # associated with the original profile.
@@ -176,13 +170,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
             self.detail_page,
             self.fr_locale,
         )
-        extra_detail_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-        )
-        relations_factory.ResearchAuthorRelationFactory(
-            research_detail_page=extra_detail_page,
-            author_profile=self.research_profile,
-        )
+        extra_detail_page = self.create_research_detail_page_with_author(author_profile=self.research_profile)
         synctree.synchronize_tree(source_locale=self.default_locale, target_locale=self.fr_locale)
         # Grab the alias page. Note: This page is not really translated, so it is still
         # associated with the original profile.

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -207,6 +207,14 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         self.assertIn(detail_page_2, latest_research)
         self.assertNotIn(detail_page_1, latest_research)
 
+    def test_get_author_research_count_return_number_of_associated_detail_pages(self):
+        # One page already exists, creating one more
+        self.create_research_detail_page_with_author(author_profile=self.research_profile)
+
+        count = self.author_index.get_author_research_count(author_profile=self.research_profile)
+
+        self.assertEqual(count, 2)
+
     def test_get_author_research_returns_profile_related_detail_pages(self):
         detail_page_1 = self.detail_page
         detail_page_2 = self.create_research_detail_page_with_author(author_profile=self.research_profile, days_ago=3)

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -197,7 +197,7 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         detail_page_3 = self.create_research_detail_page_with_author(author_profile=self.research_profile, days_ago=2)
         detail_page_4 = self.create_research_detail_page_with_author(author_profile=self.research_profile, days_ago=1)
 
-        latest_research = self.author_index.get_latest_research(
+        latest_research = self.author_index.get_latest_author_research(
             author_profile=self.research_profile,
         )
 

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -36,6 +36,14 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         self.fr_profile = self.research_profile.copy_for_translation(self.fr_locale)
         self.fr_profile.save()
 
+    def create_research_detail_page_with_author(self, author_profile, days_ago=0):
+        detail_page = self.create_research_detail_page(days_ago=days_ago)
+        relations_factory.ResearchAuthorRelationFactory(
+            research_detail_page=detail_page,
+            author_profile=author_profile,
+        )
+        return detail_page
+
     def test_get_context(self):
         context = self.author_index.get_context(request=None)
         self.translate_research_profile()
@@ -197,21 +205,9 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
 
     def test_get_latest_research(self):
         detail_page_1 = self.detail_page
-        detail_page_2 = self.create_research_detail_page(days_ago=3)
-        detail_page_3 = self.create_research_detail_page(days_ago=2)
-        detail_page_4 = self.create_research_detail_page(days_ago=1)
-        relations_factory.ResearchAuthorRelationFactory(
-            research_detail_page=detail_page_2,
-            author_profile=self.research_profile,
-        )
-        relations_factory.ResearchAuthorRelationFactory(
-            research_detail_page=detail_page_3,
-            author_profile=self.research_profile,
-        )
-        relations_factory.ResearchAuthorRelationFactory(
-            research_detail_page=detail_page_4,
-            author_profile=self.research_profile,
-        )
+        detail_page_2 = self.create_research_detail_page_with_author(author_profile=self.research_profile, days_ago=3)
+        detail_page_3 = self.create_research_detail_page_with_author(author_profile=self.research_profile, days_ago=2)
+        detail_page_4 = self.create_research_detail_page_with_author(author_profile=self.research_profile, days_ago=1)
 
         latest_research = self.author_index.get_latest_research(
             author_profile=self.research_profile,

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_author_index.py
@@ -207,6 +207,39 @@ class TestResearchAuthorIndexPage(research_test_base.ResearchHubTestCase):
         self.assertIn(detail_page_2, latest_research)
         self.assertNotIn(detail_page_1, latest_research)
 
+    def test_get_latest_research_not_returns_unpublished_pages(self):
+        detail_page_published = self.detail_page
+        detail_page_unpublished = self.create_research_detail_page_with_author(
+            author_profile=self.research_profile,
+            days_ago=1,
+        )
+        detail_page_unpublished.unpublish()
+        detail_page_unpublished.save()
+
+        latest_research = self.author_index.get_latest_research(
+            author_profile=self.research_profile,
+        )
+
+        self.assertEqual(len(latest_research), 1)
+        self.assertIn(detail_page_published, latest_research)
+        self.assertNotIn(detail_page_unpublished, latest_research)
+
+    def test_get_latest_research_not_returns_private_pages(self):
+        detail_page_public = self.detail_page
+        detail_page_private = self.create_research_detail_page_with_author(
+            author_profile=self.research_profile,
+            days_ago=1,
+        )
+        self.make_page_private(detail_page_private)
+
+        latest_research = self.author_index.get_latest_research(
+            author_profile=self.research_profile,
+        )
+
+        self.assertEqual(len(latest_research), 1)
+        self.assertIn(detail_page_public, latest_research)
+        self.assertNotIn(detail_page_private, latest_research)
+
     def test_get_author_research(self):
         # Locale and detail pages.
         with self.assertNumQueries(2):

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
@@ -1,18 +1,9 @@
 from wagtail import models as wagtail_models
 
-from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.tests.research_hub import base
-from networkapi.wagtailpages.tests.research_hub import utils
 
 
 class ResearchLandingPageTestCase(base.ResearchHubTestCase):
-    def create_research_detail_page(self, days_ago=0):
-        publication_date = utils.days_ago(n=days_ago)
-        return detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=publication_date,
-        )
-
     def test_get_latest_research_pages_returns_three_latest_pages_by_publication_date(self):
         """
         Ensure that the latest research pages are returned

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.utils import timezone
+from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.tests.research_hub import base
@@ -31,3 +32,20 @@ class ResearchLandingPageTestCase(base.ResearchHubTestCase):
         self.assertIn(detail_page_2, latest_research_pages)
         self.assertNotIn(detail_page_1, latest_research_pages)
 
+    def test_get_latest_research_pages_does_not_return_private_page(self):
+        """
+        Ensure that the latest research pages don't contain private pages.
+        """
+        detail_page_public = self.create_research_detail_page()
+        detail_page_private = self.create_research_detail_page()
+        wagtail_models.PageViewRestriction.objects.create(
+            page=detail_page_private,
+            restriction_type=wagtail_models.PageViewRestriction.PASSWORD,
+            password="test",
+        )
+
+        latest_research_pages = self.landing_page.get_latest_research_pages()
+
+        self.assertEqual(len(latest_research_pages), 1)
+        self.assertIn(detail_page_public, latest_research_pages)
+        self.assertNotIn(detail_page_private, latest_research_pages)

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
@@ -1,15 +1,13 @@
-import datetime
-
-from django.utils import timezone
 from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
 from networkapi.wagtailpages.tests.research_hub import base
+from networkapi.wagtailpages.tests.research_hub import utils
 
 
 class ResearchLandingPageTestCase(base.ResearchHubTestCase):
     def create_research_detail_page(self, days_ago=0):
-        publication_date = timezone.now().date() - datetime.timedelta(days=days_ago)
+        publication_date = utils.days_ago(n=days_ago)
         return detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
             original_publication_date=publication_date,

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
@@ -1,5 +1,3 @@
-from wagtail import models as wagtail_models
-
 from networkapi.wagtailpages.tests.research_hub import base
 
 
@@ -27,11 +25,7 @@ class ResearchLandingPageTestCase(base.ResearchHubTestCase):
         """
         detail_page_public = self.create_research_detail_page()
         detail_page_private = self.create_research_detail_page()
-        wagtail_models.PageViewRestriction.objects.create(
-            page=detail_page_private,
-            restriction_type=wagtail_models.PageViewRestriction.PASSWORD,
-            password="test",
-        )
+        self.make_page_private(detail_page_private)
 
         latest_research_pages = self.landing_page.get_latest_research_pages()
 

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_landing_page.py
@@ -1,0 +1,33 @@
+import datetime
+
+from django.utils import timezone
+
+from networkapi.wagtailpages.factory.research_hub import detail_page as detail_page_factory
+from networkapi.wagtailpages.tests.research_hub import base
+
+
+class ResearchLandingPageTestCase(base.ResearchHubTestCase):
+    def create_research_detail_page(self, days_ago=0):
+        publication_date = timezone.now().date() - datetime.timedelta(days=days_ago)
+        return detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=publication_date,
+        )
+
+    def test_get_latest_research_pages_returns_three_latest_pages_by_publication_date(self):
+        """
+        Ensure that the latest research pages are returned
+        """
+        detail_page_1 = self.create_research_detail_page(days_ago=4)
+        detail_page_2 = self.create_research_detail_page(days_ago=3)
+        detail_page_3 = self.create_research_detail_page(days_ago=2)
+        detail_page_4 = self.create_research_detail_page(days_ago=1)
+
+        latest_research_pages = self.landing_page.get_latest_research_pages()
+
+        self.assertEqual(len(latest_research_pages), 3)
+        self.assertIn(detail_page_4, latest_research_pages)
+        self.assertIn(detail_page_3, latest_research_pages)
+        self.assertIn(detail_page_2, latest_research_pages)
+        self.assertNotIn(detail_page_1, latest_research_pages)
+

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_library_page.py
@@ -3,7 +3,6 @@ import os
 
 from django.core import management
 from django.utils import timezone, translation
-from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory.research_hub import (
@@ -65,11 +64,7 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         private_detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        wagtail_models.PageViewRestriction.objects.create(
-            restriction_type=wagtail_models.PageViewRestriction.PASSWORD,
-            password="test",
-            page=private_detail_page,
-        )
+        self.make_page_private(private_detail_page)
 
         response = self.client.get(self.library_page.url)
 

--- a/network-api/networkapi/wagtailpages/tests/research_hub/utils.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/utils.py
@@ -1,10 +1,19 @@
 import datetime
 
 from django.utils import timezone
+from wagtail import models as wagtail_models
 
 
 def days_ago(n: int):
     return timezone.now().date() - datetime.timedelta(days=n)
+
+
+def make_page_private(page):
+    wagtail_models.PageViewRestriction.objects.create(
+        page=page,
+        restriction_type=wagtail_models.PageViewRestriction.PASSWORD,
+        password="test",
+    )
 
 
 def translate_detail_page(detail_page, locale):

--- a/network-api/networkapi/wagtailpages/tests/research_hub/utils.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/utils.py
@@ -1,8 +1,10 @@
 import datetime
 
+from django.utils import timezone
+
 
 def days_ago(n: int):
-    return datetime.date.today() - datetime.timedelta(days=n)
+    return timezone.now().date() - datetime.timedelta(days=n)
 
 
 def translate_detail_page(detail_page, locale):


### PR DESCRIPTION
# Description

This PR prevents the surfacing of private (e.g. password restricted) pages from surfacing in the detail page listings on the Research Hub landing page and on the author detail pages/routes. 

To test, visit the example pages and see the listing of detail pages. Go to the admin and add a view restriction (e.g. password protection) to one of the listed pages. Visit the page with the listing and notice that the protected page is not visible anymore. When using the `main` branch, you would still see the view restricted page in the listing. 

This PR also adds some test helpers to make the setups a little less verbose.

Link to sample test page: http://localhost:8000/en/research/ and http://localhost:8000/en/research/authors/5/kenneth-brady/
Related PRs/issues: #10128 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**

- [x] Is the code I'm adding covered by tests?

**Changes in Models:**

- [x] Did I update or add new fake data?
- ~~Did I squash my migration?~~
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**

- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~
