### PR TITLE
Only show filter fields if there are options

### DIFF
--- a/network-api/networkapi/templates/fragments/research_library_form.html
+++ b/network-api/networkapi/templates/fragments/research_library_form.html
@@ -1,14 +1,16 @@
 {% load l10n %}
 {% for field in form %}
-    <div class="tw-pt-8 tw-pb-24 tw-border-t">
-        <fieldset>
-            <legend>
-                <h3 class="tw-h4-heading">{{ field.label_tag }}</h3>
-            </legend>
-            {{ field.errors }}
-            <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if field|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll{% endif %}">
-                {% for option in field %}<li class="tw-flex tw-flex-row tw-items-baseline">{{ option }}</li>{% endfor %}
-            </ul>
-        </fieldset>
-    </div>
+    {% if field|length %}
+        <div class="tw-pt-8 tw-pb-24 tw-border-t">
+            <fieldset>
+                <legend>
+                    <h3 class="tw-h4-heading">{{ field.label_tag }}</h3>
+                </legend>
+                {{ field.errors }}
+                <ul class="tw-list-none tw-mb-0 tw-pl-0 {% if field|length > 5 %} tw-max-h-[13.5rem] tw-overflow-y-scroll{% endif %}">
+                    {% for option in field %}<li class="tw-flex tw-flex-row tw-items-baseline">{{ option }}</li>{% endfor %}
+                </ul>
+            </fieldset>
+        </div>
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Fixes the Research Hub library page to only show filter fields if there are options to be displayed, i.e. hides fields with no options. Fixes #10620 

Link to sample test page:
Related PRs/issues: #10620 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~ Template only

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
