### PR TITLE
Adjust accordion block width on article page

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/accordion_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/accordion_block.html
@@ -3,7 +3,7 @@
 
 {% block block_content %}
     {% for block in self.accordion_items %}
-        <details class="{% if width == "4/5" %} tw-w-4/5 tw-mx-auto {% else %} tw-w-full {% endif %} tw-font-sans tw-font-light">
+        <details class="{% if width == "4/5" %} large:tw-w-4/5 tw-mx-auto {% endif %} tw-w-full tw-font-sans tw-font-light">
             <summary class="tw-list-none [&::-webkit-details-marker]:tw-hidden tw-w-full tw-text-lg tw-leading-7 tw-min-h-40 py-3 d-flex align-items-center tw-border-t-gray-20 tw-border-t">
                 <span class="tw-mr-auto">{{ block.title }}</span>
                 <img src="{% static "_images/plus-circle.svg" %}" alt="" data-state="open" class="summary-open:tw-hidden" />


### PR DESCRIPTION
To address [design feedback](https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10102#issuecomment-1491042073) in ticket -- accordion block width on article pages on all screen sizes should always be the same width as paragraph element


Related PRs/issues: #10102

I'm including some links for testing purposes. You'll need a copy of prod db running locally to QA. Once you are on the page, you can quickly jump to accordion block by entering this line on dev tool console: `document.querySelector(".accordion-block").scrollIntoView();`

### Article Page (on larger screen sizes, accordion should be narrower on PR compared to on production)

- PR: [http://localhost:8000/en/research/library/is-that-even-legal/builders-guide/](http://localhost:8000/en/research/library/is-that-even-legal/builders-guide/)
- Production: [https://foundation.mozilla.org/en/research/library/is-that-even-legal/builders-guide/](https://foundation.mozilla.org/en/research/library/is-that-even-legal/builders-guide/)

### Default Page (both should look the same)

- PR: [http://localhost:8000/en/docs/how-do-i-wagtail/streamfield-blocks/#accordion](http://localhost:8000/en/docs/how-do-i-wagtail/streamfield-blocks/#accordion)
- Production: [https://foundation.mozilla.org/en/docs/how-do-i-wagtail/streamfield-blocks/#accordion](https://foundation.mozilla.org/en/docs/how-do-i-wagtail/streamfield-blocks/#accordion)

### Banner Page (both should look the same)

- PR: [http://localhost:8000/en/youtube/regretsreporter-dataset/](http://localhost:8000/en/youtube/regretsreporter-dataset/) (Password: find on [edit page](http://test.example.com:8000/cms/pages/21685/edit))
- Production: [https://foundation.mozilla.org/en/youtube/regretsreporter-dataset/](https://foundation.mozilla.org/en/youtube/regretsreporter-dataset/) (same password from above)