### PR TITLE
So routablepage links end up using self.locale

### DIFF
--- a/network-api/networkapi/templates/fragments/research_hub/author_card.html
+++ b/network-api/networkapi/templates/fragments/research_hub/author_card.html
@@ -1,6 +1,6 @@
 {% load wagtailroutablepage_tags wagtailimages_tags %}
 <a
-    href="{% routablepageurl page=authors_index profile_id=author_profile.id profile_slug=author_profile.name|slugify url_name="wagtailpages:research-author-detail" %}"
+    href="{% routablepageurl page=authors_index.localized profile_id=author_profile.id profile_slug=author_profile.name|slugify url_name="wagtailpages:research-author-detail" %}"
     class="tw-flex {% if not tight %} tw-gap-8 medium:tw-gap-12 large:tw-gap-16 {% else %} tw-gap-6 {% endif %} tw-group tw-items-center hover:tw-no-underline"
 >
     <div class="tw-shrink-0 tw-w-32 {% if not tight %} medium:tw-w-40 large:tw-w-48 {% endif %}">

--- a/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
+++ b/network-api/networkapi/wagtailpages/tests/research_hub/test_detail_page.py
@@ -1,6 +1,7 @@
 import wagtail_factories
 from django.core import exceptions
 from django.utils import translation
+from django.utils.text import slugify
 
 from networkapi.wagtailpages.factory.research_hub import (
     detail_page as detail_page_factory,
@@ -11,6 +12,7 @@ from networkapi.wagtailpages.models import (
     PublicationPage,
     ResearchDetailPage,
 )
+from networkapi.wagtailpages.pagemodels.research_hub import authors_index
 from networkapi.wagtailpages.tests.research_hub import base as research_test_base
 from networkapi.wagtailpages.tests.research_hub import utils as research_test_utils
 
@@ -75,6 +77,32 @@ class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
         self.assertEqual(len(research_authors_fr), 1)
         self.assertIn(profile_fr, research_authors_fr)
         self.assertNotIn(profile_en, research_authors_fr)
+
+    def test_get_research_authors_returns_localized_profiles_rendered(self) -> None:
+        """
+        Similar to the above, but these links get passed to routablepageurl in the template
+        so we can be certain that they come out localized.
+        """
+        detail_page = detail_page_factory.ResearchDetailPageFactory(parent=self.library_page)
+        self.synchronize_tree()
+        # Translating both the page and the research author profile.
+        detail_page_fr = research_test_utils.translate_detail_page(detail_page, self.fr_locale)
+        profile_fr = detail_page_fr.research_authors.first().author_profile
+        translation.activate(self.fr_locale.language_code)
+        author_index = authors_index.ResearchAuthorsIndexPage.objects.first()
+        fr_author_index = authors_index.ResearchAuthorsIndexPage.objects.filter(locale=self.fr_locale).first()
+
+        # Build a URL to check for in the response.
+        # E.G, /fr/research/authors/1/name-here/
+        fr_author_link = f'href="{fr_author_index.url}{profile_fr.id}/{slugify(profile_fr.name)}/"'
+        en_author_link = f'href="{author_index.url}{profile_fr.id}/{slugify(profile_fr.name)}/"'
+
+        # Request the fr version of the page.
+        response = self.client.get(detail_page_fr.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, fr_author_link)
+        self.assertNotContains(response, en_author_link)
 
     def test_get_research_authors_returns_default_locale(self) -> None:
         """

--- a/tasks.py
+++ b/tasks.py
@@ -294,7 +294,22 @@ def test(ctx):
 
 @task(aliases=["docker-test-python"])
 def test_python(ctx, file="", n="auto", verbose=False):
-    """Run python tests."""
+    """
+    Run python tests.
+
+    Example calls:
+    - test_python(ctx)
+    - test_python(ctx, file="test_something.py")
+    - test_python(ctx, n=4, verbose=True)
+
+    Parameters:
+    - ctx: Context object (provided by Invoke)
+    - file: Optional string representing the path to a specific test file to run.
+    - n: Optional integer or string 'auto' representing the number of parallel tests to run.
+    Default is 'auto' which allows pytest to automatically determine the optimal number.
+    - verbose: Optional boolean flag indicating whether to print verbose output during testing. Default is False.
+    """
+
     djcheck(ctx)
     makemigrations_dryrun(ctx, args="--check")
     parallel = f"-n {n}" if n != "1" else ""


### PR DESCRIPTION
# Description

Ensures that the link for the author snippet passed to routablepageurl template tag is localised.

Link to sample test page: http://0.0.0.0:8000/fr/research/library/ai-transparency-in-practice/

When viewing the test page, notice the 'Project leads' authors rendered should also link to `/fr/` locale. Without this PR change, they would link to `/en/`

Related PRs/issues: #10405

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests? - I've added a new test for this that checks the links rendered in the response. 26ed90350645996a6339fc028489b30bd61e7f11, if you revert the addition [here](https://github.com/MozillaFoundation/foundation.mozilla.org/pull/10555/files#diff-d777dd9d9504591b7cff77679987e417b39a578663328b15f9104d98740a6709R3) this test should fail

**Changes in Models:**
- [ ] ~Did I update or add new fake data?~
- [ ] ~Did I squash my migration?~
- [ ] ~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~

**Documentation:**
- [ ] ~Is my code documented?~
- [ ] ~Did I update the READMEs or wagtail documentation?~
