### PR TITLE
Allow video in accordion block

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/accordion_block.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/accordion_block.py
@@ -3,6 +3,7 @@ from wagtail import blocks
 from ..customblocks.base_rich_text_options import base_rich_text_options
 from .datawrapper_block import DatawrapperBlock
 from .image_block import ImageBlock
+from .video_block import VideoBlock
 
 accordion_rich_text = blocks.RichTextBlock(features=base_rich_text_options + ["ul", "ol", "document-link"], blank=True)
 
@@ -14,6 +15,7 @@ class AccordionItem(blocks.StructBlock):
             ("rich_text", accordion_rich_text),
             ("datawrapper", DatawrapperBlock()),
             ("image", ImageBlock()),
+            ("video", VideoBlock()),
         ]
     )
 


### PR DESCRIPTION
I take the video block as is and allow it to be included in the accordion block.

Related PRs/issues: #10467 

### Review app: 
- CMS (login: admin/adminpassword): https://foundation-s-10467-allo-estcq9.mofostaging.net/cms/pages/13/edit/
- Published Page: https://foundation-s-10467-allo-estcq9.mofostaging.net/en/blog/initial-test-blog-post-with-fixed-title/

### To QA:

- look for the "This is the title of accordion" section near the beginning of the page
- verify videos are showing up in accordion
