### PR TITLE
Update latest articles label on RCC landing page

### DIFF
--- a/network-api/networkapi/templates/pages/libraries/rcc/landing_page.html
+++ b/network-api/networkapi/templates/pages/libraries/rcc/landing_page.html
@@ -36,7 +36,7 @@
                 </div>
 
                 <div id="featured-articles" class="tw-pt-6 large:tw-pt-12">
-                    <h2 class="tw-h3-heading large:tw-pb-4">{% trans "Featured Articles" %}</h2>
+                    <h2 class="tw-h3-heading large:tw-pb-4">{% trans "Latest" %}</h2>
                     <ul class="tw-list-none px-0 ">
                         {% for rcc_detail_page in latest_rcc_detail_pages %}
                             <li class="tw-py-8 small:tw-my-8 small:tw-bg-gray-05 small:tw-p-16">


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

RCC Landing Page should have a section that reads **"Latest"**. This was erroneously coded as **"Featured Articles"**.

Link to sample test page:
Related PRs/issues: #10431 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
