### PR TITLE
Revert "Commented out a FormAssembly test that's failing until Mavis gets back"

### DIFF
--- a/tests/integration/petition/001-petition-form.spec.js
+++ b/tests/integration/petition/001-petition-form.spec.js
@@ -144,9 +144,6 @@ test.describe("FormAssembly petition form", () => {
       expect(page.url()).toContain(utility.THANK_YOU_PAGE_QUERY);
     });
 
-    // Commenting this out for now, signing up with the same email breaks this test.
-
-    /*
     test(`(${locale}) Signing petition using the same email`, async ({
       page,
     }) => {
@@ -155,6 +152,5 @@ test.describe("FormAssembly petition form", () => {
       // This means signing the petition using the same email address should still send users to the thank you page
       expect(page.url()).toContain(utility.THANK_YOU_PAGE_QUERY);
     });
-    */
   }
 });


### PR DESCRIPTION
Reverts MozillaFoundation/foundation.mozilla.org#10698

I ran all tests locally and on a different PR, all of them passed. I think the error @jhonatan-lopes was seeing was most likely due to intermittent slow response from FA. I believe we can safely revert the code changes from the previous PR.