### PR TITLE
Make sure PNI CTA is always visible on categories that are set to have CTA

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -117,6 +117,24 @@
                 tw-gap-1
                 tw-grid-flow-row-dense
             ">
+                {% if featured_cta %}
+                    {% comment %}
+                        We render the featured CTA only once into the markup if one exists.
+                        The categories only have a toggle to define if the featured CTA should be shown when the page is filtered for the category.
+                        The "current category" is the one the page is first loaded with. We show the CTA immediately if that category would, otherwise the CTA is initially hidden.
+                        JS is used to handle the show and hide of the CTA when the active category is changed. The data attribute contains the information for which categories the CTA should be shown.
+                    {% endcomment %}
+                    <div
+                        id="category-featured-cta"
+                        class="tw-col-span-2 tw-flex tw-flex-row tw-w-full {% if not current_category.show_cta %} tw-hidden {% endif %}"
+                        data-show-for-categories="{% for category in categories %}{% if category.show_cta %}{{ category.name }}, {% endif %}{% endfor %}"
+                    >
+                        {% with cta=featured_cta %}
+                            {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url large=True %}
+                        {% endwith %}
+                    </div>
+                {% endif %}
+
                 {% block extra_product_box_list_items %}{% endblock extra_product_box_list_items %}
 
                 {% if request.user.is_anonymous %}

--- a/network-api/networkapi/templates/pages/buyersguide/category_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/category_page.html
@@ -4,24 +4,6 @@
 {% block body_id %}{{ category.slug }}{% endblock %}
 
 {% block extra_product_box_list_items %}
-    {% if featured_cta %}
-        {% comment %}
-      We render the featured CTA only once into the markup if one exists.
-      The categories only have a toggle to define if the featured CTA should be shown when the page is filtered for the category.
-      The "current category" is the one the page is first loaded with. We show the CTA immediately if that category would, otherwise the CTA is initially hidden.
-      JS is used to handle the show and hide of the CTA when the active category is changed. The data attribute contains the information for which categories the CTA should be shown.
-    {% endcomment %}
-        <div
-            id="category-featured-cta"
-            class="tw-col-span-2 tw-flex tw-flex-row tw-w-full {% if not current_category.show_cta %} tw-hidden {% endif %}"
-            data-show-for-categories="{% for category in categories %}{% if category.show_cta %}{{ category.name }}, {% endif %}{% endfor %}"
-        >
-            {% with cta=featured_cta %}
-                {% include "fragments/buyersguide/call_to_action_box.html" with icon=cta.sticker_image heading=cta.title body=cta.content link_text=cta.link_label link_href=cta.get_target_url large=True %}
-            {% endwith %}
-        </div>
-    {% endif %}
-
     {% for category in categories %}
         {% comment %}
       Each category has it's own set of related articles.


### PR DESCRIPTION
# Description

Relocated CTA template code to make sure CTA markup gets generated on category pages as well as landing page.

Related PRs/issues: #10046 

---

- Review app: https://foundation-s-10046-pni--58frby.herokuapp.com/privacynotincluded
    - CTA is currently set to show on "Pets" and "Smart Home" category pages
- Review app CMS (admin/adminpassword): https://foundation-s-10046-pni--58frby.herokuapp.com/cms