### PR TITLE
added breadcrumbs

### DIFF
--- a/network-api/networkapi/templates/pages/research_hub/library_page.html
+++ b/network-api/networkapi/templates/pages/research_hub/library_page.html
@@ -1,8 +1,8 @@
 {% extends "./base.html" %}
-{% load i18n static wagtailcore_tags wagtailimages_tags %}
+{% load i18n static wagtailcore_tags wagtailimages_tags breadcrumbs %}
 {% block research_hub_content %}
     <div>
-        {% include 'fragments/breadcrumbs.html' with breadcrumb_list=breadcrumbs %}
+        {% get_research_breadcrumbs %}
         <h1>{{ page.title }}</h1>
     </div>
     <div class="large:tw-w-160 large:tw-h-64 tw-mt-12 tw-mb-8 large:tw-mb-0 large:-tw-ml-12 large:tw-p-12 large:tw-bg-gray-05">


### PR DESCRIPTION
# Description
Link to test page: https://foundation-s-hotfix-rh--eabvuj.herokuapp.com/en/research/library/?search=

This PR updates the Research Hub Library page to use the new breadcrumbs that were added in https://github.com/MozillaFoundation/foundation.mozilla.org/pull/10572


## Steps to test:

1. Visit the link above
2. Make sure the breadcrumbs appear above the title as expected
3. If everything looks OK, testing is complete!