### PR TITLE
Display number of results in RCC library page

### DIFF
--- a/network-api/networkapi/templates/fragments/libraries/author_card.html
+++ b/network-api/networkapi/templates/fragments/libraries/author_card.html
@@ -8,7 +8,7 @@
             {% if author_profile.image %}
                 {% image author_profile.image fill-182x182 class=profile_image_classes alt=author_profile.name %}
             {% else %}
-                <img src="{% static '_images/author-placeholder.jpg' %}" alt="{{ author_profile.name }}" class="{{ profile_image_classes }}">
+                <img src="{% static '_images/author-placeholder.jpg' %}" width="100" height="100" alt="{{ author_profile.name }}" class="{{ profile_image_classes }}">
             {% endif %}
         {% endwith %}
     </div>

--- a/network-api/networkapi/templates/pages/libraries/rcc/library_page.html
+++ b/network-api/networkapi/templates/pages/libraries/rcc/library_page.html
@@ -56,7 +56,7 @@
                 </div>
                 <div class="tw-h4-heading tw-mb-0">
                     {# RESULTS COUNT #}
-                    {% comment %} {% if search_query %}
+                    {% if search_query %}
                         {% blocktranslate count counter=rcc_detail_pages_count trimmed %}
                             <strong>{{ rcc_detail_pages_count }}</strong> result for <q>{{ search_query }}</q>
                         {% plural %}
@@ -68,7 +68,7 @@
                         {% plural %}
                             <strong>{{ rcc_detail_pages_count }}</strong> results
                         {% endblocktranslate %}
-                    {% endif %} {% endcomment %}
+                    {% endif %}
                 </div>
             </div>
             <ul class="tw-list-none tw-mt-16 large:tw-mt-12 tw-mb-12 tw-px-0 tw-border-t tw-border-b tw-border-gray-20 tw-divide-y tw-divide-gray-05">


### PR DESCRIPTION
# Description

Modify RCC library page template to display the number of results in the page.

To test it, go to `en/responsible-computing-challenge-playbook/curriculum-library` and check the results. You should see a text with **X results**:

![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/c67f7d57-5207-4185-b9e6-bd1720aeab7d)


Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
