### PR TITLE
Add Filtering to RCC library page

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/libraries/rcc/detail_page.py
+++ b/network-api/networkapi/wagtailpages/factory/libraries/rcc/detail_page.py
@@ -44,9 +44,7 @@ class RCCDetailPageFactory(wagtail_factories.PageFactory):
     )
 
     related_content_types = factory.RelatedFactoryList(
-        factory=(
-            "networkapi.wagtailpages.factory.libraries.rcc" ".relations.RCCDetailPageRCCContentTypeRelationFactory"
-        ),
+        factory="networkapi.wagtailpages.factory.libraries.rcc.relations.RCCDetailPageRCCContentTypeRelationFactory",
         factory_related_name="rcc_detail_page",
         size=1,
     )

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/forms.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/forms.py
@@ -1,0 +1,57 @@
+from django import forms
+from django.utils.translation import pgettext_lazy
+
+from networkapi.wagtailpages import utils
+from networkapi.wagtailpages.pagemodels import profiles as profile_models
+from networkapi.wagtailpages.pagemodels.libraries.rcc import taxonomies
+
+
+def _get_author_options():
+    author_profiles = utils.get_rcc_authors(profile_models.Profile.objects.all())
+    author_profiles = utils.localize_queryset(author_profiles)
+    return [(author_profile.id, author_profile.name) for author_profile in author_profiles]
+
+
+def _get_content_type_options():
+    content_types = taxonomies.RCCContentType.objects.all()
+    content_types = utils.localize_queryset(content_types)
+    return [(content_type.id, content_type.name) for content_type in content_types]
+
+
+def _get_curricular_area_options():
+    curricular_areas = taxonomies.RCCCurricularArea.objects.all()
+    curricular_areas = utils.localize_queryset(curricular_areas)
+    return [(curricular_area.id, curricular_area.name) for curricular_area in curricular_areas]
+
+
+def _get_topic_options():
+    topics = taxonomies.RCCTopic.objects.all()
+    topics = utils.localize_queryset(topics)
+    return [(topic.id, topic.name) for topic in topics]
+
+
+class RCCLibraryPageFilterForm(forms.Form):
+    content_types = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple(attrs={"class": "rh-checkbox"}),
+        choices=_get_content_type_options,
+        label=pgettext_lazy("Filter form field label", "Content Type"),
+    )
+    contributors = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple(attrs={"class": "rh-checkbox"}),
+        choices=_get_author_options,
+        label=pgettext_lazy("Filter form field label - Authors of RCC articles", "Contributors"),
+    )
+    topics = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple(attrs={"class": "rh-checkbox"}),
+        choices=_get_topic_options,
+        label=pgettext_lazy("Filter form field label", "Topics"),
+    )
+    curricular_areas = forms.MultipleChoiceField(
+        required=False,
+        widget=forms.CheckboxSelectMultiple(attrs={"class": "rh-checkbox"}),
+        choices=_get_curricular_area_options,
+        label=pgettext_lazy("Filter form field label", "Curricular Area"),
+    )

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/library_page.py
@@ -9,15 +9,17 @@ from wagtail.admin import panels
 from wagtail.images import edit_handlers as image_panels
 from wagtail_localize.fields import SynchronizedField, TranslatableField
 
-# from networkapi.wagtailpages import utils
-# from networkapi.wagtailpages.pagemodels import profiles as profile_models
+from networkapi.wagtailpages import utils
+from networkapi.wagtailpages.pagemodels import profiles as profile_models
 from networkapi.wagtailpages.pagemodels.base import BasePage
-from networkapi.wagtailpages.pagemodels.libraries.rcc import detail_page  # taxonomies,
-from networkapi.wagtailpages.pagemodels.libraries.rcc import constants
-
-# from networkapi.wagtailpages.pagemodels.libraries.rcc.forms import (
-#     RCCLibraryPageFilterForm,
-# )
+from networkapi.wagtailpages.pagemodels.libraries.rcc import (
+    constants,
+    detail_page,
+    taxonomies,
+)
+from networkapi.wagtailpages.pagemodels.libraries.rcc.forms import (
+    RCCLibraryPageFilterForm,
+)
 
 if typing.TYPE_CHECKING:
     from django import http
@@ -65,31 +67,33 @@ class RCCLibraryPage(BasePage):
     ]
 
     def get_context(self, request: "http.HttpRequest") -> "django_template.Context":
-        #     search_query: str = request.GET.get("search", "")
+        search_query: str = request.GET.get("search", "")
         sort_value: str = request.GET.get("sort", "")
         sort: constants.SortOption = constants.SORT_CHOICES.get(sort_value, constants.SORT_NEWEST_FIRST)
 
-        #     filter_form = RCCLibraryPageFilterForm(request.GET, label_suffix="")
-        #     if not filter_form.is_valid():
-        #         # If the form is not valid, we will not filter by any of the values.
-        #         # This will result in all articles being displayed.
-        #         filtered_author_ids: list[int] = []
-        #         filtered_content_type_ids: list[int] = []
-        #         filtered_curricular_area_ids: list[int] = []
-        #         filtered_topic_ids: list[int] = []
+        filter_form = RCCLibraryPageFilterForm(request.GET, label_suffix="")
+        if not filter_form.is_valid():
+            # If the form is not valid, we will not filter by any of the values.
+            # This will result in all articles being displayed.
+            filtered_author_ids: list[int] = []
+            filtered_content_type_ids: list[int] = []
+            filtered_curricular_area_ids: list[int] = []
+            filtered_topic_ids: list[int] = []
 
-        #     filtered_author_ids = filter_form.cleaned_data["contributors"]
-        #     filtered_content_type_ids = filter_form.cleaned_data["content_types"]
-        #     filtered_curricular_area_ids = filter_form.cleaned_data["curricular_areas"]
-        #     filtered_topic_ids = filter_form.cleaned_data["topics"]
+        filtered_author_ids = filter_form.cleaned_data["contributors"]
+        filtered_content_type_ids = filter_form.cleaned_data["content_types"]
+        filtered_curricular_area_ids = filter_form.cleaned_data["curricular_areas"]
+        filtered_topic_ids = filter_form.cleaned_data["topics"]
 
-        searched_and_filtered_rcc_detail_pages = self._get_rcc_detail_pages(sort=sort)
-        # search=search_query,
-        # sort=sort,
-        # author_profile_ids=filtered_author_ids,
-        # content_type_ids=filtered_content_type_ids,
-        # curricular_area_ids=filtered_curricular_area_ids,
-        # topic_ids=filtered_topic_ids,
+        searched_and_filtered_rcc_detail_pages = self._get_rcc_detail_pages(
+            search=search_query,
+            sort=sort,
+            author_profile_ids=filtered_author_ids,
+            content_type_ids=filtered_content_type_ids,
+            curricular_area_ids=filtered_curricular_area_ids,
+            topic_ids=filtered_topic_ids,
+        )
+
         rcc_detail_pages_paginator = paginator.Paginator(
             object_list=searched_and_filtered_rcc_detail_pages,
             per_page=self.results_count,
@@ -100,9 +104,9 @@ class RCCLibraryPage(BasePage):
         rcc_detail_pages_page = rcc_detail_pages_paginator.get_page(page)
 
         context: "django_template.Context" = super().get_context(request)
-        # context["search_query"] = search_query
-        # context["sort"] = sort
-        # context["form"] = filter_form
+        context["search_query"] = search_query
+        context["sort"] = sort
+        context["form"] = filter_form
         context["rcc_detail_pages_count"] = rcc_detail_pages_paginator.count
         context["rcc_detail_pages"] = rcc_detail_pages_page
         return context
@@ -116,7 +120,6 @@ class RCCLibraryPage(BasePage):
         content_type_ids: Optional[list[int]] = None,
         curricular_area_ids: Optional[list[int]] = None,
         topic_ids: Optional[list[int]] = None,
-        year: Optional[int] = None,
     ):
         author_profile_ids = author_profile_ids or []
         content_type_ids = content_type_ids or []
@@ -126,45 +129,42 @@ class RCCLibraryPage(BasePage):
         rcc_detail_pages = detail_page.RCCDetailPage.objects.live().public()
         rcc_detail_pages = rcc_detail_pages.filter(locale=wagtail_models.Locale.get_active())
 
-        # author_profiles = utils.get_rcc_authors(profile_models.Profile.objects.all())
-        # author_profiles = author_profiles.filter(id__in=author_profile_ids)
-        # for author_profile in author_profiles:
-        #     # Synced but not translated pages are still associated with the default
-        #     # locale's author profile. But, we want to show them when we are filtering
-        #     # for the localized author profile. We use the fact that the localized and
-        #     # default locale's author profile have the same `translation_key`.
-        #     rcc_detail_pages = rcc_detail_pages.filter(
-        #         rcc_authors__author_profile__translation_key=(author_profile.translation_key)
-        #     )
+        author_profiles = utils.get_rcc_authors(profile_models.Profile.objects.all())
+        author_profiles = author_profiles.filter(id__in=author_profile_ids)
+        for author_profile in author_profiles:
+            # Synced but not translated pages are still associated with the default
+            # locale's author profile. But, we want to show them when we are filtering
+            # for the localized author profile. We use the fact that the localized and
+            # default locale's author profile have the same `translation_key`.
+            rcc_detail_pages = rcc_detail_pages.filter(
+                rcc_authors__author_profile__translation_key=(author_profile.translation_key)
+            )
 
-        # content_types = taxonomies.RCCContentType.objects.filter(id__in=content_type_ids)
-        # for content_type in content_types:
-        #     rcc_detail_pages = rcc_detail_pages.filter(
-        #         related_content_types__content_type__translation_key=content_type.translation_key
-        #     )
+        content_types = taxonomies.RCCContentType.objects.filter(id__in=content_type_ids)
+        for content_type in content_types:
+            rcc_detail_pages = rcc_detail_pages.filter(
+                related_content_types__content_type__translation_key=content_type.translation_key
+            )
 
-        # curricular_areas = taxonomies.RCCCurricularArea.objects.filter(id__in=curricular_area_ids)
-        # for curricular_area in curricular_areas:
-        #     rcc_detail_pages = rcc_detail_pages.filter(
-        #         related_curricular_areas__curricular_area__translation_key=curricular_area.translation_key
-        #     )
+        curricular_areas = taxonomies.RCCCurricularArea.objects.filter(id__in=curricular_area_ids)
+        for curricular_area in curricular_areas:
+            rcc_detail_pages = rcc_detail_pages.filter(
+                related_curricular_areas__curricular_area__translation_key=curricular_area.translation_key
+            )
 
-        # topics = taxonomies.RCCTopic.objects.filter(id__in=topic_ids)
-        # for topic in topics:
-        #     rcc_detail_pages = rcc_detail_pages.filter(
-        #         related_topics__rcc_topic__translation_key=topic.translation_key
-        #     )
-
-        # if year:
-        #     rcc_detail_pages = rcc_detail_pages.filter(original_publication_date__year=year)
+        topics = taxonomies.RCCTopic.objects.filter(id__in=topic_ids)
+        for topic in topics:
+            rcc_detail_pages = rcc_detail_pages.filter(
+                related_topics__rcc_topic__translation_key=topic.translation_key
+            )
 
         rcc_detail_pages = rcc_detail_pages.order_by(sort.order_by_value)
 
-        # if search:
-        #     rcc_detail_pages = rcc_detail_pages.search(
-        #         search,
-        #         order_by_relevance=False,  # To preserve original ordering
-        #     )
+        if search:
+            rcc_detail_pages = rcc_detail_pages.search(
+                search,
+                order_by_relevance=False,  # To preserve original ordering
+            )
 
         return rcc_detail_pages
 

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/library_page.py
@@ -74,17 +74,17 @@ class RCCLibraryPage(BasePage):
         filter_form = RCCLibraryPageFilterForm(request.GET, label_suffix="")
 
         if filter_form.is_valid():
-            filtered_author_ids = filter_form.cleaned_data["contributors"]
-            filtered_content_type_ids = filter_form.cleaned_data["content_types"]
-            filtered_curricular_area_ids = filter_form.cleaned_data["curricular_areas"]
-            filtered_topic_ids = filter_form.cleaned_data["topics"]
+            filtered_author_ids: list[int] = filter_form.cleaned_data["contributors"]
+            filtered_content_type_ids: list[int] = filter_form.cleaned_data["content_types"]
+            filtered_curricular_area_ids: list[int] = filter_form.cleaned_data["curricular_areas"]
+            filtered_topic_ids: list[int] = filter_form.cleaned_data["topics"]
         else:
             # If the form is not valid, we will not filter by any of the values.
             # This will result in all articles being displayed.
-            filtered_author_ids: list[int] = []
-            filtered_content_type_ids: list[int] = []
-            filtered_curricular_area_ids: list[int] = []
-            filtered_topic_ids: list[int] = []
+            filtered_author_ids = []
+            filtered_content_type_ids = []
+            filtered_curricular_area_ids = []
+            filtered_topic_ids = []
 
         searched_and_filtered_rcc_detail_pages = self._get_rcc_detail_pages(
             search=search_query,

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/rcc/library_page.py
@@ -72,18 +72,19 @@ class RCCLibraryPage(BasePage):
         sort: constants.SortOption = constants.SORT_CHOICES.get(sort_value, constants.SORT_NEWEST_FIRST)
 
         filter_form = RCCLibraryPageFilterForm(request.GET, label_suffix="")
-        if not filter_form.is_valid():
+
+        if filter_form.is_valid():
+            filtered_author_ids = filter_form.cleaned_data["contributors"]
+            filtered_content_type_ids = filter_form.cleaned_data["content_types"]
+            filtered_curricular_area_ids = filter_form.cleaned_data["curricular_areas"]
+            filtered_topic_ids = filter_form.cleaned_data["topics"]
+        else:
             # If the form is not valid, we will not filter by any of the values.
             # This will result in all articles being displayed.
             filtered_author_ids: list[int] = []
             filtered_content_type_ids: list[int] = []
             filtered_curricular_area_ids: list[int] = []
             filtered_topic_ids: list[int] = []
-
-        filtered_author_ids = filter_form.cleaned_data["contributors"]
-        filtered_content_type_ids = filter_form.cleaned_data["content_types"]
-        filtered_curricular_area_ids = filter_form.cleaned_data["curricular_areas"]
-        filtered_topic_ids = filter_form.cleaned_data["topics"]
 
         searched_and_filtered_rcc_detail_pages = self._get_rcc_detail_pages(
             search=search_query,

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/research_hub/forms.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/research_hub/forms.py
@@ -41,7 +41,7 @@ def _get_year_options():
     return [empty_option] + year_options
 
 
-class LibraryPageFilterForm(forms.Form):
+class ResearchLibraryPageFilterForm(forms.Form):
     topic = forms.MultipleChoiceField(
         required=False,
         widget=forms.CheckboxSelectMultiple(attrs={"class": "rh-checkbox"}),

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/research_hub/library_page.py
@@ -18,7 +18,7 @@ from networkapi.wagtailpages.pagemodels.libraries.research_hub import (
     taxonomies,
 )
 from networkapi.wagtailpages.pagemodels.libraries.research_hub.forms import (
-    LibraryPageFilterForm,
+    ResearchLibraryPageFilterForm,
 )
 
 if typing.TYPE_CHECKING:
@@ -71,19 +71,19 @@ class ResearchLibraryPage(BasePage):
         sort_value: str = request.GET.get("sort", "")
         sort: constants.SortOption = constants.SORT_CHOICES.get(sort_value, constants.SORT_NEWEST_FIRST)
 
-        filter_form = LibraryPageFilterForm(request.GET, label_suffix="")
-        if not filter_form.is_valid():
+        filter_form = ResearchLibraryPageFilterForm(request.GET, label_suffix="")
+        if filter_form.is_valid():
+            filtered_author_ids = filter_form.cleaned_data["author"]
+            filtered_topic_ids = filter_form.cleaned_data["topic"]
+            filtered_region_ids = filter_form.cleaned_data["region"]
+            filtered_year = filter_form.cleaned_data["year"]
+        else:
             # If the form is not valid, we will not filter by any of the values.
             # This will result in all research being displayed.
             filtered_author_ids: list[int] = []
             filtered_topic_ids: list[int] = []
             filtered_region_ids: list[int] = []
             filtered_year: Optional[int] = None
-
-        filtered_author_ids = filter_form.cleaned_data["author"]
-        filtered_topic_ids = filter_form.cleaned_data["topic"]
-        filtered_region_ids = filter_form.cleaned_data["region"]
-        filtered_year = filter_form.cleaned_data["year"]
 
         searched_and_filtered_research_detail_pages = self._get_research_detail_pages(
             search=search_query,

--- a/network-api/networkapi/wagtailpages/pagemodels/libraries/research_hub/library_page.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/libraries/research_hub/library_page.py
@@ -73,17 +73,17 @@ class ResearchLibraryPage(BasePage):
 
         filter_form = ResearchLibraryPageFilterForm(request.GET, label_suffix="")
         if filter_form.is_valid():
-            filtered_author_ids = filter_form.cleaned_data["author"]
-            filtered_topic_ids = filter_form.cleaned_data["topic"]
-            filtered_region_ids = filter_form.cleaned_data["region"]
-            filtered_year = filter_form.cleaned_data["year"]
+            filtered_author_ids: list[int] = filter_form.cleaned_data["author"]
+            filtered_topic_ids: list[int] = filter_form.cleaned_data["topic"]
+            filtered_region_ids: list[int] = filter_form.cleaned_data["region"]
+            filtered_year: Optional[int] = filter_form.cleaned_data["year"]
         else:
             # If the form is not valid, we will not filter by any of the values.
             # This will result in all research being displayed.
-            filtered_author_ids: list[int] = []
-            filtered_topic_ids: list[int] = []
-            filtered_region_ids: list[int] = []
-            filtered_year: Optional[int] = None
+            filtered_author_ids = []
+            filtered_topic_ids = []
+            filtered_region_ids = []
+            filtered_year = None
 
         searched_and_filtered_research_detail_pages = self._get_research_detail_pages(
             search=search_query,

--- a/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_forms.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_forms.py
@@ -1,6 +1,3 @@
-import os
-
-from django.core import management
 from django.utils import translation
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
@@ -20,10 +17,6 @@ from networkapi.wagtailpages.tests.libraries.rcc import utils as rcc_test_utils
 
 
 class TestFormUtilitiesFunctions(rcc_test_base.RCCTestCase):
-    def update_index(self):
-        with open(os.devnull, "w") as f:
-            management.call_command("update_index", verbosity=0, stdout=f)
-
     def test_rcc_author_profile_obtained_by_get_author_options(self):
         detail_page = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,

--- a/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_forms.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_forms.py
@@ -1,0 +1,302 @@
+import os
+
+from django.core import management
+from django.utils import translation
+
+from networkapi.wagtailpages.factory import profiles as profiles_factory
+from networkapi.wagtailpages.factory.libraries.rcc import (
+    detail_page as detail_page_factory,
+)
+from networkapi.wagtailpages.factory.libraries.rcc import relations as relations_factory
+from networkapi.wagtailpages.factory.libraries.rcc import (
+    taxonomies as taxonomies_factory,
+)
+from networkapi.wagtailpages.pagemodels.libraries.rcc import forms
+from networkapi.wagtailpages.pagemodels.libraries.rcc.forms import (
+    RCCLibraryPageFilterForm,
+)
+from networkapi.wagtailpages.tests.libraries.rcc import base as rcc_test_base
+from networkapi.wagtailpages.tests.libraries.rcc import utils as rcc_test_utils
+
+
+class TestFormUtilitiesFunctions(rcc_test_base.RCCTestCase):
+    def update_index(self):
+        with open(os.devnull, "w") as f:
+            management.call_command("update_index", verbosity=0, stdout=f)
+
+    def test_rcc_author_profile_obtained_by_get_author_options(self):
+        detail_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+
+        author_options = forms._get_author_options()
+        author_option_values = [i for i, _ in author_options]
+
+        self.assertIn(
+            detail_page.rcc_authors.first().author_profile.id,
+            author_option_values,
+        )
+
+    def test_non_rcc_author_profile_not_obtained_by_get_author_options(self):
+        profile = profiles_factory.ProfileFactory()
+
+        author_options = forms._get_author_options()
+        author_option_values = [i for i, _ in author_options]
+
+        self.assertNotIn(
+            profile.id,
+            author_option_values,
+        )
+
+    def test_rcc_author_in_context_aliased_detail_page_fr(self):
+        """
+        After the treesync, there are alias pages in the non-default locales. But,
+        before the pages are translated (a manual action) the related models like author
+        are still the ones from the default locale.
+        """
+        detail_page_en = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+        profile_en = detail_page_en.rcc_authors.first().author_profile
+        self.synchronize_tree()
+        translation.activate(self.fr_locale.language_code)
+
+        author_options = forms._get_author_options()
+        author_option_values = [i for i, _ in author_options]
+
+        self.assertIn(
+            profile_en.id,
+            author_option_values,
+        )
+
+    def test_rcc_author_in_context_translated_detail_page_fr(self):
+        """
+        When a profile for the active locale exists, pass that one to the context.
+
+        Profiles are not necessarily people, so they might have translated names.
+        """
+        detail_page_en = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+        profile_en = detail_page_en.rcc_authors.first().author_profile
+        self.synchronize_tree()
+        detail_page_fr = rcc_test_utils.translate_detail_page(detail_page_en, self.fr_locale)
+        profile_fr = detail_page_fr.rcc_authors.first().author_profile
+        translation.activate(self.fr_locale.language_code)
+
+        author_options = forms._get_author_options()
+        author_option_values = [i for i, _ in author_options]
+
+        self.assertNotIn(
+            profile_en.id,
+            author_option_values,
+        )
+        self.assertIn(
+            profile_fr.id,
+            author_option_values,
+        )
+
+    def test_rcc_topics_in_options(self):
+        topic_1 = taxonomies_factory.RCCTopicFactory()
+        topic_2 = taxonomies_factory.RCCTopicFactory()
+
+        topic_options = forms._get_topic_options()
+        topic_option_values = [i for i, _ in topic_options]
+
+        self.assertEqual(len(topic_option_values), 2)
+        self.assertIn(topic_1.id, topic_option_values)
+        self.assertIn(topic_2.id, topic_option_values)
+
+    def test_rcc_content_types_in_options(self):
+        content_type_1 = taxonomies_factory.RCCContentTypeFactory()
+        content_type_2 = taxonomies_factory.RCCContentTypeFactory()
+
+        content_type_options = forms._get_content_type_options()
+        content_type_option_values = [i for i, _ in content_type_options]
+
+        self.assertEqual(len(content_type_option_values), 2)
+        self.assertIn(content_type_1.id, content_type_option_values)
+        self.assertIn(content_type_2.id, content_type_option_values)
+
+    def test_rcc_curricular_areas_in_options(self):
+        curricular_area_1 = taxonomies_factory.RCCCurricularAreaFactory()
+        curricular_area_2 = taxonomies_factory.RCCCurricularAreaFactory()
+
+        curricular_area_options = forms._get_curricular_area_options()
+        curricular_area_option_values = [i for i, _ in curricular_area_options]
+
+        self.assertEqual(len(curricular_area_option_values), 2)
+        self.assertIn(curricular_area_1.id, curricular_area_option_values)
+        self.assertIn(curricular_area_2.id, curricular_area_option_values)
+
+    def test_topic_in_options_matches_active_locale(self):
+        topic_en = taxonomies_factory.RCCTopicFactory()
+        topic_fr = topic_en.copy_for_translation(self.fr_locale)
+        topic_fr.save()
+
+        # Activate the default locale
+        translation.activate(self.default_locale.language_code)
+
+        topic_options_en = forms._get_topic_options()
+        topic_option_values_en = [i for i, _ in topic_options_en]
+        self.assertEqual(len(topic_option_values_en), 1)
+        self.assertIn(topic_en.id, topic_option_values_en)
+        self.assertNotIn(topic_fr.id, topic_option_values_en)
+
+        # Activate the French locale
+        translation.activate(self.fr_locale.language_code)
+
+        topic_options_fr = forms._get_topic_options()
+        topic_option_values_fr = [i for i, _ in topic_options_fr]
+        self.assertEqual(len(topic_option_values_fr), 1)
+        self.assertNotIn(topic_en.id, topic_option_values_fr)
+        self.assertIn(topic_fr.id, topic_option_values_fr)
+
+    def test_content_type_in_options_matches_active_locale(self):
+        content_type_en = taxonomies_factory.RCCContentTypeFactory()
+        content_type_fr = content_type_en.copy_for_translation(self.fr_locale)
+        content_type_fr.save()
+
+        # Activate the default locale
+        translation.activate(self.default_locale.language_code)
+
+        content_type_options_en = forms._get_content_type_options()
+        content_type_option_values_en = [i for i, _ in content_type_options_en]
+        self.assertEqual(len(content_type_option_values_en), 1)
+        self.assertIn(content_type_en.id, content_type_option_values_en)
+        self.assertNotIn(content_type_fr.id, content_type_option_values_en)
+
+        # Activate the French locale
+        translation.activate(self.fr_locale.language_code)
+
+        content_type_options_fr = forms._get_content_type_options()
+        content_type_option_values_fr = [i for i, _ in content_type_options_fr]
+        self.assertEqual(len(content_type_option_values_fr), 1)
+        self.assertNotIn(content_type_en.id, content_type_option_values_fr)
+        self.assertIn(content_type_fr.id, content_type_option_values_fr)
+
+    def test_curricular_area_in_options_matches_active_locale(self):
+        curricular_area_en = taxonomies_factory.RCCCurricularAreaFactory()
+        curricular_area_fr = curricular_area_en.copy_for_translation(self.fr_locale)
+        curricular_area_fr.save()
+
+        # Activate the default locale
+        translation.activate(self.default_locale.language_code)
+
+        curricular_area_options_en = forms._get_curricular_area_options()
+        curricular_area_option_values_en = [i for i, _ in curricular_area_options_en]
+        self.assertEqual(len(curricular_area_option_values_en), 1)
+        self.assertIn(curricular_area_en.id, curricular_area_option_values_en)
+        self.assertNotIn(curricular_area_fr.id, curricular_area_option_values_en)
+
+        # Activate the French locale
+        translation.activate(self.fr_locale.language_code)
+
+        curricular_area_options_fr = forms._get_curricular_area_options()
+        curricular_area_option_values_fr = [i for i, _ in curricular_area_options_fr]
+        self.assertEqual(len(curricular_area_option_values_fr), 1)
+        self.assertNotIn(curricular_area_en.id, curricular_area_option_values_fr)
+        self.assertIn(curricular_area_fr.id, curricular_area_option_values_fr)
+
+    def test_localized_topic_options(self):
+        """
+        Use active locales version of topic if available.
+
+        If no translation is available for a given topic, display the default locale
+        topic.
+
+        """
+        topic_1_en = taxonomies_factory.RCCTopicFactory()
+        topic_1_fr = topic_1_en.copy_for_translation(self.fr_locale)
+        topic_1_fr.save()
+        topic_2_en = taxonomies_factory.RCCTopicFactory()
+        translation.activate(self.fr_locale.language_code)
+
+        topic_options = forms._get_topic_options()
+        topic_option_values = [i for i, _ in topic_options]
+
+        self.assertEqual(len(topic_option_values), 2)
+        self.assertNotIn(topic_1_en.id, topic_option_values)
+        self.assertIn(topic_1_fr.id, topic_option_values)
+        self.assertIn(topic_2_en.id, topic_option_values)
+
+    def test_localized_content_type_options(self):
+        """
+        Use active locales version of content type if available.
+
+        If no translation is available for a given content type, display the default locale
+        content type.
+
+        """
+        content_type_1_en = taxonomies_factory.RCCContentTypeFactory()
+        content_type_1_fr = content_type_1_en.copy_for_translation(self.fr_locale)
+        content_type_1_fr.save()
+        content_type_2_en = taxonomies_factory.RCCContentTypeFactory()
+        translation.activate(self.fr_locale.language_code)
+
+        content_type_options = forms._get_content_type_options()
+        content_type_option_values = [i for i, _ in content_type_options]
+
+        self.assertEqual(len(content_type_option_values), 2)
+        self.assertNotIn(content_type_1_en.id, content_type_option_values)
+        self.assertIn(content_type_1_fr.id, content_type_option_values)
+        self.assertIn(content_type_2_en.id, content_type_option_values)
+
+    def test_localized_curricular_area_options(self):
+        """
+        Use active locales version of curricular area if available.
+
+        If no translation is available for a given curricular area, display the default locale
+        curricular area.
+
+        """
+        curricular_area_1_en = taxonomies_factory.RCCCurricularAreaFactory()
+        curricular_area_1_fr = curricular_area_1_en.copy_for_translation(self.fr_locale)
+        curricular_area_1_fr.save()
+        curricular_area_2_en = taxonomies_factory.RCCCurricularAreaFactory()
+        translation.activate(self.fr_locale.language_code)
+
+        curricular_area_options = forms._get_curricular_area_options()
+        curricular_area_option_values = [i for i, _ in curricular_area_options]
+
+        self.assertEqual(len(curricular_area_option_values), 2)
+        self.assertNotIn(curricular_area_1_en.id, curricular_area_option_values)
+        self.assertIn(curricular_area_1_fr.id, curricular_area_option_values)
+        self.assertIn(curricular_area_2_en.id, curricular_area_option_values)
+
+
+class RCCLibraryPageFilterFormTestCase(rcc_test_base.RCCTestCase):
+    def test_form_content_types(self):
+        """Test that the form content types field is populated with the correct choices."""
+        content_types = taxonomies_factory.RCCContentTypeFactory.create_batch(size=3)
+        form = RCCLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["content_types"].choices, [(ct.id, ct.name) for ct in content_types])
+
+    def test_form_curricular_areas(self):
+        """Test that the form curricular areas field is populated with the correct choices."""
+        curricular_areas = taxonomies_factory.RCCCurricularAreaFactory.create_batch(size=3)
+        form = RCCLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["curricular_areas"].choices, [(ca.id, ca.name) for ca in curricular_areas])
+
+    def test_form_topics(self):
+        """Test that the form topics field is populated with the correct choices."""
+        topics = taxonomies_factory.RCCTopicFactory.create_batch(size=3)
+        form = RCCLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["topics"].choices, [(t.id, t.name) for t in topics])
+
+    def test_form_contributors(self):
+        """Test that the form contributors field is populated with the correct choices."""
+        contributors = profiles_factory.ProfileFactory.create_batch(size=3)
+        detail_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            rcc_authors=[],
+        )
+
+        for contributor in contributors:
+            relations_factory.RCCAuthorRelationFactory(
+                rcc_detail_page=detail_page,
+                author_profile=contributor,
+            )
+
+        form = RCCLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["contributors"].choices, [(c.id, c.name) for c in contributors])

--- a/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_library_page.py
@@ -1,16 +1,22 @@
 import os
 
 from django.core import management, paginator
+from django.utils import translation
 
+from networkapi.wagtailpages.factory import profiles as profiles_factory
 from networkapi.wagtailpages.factory.libraries.rcc import (
     detail_page as detail_page_factory,
 )
+from networkapi.wagtailpages.factory.libraries.rcc import relations as relations_factory
+from networkapi.wagtailpages.factory.libraries.rcc import (
+    taxonomies as taxonomies_factory,
+)
 from networkapi.wagtailpages.pagemodels.libraries.rcc import constants
-from networkapi.wagtailpages.tests.libraries.rcc import base as research_test_base
-from networkapi.wagtailpages.tests.libraries.rcc import utils as research_test_utils
+from networkapi.wagtailpages.tests.libraries.rcc import base as rcc_test_base
+from networkapi.wagtailpages.tests.libraries.rcc import utils as rcc_test_utils
 
 
-class TestRCCLibraryPage(research_test_base.RCCTestCase):
+class TestRCCLibraryPage(rcc_test_base.RCCTestCase):
     def update_index(self):
         with open(os.devnull, "w") as f:
             management.call_command("update_index", verbosity=0, stdout=f)
@@ -23,11 +29,11 @@ class TestRCCLibraryPage(research_test_base.RCCTestCase):
             parent=self.library_page,
         )
 
-        research_detail_pages = self.library_page._get_rcc_detail_pages()
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages()
 
-        self.assertEqual(len(research_detail_pages), 2)
-        self.assertIn(detail_page_1, research_detail_pages)
-        self.assertIn(detail_page_2, research_detail_pages)
+        self.assertEqual(len(rcc_detail_pages), 2)
+        self.assertIn(detail_page_1, rcc_detail_pages)
+        self.assertIn(detail_page_2, rcc_detail_pages)
 
     def test_get_rcc_detail_pages_with_translation_aliases(self):
         detail_page_1 = detail_page_factory.RCCDetailPageFactory(
@@ -40,13 +46,13 @@ class TestRCCLibraryPage(research_test_base.RCCTestCase):
         fr_detail_page_1 = detail_page_1.get_translation(self.fr_locale)
         fr_detail_page_2 = detail_page_2.get_translation(self.fr_locale)
 
-        research_detail_pages = self.library_page._get_rcc_detail_pages()
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages()
 
-        self.assertEqual(len(research_detail_pages), 2)
-        self.assertIn(detail_page_1, research_detail_pages)
-        self.assertIn(detail_page_2, research_detail_pages)
-        self.assertNotIn(fr_detail_page_1, research_detail_pages)
-        self.assertNotIn(fr_detail_page_2, research_detail_pages)
+        self.assertEqual(len(rcc_detail_pages), 2)
+        self.assertIn(detail_page_1, rcc_detail_pages)
+        self.assertIn(detail_page_2, rcc_detail_pages)
+        self.assertNotIn(fr_detail_page_1, rcc_detail_pages)
+        self.assertNotIn(fr_detail_page_2, rcc_detail_pages)
 
     def test_private_detail_pages_are_hidden(self):
         public_detail_page = detail_page_factory.RCCDetailPageFactory(
@@ -57,41 +63,41 @@ class TestRCCLibraryPage(research_test_base.RCCTestCase):
         )
         self.make_page_private(private_detail_page)
 
-        research_detail_pages = self.library_page._get_rcc_detail_pages()
-        self.assertEqual(len(research_detail_pages), 1)
-        self.assertIn(public_detail_page, research_detail_pages)
-        self.assertNotIn(private_detail_page, research_detail_pages)
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages()
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(public_detail_page, rcc_detail_pages)
+        self.assertNotIn(private_detail_page, rcc_detail_pages)
 
     def test_sort_newest_first(self):
         oldest_page = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(2),
+            original_publication_date=rcc_test_utils.days_ago(2),
         )
         newest_page = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(1),
+            original_publication_date=rcc_test_utils.days_ago(1),
         )
 
-        research_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_NEWEST_FIRST))
+        rcc_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_NEWEST_FIRST))
 
-        newest_page_index = research_detail_pages.index(newest_page)
-        oldest_page_index = research_detail_pages.index(oldest_page)
+        newest_page_index = rcc_detail_pages.index(newest_page)
+        oldest_page_index = rcc_detail_pages.index(oldest_page)
         self.assertLess(newest_page_index, oldest_page_index)
 
     def test_sort_oldest_first(self):
         oldest_page = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(2),
+            original_publication_date=rcc_test_utils.days_ago(2),
         )
         newest_page = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(1),
+            original_publication_date=rcc_test_utils.days_ago(1),
         )
 
-        research_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_OLDEST_FIRST))
+        rcc_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_OLDEST_FIRST))
 
-        newest_page_index = research_detail_pages.index(newest_page)
-        oldest_page_index = research_detail_pages.index(oldest_page)
+        newest_page_index = rcc_detail_pages.index(newest_page)
+        oldest_page_index = rcc_detail_pages.index(oldest_page)
         self.assertLess(oldest_page_index, newest_page_index)
 
     def test_sort_alphabetical(self):
@@ -104,10 +110,10 @@ class TestRCCLibraryPage(research_test_base.RCCTestCase):
             title="Banana",
         )
 
-        research_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_ALPHABETICAL))
+        rcc_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_ALPHABETICAL))
 
-        apple_page_index = research_detail_pages.index(apple_page)
-        banana_page_index = research_detail_pages.index(banana_page)
+        apple_page_index = rcc_detail_pages.index(apple_page)
+        banana_page_index = rcc_detail_pages.index(banana_page)
         self.assertLess(apple_page_index, banana_page_index)
 
     def test_sort_alphabetical_reversed(self):
@@ -121,23 +127,21 @@ class TestRCCLibraryPage(research_test_base.RCCTestCase):
             title="Banana",
         )
 
-        research_detail_pages = list(
-            self.library_page._get_rcc_detail_pages(sort=constants.SORT_ALPHABETICAL_REVERSED)
-        )
+        rcc_detail_pages = list(self.library_page._get_rcc_detail_pages(sort=constants.SORT_ALPHABETICAL_REVERSED))
 
-        apple_page_index = research_detail_pages.index(apple_page)
-        banana_page_index = research_detail_pages.index(banana_page)
+        apple_page_index = rcc_detail_pages.index(apple_page)
+        banana_page_index = rcc_detail_pages.index(banana_page)
         self.assertLess(banana_page_index, apple_page_index)
 
     def test_get_rcc_detail_pages_sort_default(self):
 
         detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(2),
+            original_publication_date=rcc_test_utils.days_ago(2),
         )
         detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(1),
+            original_publication_date=rcc_test_utils.days_ago(1),
         )
 
         default_sort_detail_pages = list(self.library_page._get_rcc_detail_pages())
@@ -151,16 +155,574 @@ class TestRCCLibraryPage(research_test_base.RCCTestCase):
         for _ in range(6):
             detail_page_factory.RCCDetailPageFactory(parent=self.library_page)
 
-        research_detail_pages = self.library_page._get_rcc_detail_pages()
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages()
 
-        research_detail_pages_paginator = paginator.Paginator(
-            object_list=research_detail_pages,
+        rcc_detail_pages_paginator = paginator.Paginator(
+            object_list=rcc_detail_pages,
             per_page=self.library_page.results_count,
             allow_empty_first_page=True,
         )
 
-        first_page_response = research_detail_pages_paginator.get_page(1)
-        second_page_response = research_detail_pages_paginator.get_page(2)
+        first_page_response = rcc_detail_pages_paginator.get_page(1)
+        second_page_response = rcc_detail_pages_paginator.get_page(2)
 
         self.assertEqual(len(first_page_response), 4)
         self.assertEqual(len(second_page_response), 2)
+
+
+class TestRCCLibraryPageSearch(TestRCCLibraryPage):
+    def test_search_by_detail_page_title(self):
+        # Fields other than title are empty to avoid accidental test failures due to
+        # fake data generation.
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Apple",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Banana",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_introduction(self):
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="Apple",
+            overview="",
+            contributors="",
+        )
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="Banana",
+            overview="",
+            contributors="",
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_overview(self):
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="",
+            overview="Apple",
+            contributors="",
+        )
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="",
+            overview="Banana",
+            contributors="",
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_contributors(self):
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="",
+            overview="",
+            contributors="Apple",
+        )
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="",
+            overview="",
+            contributors="Banana",
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_author_name(self):
+        """Test detail page can be searched by author profile name."""
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        apple_profile = profiles_factory.ProfileFactory(
+            name="Apple",
+            tagline="",
+            introduction="",
+        )
+        relations_factory.RCCAuthorRelationFactory(rcc_detail_page=apple_page, author_profile=apple_profile)
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        banana_profile = profiles_factory.ProfileFactory(
+            name="Banana",
+            tagline="",
+            introduction="",
+        )
+        relations_factory.RCCAuthorRelationFactory(rcc_detail_page=banana_page, author_profile=banana_profile)
+        self.update_index()
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_content_type_name(self):
+        """Test detail page can be searched by content type taxonomy name."""
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        apple_content_type = taxonomies_factory.RCCContentTypeFactory(
+            name="Apple",
+        )
+        relations_factory.RCCDetailPageRCCContentTypeRelationFactory(
+            rcc_detail_page=apple_page, content_type=apple_content_type
+        )
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        banana_content_type = taxonomies_factory.RCCContentTypeFactory(
+            name="banana",
+        )
+        relations_factory.RCCDetailPageRCCContentTypeRelationFactory(
+            rcc_detail_page=banana_page, content_type=banana_content_type
+        )
+        self.update_index()
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_curricular_area_name(self):
+        """Test detail page can be searched by curricular_area taxonomy name."""
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        apple_curricular_area = taxonomies_factory.RCCCurricularAreaFactory(
+            name="Apple",
+        )
+        relations_factory.RCCDetailPageRCCCurricularAreaRelationFactory(
+            rcc_detail_page=apple_page, curricular_area=apple_curricular_area
+        )
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        banana_curricular_area = taxonomies_factory.RCCCurricularAreaFactory(
+            name="banana",
+        )
+        relations_factory.RCCDetailPageRCCCurricularAreaRelationFactory(
+            rcc_detail_page=banana_page, curricular_area=banana_curricular_area
+        )
+        self.update_index()
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+    def test_search_by_detail_page_topic_name(self):
+        """Test detail page can be searched by topic name."""
+        apple_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        apple_topic = taxonomies_factory.RCCTopicFactory(
+            name="Apple",
+        )
+        relations_factory.RCCDetailPageRCCTopicRelationFactory(rcc_detail_page=apple_page, rcc_topic=apple_topic)
+        banana_page = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            title="Also cherry",
+            introduction="",
+            overview="",
+            contributors="",
+        )
+        banana_topic = taxonomies_factory.RCCTopicFactory(
+            name="banana",
+        )
+        relations_factory.RCCDetailPageRCCTopicRelationFactory(rcc_detail_page=banana_page, rcc_topic=banana_topic)
+        self.update_index()
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(search="Apple")
+
+        self.assertEqual(len(rcc_detail_pages), 1)
+        self.assertIn(apple_page, rcc_detail_pages)
+        self.assertNotIn(banana_page, rcc_detail_pages)
+
+
+class TestRCCLibraryPageFilters(TestRCCLibraryPage):
+    def test_filter_author_profile(self):
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+        author_profile = detail_page_1.rcc_authors.first().author_profile
+        self.assertNotEqual(
+            author_profile,
+            detail_page_2.rcc_authors.first().author_profile,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(author_profile_ids=[author_profile.id])
+
+        self.assertIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_multiple_author_profiles(self):
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+        profile_a = detail_page_1.rcc_authors.first().author_profile
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+        )
+        profile_b = detail_page_2.rcc_authors.first().author_profile
+        # Make author of first page also an author of the second page
+        relations_factory.RCCAuthorRelationFactory(
+            rcc_detail_page=detail_page_2,
+            author_profile=profile_a,
+        )
+
+        response = self.client.get(
+            self.library_page.url,
+            data={"contributors": [profile_a.id, profile_b.id]},
+        )
+
+        # Only show the page where both profiles are authors
+        rcc_detail_pages = response.context["rcc_detail_pages"]
+        self.assertNotIn(detail_page_1, rcc_detail_pages)
+        self.assertIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_localized_author_profile(self):
+        """
+        When filtering for a localized author profile, we also want to show pages
+        associated with the default locale's profile. This is because after tree sync,
+        pages are copied to the different locales, but related models are still the ones
+        from the default locale.
+
+        This test is setting up an aliased page and a translated page. The aliased page
+        is not associated with the translated profile, but we still want to see it in
+        the results.
+        """
+        profile = profiles_factory.ProfileFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            rcc_authors__author_profile=profile,
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            rcc_authors__author_profile=profile,
+        )
+        self.synchronize_tree()
+        detail_page_1_fr = detail_page_1.get_translation(self.fr_locale)
+        self.assertEqual(profile, detail_page_1_fr.rcc_authors.first().author_profile)
+        detail_page_2_fr = rcc_test_utils.translate_detail_page(detail_page_2, self.fr_locale)
+        profile_fr = detail_page_2_fr.rcc_authors.first().author_profile
+        self.assertNotEqual(profile, profile_fr)
+        self.assertEqual(profile.translation_key, profile_fr.translation_key)
+        translation.activate(self.fr_locale.language_code)
+
+        rcc_detail_pages = self.library_page.localized._get_rcc_detail_pages(author_profile_ids=[profile_fr.id])
+
+        self.assertIn(detail_page_1_fr, rcc_detail_pages)
+        self.assertIn(detail_page_2_fr, rcc_detail_pages)
+        self.assertNotIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_content_type(self):
+        content_type_A = taxonomies_factory.RCCContentTypeFactory()
+        detail_page_A = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_content_types__content_type=content_type_A,
+        )
+        content_type_B = taxonomies_factory.RCCContentTypeFactory()
+        detail_page_B = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_content_types__content_type=content_type_B,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(content_type_ids=[content_type_A.id])
+
+        self.assertIn(detail_page_A, rcc_detail_pages)
+        self.assertNotIn(detail_page_B, rcc_detail_pages)
+
+    def test_filter_curricular_area(self):
+        curricular_area_A = taxonomies_factory.RCCCurricularAreaFactory()
+        detail_page_A = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_curricular_areas__curricular_area=curricular_area_A,
+        )
+        curricular_area_B = taxonomies_factory.RCCCurricularAreaFactory()
+        detail_page_B = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_curricular_areas__curricular_area=curricular_area_B,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(curricular_area_ids=[curricular_area_A.id])
+
+        self.assertIn(detail_page_A, rcc_detail_pages)
+        self.assertNotIn(detail_page_B, rcc_detail_pages)
+
+    def test_filter_topic(self):
+        topic_A = taxonomies_factory.RCCTopicFactory()
+        detail_page_A = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_topics__rcc_topic=topic_A,
+        )
+        topic_B = taxonomies_factory.RCCTopicFactory()
+        detail_page_B = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_topics__rcc_topic=topic_B,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(topic_ids=[topic_A.id])
+
+        self.assertIn(detail_page_A, rcc_detail_pages)
+        self.assertNotIn(detail_page_B, rcc_detail_pages)
+
+    def test_filter_multiple_content_types(self):
+        content_type_A = taxonomies_factory.RCCContentTypeFactory()
+        content_type_B = taxonomies_factory.RCCContentTypeFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_content_types__content_type=content_type_A,
+        )
+        relations_factory.RCCDetailPageRCCContentTypeRelationFactory(
+            rcc_detail_page=detail_page_1, content_type=content_type_B
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_content_types__content_type=content_type_A,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(
+            content_type_ids=[content_type_A.id, content_type_B.id]
+        )
+
+        self.assertIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_multiple_curricular_areas(self):
+        curricular_area_A = taxonomies_factory.RCCCurricularAreaFactory()
+        curricular_area_B = taxonomies_factory.RCCCurricularAreaFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_curricular_areas__curricular_area=curricular_area_A,
+        )
+        relations_factory.RCCDetailPageRCCCurricularAreaRelationFactory(
+            rcc_detail_page=detail_page_1, curricular_area=curricular_area_B
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_curricular_areas__curricular_area=curricular_area_A,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(
+            curricular_area_ids=[curricular_area_A.id, curricular_area_B.id]
+        )
+
+        self.assertIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_multiple_topics(self):
+        topic_A = taxonomies_factory.RCCTopicFactory()
+        topic_B = taxonomies_factory.RCCTopicFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_topics__rcc_topic=topic_A,
+        )
+        relations_factory.RCCDetailPageRCCTopicRelationFactory(rcc_detail_page=detail_page_1, rcc_topic=topic_B)
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_topics__rcc_topic=topic_A,
+        )
+
+        rcc_detail_pages = self.library_page._get_rcc_detail_pages(topic_ids=[topic_A.id, topic_B.id])
+
+        self.assertIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_localized_content_type(self):
+        """
+        When filtering for a localized content type, we also want to show pages
+        associated with the default locale's content type. This is because after tree sync,
+        pages are copied to the different locales, but related models are still the ones
+        from the default locale.
+
+        This test is setting up an aliased page and a translated page. The aliased page
+        is not associated with the translated content type, but we still want to see it in
+        the results.
+        """
+        content_type = taxonomies_factory.RCCContentTypeFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_content_types__content_type=content_type,
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_content_types__content_type=content_type,
+        )
+        self.synchronize_tree()
+
+        # Translate the first page, but not the content type
+        detail_page_1_fr = detail_page_1.get_translation(self.fr_locale)
+        # The translated page should have the same content type as the default page
+        self.assertEqual(content_type, detail_page_1_fr.related_content_types.first().content_type)
+
+        # Translate the second page and the content type
+        detail_page_2_fr = rcc_test_utils.translate_detail_page(detail_page_2, self.fr_locale)
+        content_type_fr = detail_page_2_fr.related_content_types.first().content_type
+        self.assertNotEqual(content_type, content_type_fr)
+        self.assertEqual(content_type.translation_key, content_type_fr.translation_key)
+
+        # Switch to the French locale
+        translation.activate(self.fr_locale.language_code)
+
+        # Filter for the translated content type
+        rcc_detail_pages = self.library_page.localized._get_rcc_detail_pages(content_type_ids=[content_type_fr.id])
+
+        # We should see both pages, even though the first one is not associated with the
+        # translated content type
+        self.assertEqual(len(rcc_detail_pages), 2)
+        self.assertIn(detail_page_1_fr, rcc_detail_pages)
+        self.assertIn(detail_page_2_fr, rcc_detail_pages)
+        self.assertNotIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_localized_curricular_area(self):
+        """
+        When filtering for a localized curricular area, we also want to show pages
+        associated with the default locale's curricular area. This is because after tree sync,
+        pages are copied to the different locales, but related models are still the ones
+        from the default locale.
+
+        This test is setting up an aliased page and a translated page. The aliased page
+        is not associated with the translated curricular area, but we still want to see it in
+        the results.
+        """
+        curricular_area = taxonomies_factory.RCCCurricularAreaFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_curricular_areas__curricular_area=curricular_area,
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_curricular_areas__curricular_area=curricular_area,
+        )
+        self.synchronize_tree()
+
+        # Translate the first page, but not the curricular area
+        detail_page_1_fr = detail_page_1.get_translation(self.fr_locale)
+        # The translated page should have the same curricular area as the default page
+        self.assertEqual(curricular_area, detail_page_1_fr.related_curricular_areas.first().curricular_area)
+
+        # Translate the second page and the curricular area
+        detail_page_2_fr = rcc_test_utils.translate_detail_page(detail_page_2, self.fr_locale)
+        curricular_area_fr = detail_page_2_fr.related_curricular_areas.first().curricular_area
+        self.assertNotEqual(curricular_area, curricular_area_fr)
+        self.assertEqual(curricular_area.translation_key, curricular_area_fr.translation_key)
+
+        # Switch to the French locale
+        translation.activate(self.fr_locale.language_code)
+
+        # Filter for the translated curricular area
+        rcc_detail_pages = self.library_page.localized._get_rcc_detail_pages(
+            curricular_area_ids=[curricular_area_fr.id]
+        )
+
+        # We should see both pages, even though the first one is not associated with the
+        # translated curricular area
+        self.assertEqual(len(rcc_detail_pages), 2)
+        self.assertIn(detail_page_1_fr, rcc_detail_pages)
+        self.assertIn(detail_page_2_fr, rcc_detail_pages)
+        self.assertNotIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)
+
+    def test_filter_localized_topic(self):
+        """
+        When filtering for a localized topic, we also want to show pages
+        associated with the default locale's topic. This is because after tree sync,
+        pages are copied to the different locales, but related models are still the ones
+        from the default locale.
+
+        This test is setting up an aliased page and a translated page. The aliased page
+        is not associated with the translated topic, but we still want to see it in
+        the results.
+        """
+        topic = taxonomies_factory.RCCTopicFactory()
+        detail_page_1 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_topics__rcc_topic=topic,
+        )
+        detail_page_2 = detail_page_factory.RCCDetailPageFactory(
+            parent=self.library_page,
+            related_topics__rcc_topic=topic,
+        )
+        self.synchronize_tree()
+        detail_page_1_fr = detail_page_1.get_translation(self.fr_locale)
+        self.assertEqual(topic, detail_page_1_fr.related_topics.first().rcc_topic)
+        detail_page_2_fr = rcc_test_utils.translate_detail_page(detail_page_2, self.fr_locale)
+        topic_fr = detail_page_2_fr.related_topics.first().rcc_topic
+        self.assertNotEqual(topic, topic_fr)
+        self.assertEqual(topic.translation_key, topic_fr.translation_key)
+        translation.activate(self.fr_locale.language_code)
+
+        rcc_detail_pages = self.library_page.localized._get_rcc_detail_pages(topic_ids=[topic_fr.id])
+
+        self.assertEqual(len(rcc_detail_pages), 2)
+        self.assertIn(detail_page_1_fr, rcc_detail_pages)
+        self.assertIn(detail_page_2_fr, rcc_detail_pages)
+        self.assertNotIn(detail_page_1, rcc_detail_pages)
+        self.assertNotIn(detail_page_2, rcc_detail_pages)

--- a/network-api/networkapi/wagtailpages/tests/libraries/rcc/utils.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/rcc/utils.py
@@ -40,7 +40,7 @@ def translate_detail_page(detail_page, locale):
         curricular_area_orig = related_curricular_area_trans.curricular_area
         curricular_area_trans = curricular_area_orig.copy_for_translation(locale)
         curricular_area_trans.save()
-        related_curricular_area_trans.content_type = curricular_area_trans
+        related_curricular_area_trans.curricular_area = curricular_area_trans
         related_curricular_area_trans.save()
 
     for related_topic_trans in trans_detail_page.related_topics.all():

--- a/network-api/networkapi/wagtailpages/tests/libraries/research_hub/test_forms.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/research_hub/test_forms.py
@@ -1,7 +1,5 @@
 import datetime
-import os
 
-from django.core import management
 from django.utils import timezone, translation
 
 from networkapi.wagtailpages.factory import profiles as profiles_factory
@@ -27,10 +25,6 @@ from networkapi.wagtailpages.tests.libraries.research_hub import (
 
 
 class TestFormUtilitiesFunctions(research_test_base.ResearchHubTestCase):
-    def update_index(self):
-        with open(os.devnull, "w") as f:
-            management.call_command("update_index", verbosity=0, stdout=f)
-
     def test_research_author_profile_obtained_by_get_author_options(self):
         detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,

--- a/network-api/networkapi/wagtailpages/tests/libraries/research_hub/test_forms.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/research_hub/test_forms.py
@@ -9,9 +9,15 @@ from networkapi.wagtailpages.factory.libraries.research_hub import (
     detail_page as detail_page_factory,
 )
 from networkapi.wagtailpages.factory.libraries.research_hub import (
+    relations as relations_factory,
+)
+from networkapi.wagtailpages.factory.libraries.research_hub import (
     taxonomies as taxonomies_factory,
 )
 from networkapi.wagtailpages.pagemodels.libraries.research_hub import forms
+from networkapi.wagtailpages.pagemodels.libraries.research_hub.forms import (
+    ResearchLibraryPageFilterForm,
+)
 from networkapi.wagtailpages.tests.libraries.research_hub import (
     base as research_test_base,
 )
@@ -206,3 +212,49 @@ class TestFormUtilitiesFunctions(research_test_base.ResearchHubTestCase):
         self.assertEqual(len(year_option_values), 3)
         self.assertIn(year_1, year_option_values)
         self.assertIn(year_2, year_option_values)
+
+
+class ResearchLibraryPageFilterFormTestCase(research_test_base.ResearchHubTestCase):
+    def test_form_topics(self):
+        """Test that the form topics field is populated with the correct choices."""
+        topics = taxonomies_factory.ResearchTopicFactory.create_batch(size=3)
+        form = ResearchLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["topic"].choices, [(t.id, t.name) for t in topics])
+
+    def test_form_years(self):
+        """Test that the form years field is populated with the correct choices."""
+        years = [timezone.now().year, timezone.now().year - 1]
+        detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=datetime.date(year=years[0], month=1, day=1),
+        )
+        detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=datetime.date(year=years[1], month=1, day=1),
+        )
+
+        form = ResearchLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["year"].choices, [("", "Any")] + [(y, y) for y in years])
+
+    def test_form_regions(self):
+        """Test that the form regions field is populated with the correct choices."""
+        regions = taxonomies_factory.ResearchRegionFactory.create_batch(size=3)
+        form = ResearchLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["region"].choices, [(r.id, r.name) for r in regions])
+
+    def test_form_authors(self):
+        """Test that the form authors field is populated with the correct choices."""
+        authors = profiles_factory.ProfileFactory.create_batch(size=3)
+        detail_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            research_authors=[],
+        )
+
+        for author in authors:
+            relations_factory.ResearchAuthorRelationFactory(
+                research_detail_page=detail_page,
+                author_profile=author,
+            )
+
+        form = ResearchLibraryPageFilterForm()
+        self.assertCountEqual(form.fields["author"].choices, [(a.id, a.name) for a in authors])

--- a/network-api/networkapi/wagtailpages/tests/libraries/research_hub/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/research_hub/test_library_page.py
@@ -75,6 +75,113 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(public_detail_page, research_detail_pages)
         self.assertNotIn(private_detail_page, research_detail_pages)
 
+    def test_sort_newest_first(self):
+        oldest_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=research_test_utils.days_ago(2),
+        )
+        newest_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=research_test_utils.days_ago(1),
+        )
+
+        research_detail_pages = list(self.library_page._get_research_detail_pages(sort=constants.SORT_NEWEST_FIRST))
+
+        newest_page_index = research_detail_pages.index(newest_page)
+        oldest_page_index = research_detail_pages.index(oldest_page)
+        self.assertLess(newest_page_index, oldest_page_index)
+
+    def test_sort_oldest_first(self):
+        oldest_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=research_test_utils.days_ago(2),
+        )
+        newest_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=research_test_utils.days_ago(1),
+        )
+
+        research_detail_pages = list(self.library_page._get_research_detail_pages(sort=constants.SORT_OLDEST_FIRST))
+
+        newest_page_index = research_detail_pages.index(newest_page)
+        oldest_page_index = research_detail_pages.index(oldest_page)
+        self.assertLess(oldest_page_index, newest_page_index)
+
+    def test_sort_alphabetical(self):
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            title="Apple",
+        )
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            title="Banana",
+        )
+
+        research_detail_pages = list(self.library_page._get_research_detail_pages(sort=constants.SORT_ALPHABETICAL))
+
+        apple_page_index = research_detail_pages.index(apple_page)
+        banana_page_index = research_detail_pages.index(banana_page)
+        self.assertLess(apple_page_index, banana_page_index)
+
+    def test_sort_alphabetical_reversed(self):
+
+        apple_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            title="Apple",
+        )
+        banana_page = detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            title="Banana",
+        )
+
+        research_detail_pages = list(
+            self.library_page._get_research_detail_pages(sort=constants.SORT_ALPHABETICAL_REVERSED)
+        )
+
+        apple_page_index = research_detail_pages.index(apple_page)
+        banana_page_index = research_detail_pages.index(banana_page)
+        self.assertLess(banana_page_index, apple_page_index)
+
+    def test_get_research_detail_pages_sort_default(self):
+
+        detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=research_test_utils.days_ago(2),
+        )
+        detail_page_factory.ResearchDetailPageFactory(
+            parent=self.library_page,
+            original_publication_date=research_test_utils.days_ago(1),
+        )
+
+        default_sort_detail_pages = list(self.library_page._get_research_detail_pages())
+        newest_first_detail_pages = list(
+            self.library_page._get_research_detail_pages(sort=constants.SORT_NEWEST_FIRST)
+        )
+
+        self.assertEqual(default_sort_detail_pages, newest_first_detail_pages)
+
+    def test_pagination(self):
+        self.library_page.results_count = 4
+        self.library_page.save()
+        for _ in range(6):
+            detail_page_factory.ResearchDetailPageFactory(parent=self.library_page)
+
+        research_detail_pages = self.library_page._get_research_detail_pages()
+
+        research_detail_pages_paginator = paginator.Paginator(
+            object_list=research_detail_pages,
+            per_page=self.library_page.results_count,
+            allow_empty_first_page=True,
+        )
+
+        first_page_response = research_detail_pages_paginator.get_page(1)
+        second_page_response = research_detail_pages_paginator.get_page(2)
+
+        self.assertEqual(len(first_page_response), 4)
+        self.assertEqual(len(second_page_response), 2)
+
+
+class TestResearchLibraryPageSearch(TestResearchLibraryPage):
     def test_search_by_detail_page_title(self):
         # Fields other than title are empty to avoid accidental test failures due to
         # fake data generation.
@@ -272,91 +379,8 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
         self.assertIn(apple_page, research_detail_pages)
         self.assertNotIn(banana_page, research_detail_pages)
 
-    def test_sort_newest_first(self):
-        oldest_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(2),
-        )
-        newest_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(1),
-        )
 
-        research_detail_pages = list(self.library_page._get_research_detail_pages(sort=constants.SORT_NEWEST_FIRST))
-
-        newest_page_index = research_detail_pages.index(newest_page)
-        oldest_page_index = research_detail_pages.index(oldest_page)
-        self.assertLess(newest_page_index, oldest_page_index)
-
-    def test_sort_oldest_first(self):
-        oldest_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(2),
-        )
-        newest_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(1),
-        )
-
-        research_detail_pages = list(self.library_page._get_research_detail_pages(sort=constants.SORT_OLDEST_FIRST))
-
-        newest_page_index = research_detail_pages.index(newest_page)
-        oldest_page_index = research_detail_pages.index(oldest_page)
-        self.assertLess(oldest_page_index, newest_page_index)
-
-    def test_sort_alphabetical(self):
-        apple_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            title="Apple",
-        )
-        banana_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            title="Banana",
-        )
-
-        research_detail_pages = list(self.library_page._get_research_detail_pages(sort=constants.SORT_ALPHABETICAL))
-
-        apple_page_index = research_detail_pages.index(apple_page)
-        banana_page_index = research_detail_pages.index(banana_page)
-        self.assertLess(apple_page_index, banana_page_index)
-
-    def test_sort_alphabetical_reversed(self):
-
-        apple_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            title="Apple",
-        )
-        banana_page = detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            title="Banana",
-        )
-
-        research_detail_pages = list(
-            self.library_page._get_research_detail_pages(sort=constants.SORT_ALPHABETICAL_REVERSED)
-        )
-
-        apple_page_index = research_detail_pages.index(apple_page)
-        banana_page_index = research_detail_pages.index(banana_page)
-        self.assertLess(banana_page_index, apple_page_index)
-
-    def test_get_research_detail_pages_sort_default(self):
-
-        detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(2),
-        )
-        detail_page_factory.ResearchDetailPageFactory(
-            parent=self.library_page,
-            original_publication_date=research_test_utils.days_ago(1),
-        )
-
-        default_sort_detail_pages = list(self.library_page._get_research_detail_pages())
-        newest_first_detail_pages = list(
-            self.library_page._get_research_detail_pages(sort=constants.SORT_NEWEST_FIRST)
-        )
-
-        self.assertEqual(default_sort_detail_pages, newest_first_detail_pages)
-
+class TestResearchLibraryPageFilters(TestResearchLibraryPage):
     def test_filter_author_profile(self):
         detail_page_1 = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
@@ -600,23 +624,3 @@ class TestResearchLibraryPage(research_test_base.ResearchHubTestCase):
 
         self.assertIn(detail_page_1, research_detail_pages)
         self.assertNotIn(detail_page_2, research_detail_pages)
-
-    def test_pagination(self):
-        self.library_page.results_count = 4
-        self.library_page.save()
-        for _ in range(6):
-            detail_page_factory.ResearchDetailPageFactory(parent=self.library_page)
-
-        research_detail_pages = self.library_page._get_research_detail_pages()
-
-        research_detail_pages_paginator = paginator.Paginator(
-            object_list=research_detail_pages,
-            per_page=self.library_page.results_count,
-            allow_empty_first_page=True,
-        )
-
-        first_page_response = research_detail_pages_paginator.get_page(1)
-        second_page_response = research_detail_pages_paginator.get_page(2)
-
-        self.assertEqual(len(first_page_response), 4)
-        self.assertEqual(len(second_page_response), 2)


### PR DESCRIPTION
# Description

Add ability to filter RCC library page by content type, curricular area, contributors (authors) and topics. Re-enable search and sorting.

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues:

#10427 
#10441 
#10428 
#10429 


# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~
