### PR TITLE
Exclude Dear Internet page from visual regression test

### DIFF
--- a/tests/foundation-urls.js
+++ b/tests/foundation-urls.js
@@ -26,6 +26,7 @@ module.exports = {
   "PNI general product page": "/privacynotincluded/general-percy-product",
   "YouTube regrets": "/campaigns/youtube-regrets",
   "YouTube regrets  reporter": "/campaigns/regrets-reporter",
-  "Dear Internet": "/campaigns/dearinternet",
+  // Disabled Dear Internet for now as Percy been giving false positive visual diffs
+  // "Dear Internet": "/campaigns/dearinternet",
   Styleguide: "/style-guide",
 };


### PR DESCRIPTION
Exclude Dear Internet page from visual regression test because
1. Percy has been giving false positive flags on that page
2. Dear Internet page receives low traffic now
3. We are not actively updating that page

--- 

Related PRs/issues: #10328 (PR only addresses one of the issues mentioned in ticket)
Percy results for this PR: https://percy.io/Mozilla-Foundation/foundation.mozilla.org/builds/27269439/missing
