### PR TITLE
Fix package.json with the new path to Playwright integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "optimize:png": "find source/images -type f -name '*.png' -print0 | xargs -0 -n 1 -P 6 optipng",
     "optimize": "run-p optimize:**",
     "percy": "percy exec -t 750 -- npm run playwright:percy",
-    "playwright": "npm run playwright:wait:dev && playwright test ./tests/integration.spec.js",
+    "playwright": "npm run playwright:wait:dev && playwright test ./tests/integration/",
     "playwright:install": "playwright install chromium firefox webkit",
     "playwright:wait:dev": "wait-on -i 3000 http://localhost:8000/static/_css/tailwind.compiled.css",
     "playwright:percy": "run-p --race server playwright:visual",


### PR DESCRIPTION
Follow-up for https://github.com/MozillaFoundation/foundation.mozilla.org/pull/10621. 

In #10621 I forgot to also update the "playwright" task to point to the new directory we created. Filing this PR to fix that.

## To QA

- have `docker-compose up` running on one tab
- run `npm run playwright` on another tab
- check the result 
  - if it's `1 skipped 1 passed` then we are good 👍🏻 
  - if you see "0 tests found" then this PR doesn't have the right fix 👎🏻 