### PR TITLE
Fixes typo so all test files aren't in the coverage calculation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ source = netwrok-api/networkapi
 omit =
    *migrations*
    *settings.py*
-   *test_*d
+   *test_*
 branch = true
 
 [coverage:report]


### PR DESCRIPTION
# Description

Typo was causing coverage to include test.py files in the report.

When I was looking at adding a repo badge to the README for the coverage metric, I noticed that the coveralls reports [eg](https://coveralls.io/jobs/120188393) from CI report 84%, whereas now locally we are at 68%. I haven't looked into it too much but I think it might be because coveralls is set up only on the `/donate` folder? Or that it's only configured to report `main` branch stats.

Link to sample test page: N/A
Related PRs/issues: # N/A

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] ~~Is the code I'm adding covered by tests?~~

**Changes in Models:**
- [ ] ~~Did I update or add new fake data?~~
- [ ] ~~Did I squash my migration?~~
- [ ] ~~Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [ ] ~~Is my code documented?~~
- [ ] ~~Did I update the READMEs or wagtail documentation?~~
