### PR TITLE
Fix Profile auto slug bug

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/profiles.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/profiles.py
@@ -1,4 +1,6 @@
 from django.db import models
+from django.db.models import F, Value
+from django.db.models.functions import Concat
 from django.utils.text import slugify
 from wagtail.admin.panels import FieldPanel
 from wagtail.models import TranslatableMixin
@@ -63,8 +65,9 @@ class Profile(index.Indexed, TranslatableMixin, models.Model):
         return self.name
 
     def save(self, *args, **kwargs):
-        self.slug = slugify(f"{self.name}-{str(self.id)}")
+        self.slug = slugify(self.name)
         super(Profile, self).save(*args, **kwargs)
+        self._meta.model.objects.filter(id=self.id).update(slug=Concat(F("slug"), Value("-"), F("id")))
 
     class Meta(TranslatableMixin.Meta):
         ordering = ["name"]

--- a/network-api/networkapi/wagtailpages/tests/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/test_blog.py
@@ -828,6 +828,7 @@ class TestBlogIndexAuthors(test_base.WagtailpagesTestCase):
         self.assertEqual(response.render().status_code, 200)
 
     def test_authors_detail(self):
+        self.profile_1.refresh_from_db()
         blog_author_url = self.blog_index.get_url() + self.blog_index.reverse_subpage(
             "blog-author-detail", args=(self.profile_1.slug,)
         )

--- a/network-api/networkapi/wagtailpages/tests/test_profiles.py
+++ b/network-api/networkapi/wagtailpages/tests/test_profiles.py
@@ -15,6 +15,18 @@ class ProfileTest(test.TestCase):
         profile_factories.ProfileFactory()
         self.assertTrue(True)
 
+    def test_profile_auto_slugs_name_and_id_when_creating_a_profile(self):
+        profile = profile_factories.ProfileFactory(name="John Doe")
+        profile.refresh_from_db()
+        self.assertEqual(profile.slug, f"john-doe-{profile.pk}")
+
+    def test_profile_auto_slugs_name_and_id_when_updating_a_profile(self):
+        profile = profile_factories.ProfileFactory(name="John Doe")
+        profile.name = "Jane Doe"
+        profile.save()
+        profile.refresh_from_db()
+        self.assertEqual(profile.slug, f"jane-doe-{profile.pk}")
+
     def test_filter_research_authors(self):
         research_author_profile = profile_factories.ProfileFactory()
         relations_factory.ResearchAuthorRelationFactory(


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Fix bug where slug id is not set properly when a `Profile` is saved.

Link to sample test page:
Related PRs/issues: #10509 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
