### PR TITLE
Limit DetailPage child page types to article and publication

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/research_hub/detail_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/research_hub/detail_page.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 class ResearchDetailPage(research_base.ResearchHubBasePage):
     parent_page_types = ["ResearchLibraryPage"]
 
+    subpage_types = ["ArticlePage", "PublicationPage"]
+
     cover_image = models.ForeignKey(
         wagtail_images.get_image_model_string(),
         null=True,

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
@@ -4,10 +4,21 @@ from django.core import exceptions
 from networkapi.wagtailpages.factory.research_hub import (
     detail_page as detail_page_factory,
 )
+from networkapi.wagtailpages.models import (
+    ArticlePage,
+    PublicationPage,
+    ResearchDetailPage,
+)
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 
 
 class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
+    def test_children(self):
+        self.assertAllowedSubpageTypes(
+            parent_model=ResearchDetailPage,
+            child_models={ArticlePage, PublicationPage},
+        )
+
     def test_research_detail_page_breadcrumbs(self) -> None:
         detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,


### PR DESCRIPTION
## Description

<!-- Describe the PR here -->
**Related PRs/issues:** #10361 
**Link to sample test page:** https://foundation-s-10361-deta-z0bb2c.herokuapp.com/cms/pages/181/add_subpage/
**Review App admin credentials:** admin/adminpassword


This PR updates the `DetailPage` model to limit child page choices to `ArticlePage` and `PublicationPage` I have also added a test to verify that DetailPages can only have children of these page types.


## Screenshots:

![Screenshot 2023-04-04 at 16-55-08 Create a page in Test Research Detail Page - Wagtail](https://user-images.githubusercontent.com/18314510/229947605-d4857a28-09f6-4727-b1db-3119bb188605.png)


## Steps to test:

1. Visit the test detail page's ["add child" page](https://foundation-s-10361-deta-z0bb2c.herokuapp.com/cms/pages/181/add_subpage/) using the credentials `admin/adminpassword`
2. Note that there are now only two options:  **Article Page** and **Publication Page**
3. If everything is looking as expected, testing is complete!




## Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?
