### PR TITLE
Fix URL to link RCC author detail page to pre-filtered library page

### DIFF
--- a/network-api/networkapi/templates/pages/libraries/rcc/author_detail_page.html
+++ b/network-api/networkapi/templates/pages/libraries/rcc/author_detail_page.html
@@ -61,7 +61,7 @@
                 {% endfor %}
             </ul>
             {% if author_article_count > 3 %}
-                <a href="{% pageurl library_page %}?author={{ author_profile.id|unlocalize }}" class="tw-btn-secondary tw-mt-12 small:tw-mt-16 tw-w-full small:tw-w-auto">{% translate "Browse all projects" context "Button to see more than the latest three RCC articles from an author" %} ({{ author_article_count }})</a>
+                <a href="{% pageurl library_page %}?contributors={{ author_profile.id|unlocalize }}" class="tw-btn-secondary tw-mt-12 small:tw-mt-16 tw-w-full small:tw-w-auto">{% translate "Browse all projects" context "Button to see more than the latest three RCC articles from an author" %} ({{ author_article_count }})</a>
             {% endif %}
         </div>
     </div>

--- a/network-api/networkapi/wagtailpages/factory/libraries/rcc/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/libraries/rcc/__init__.py
@@ -53,7 +53,7 @@ def generate(seed):
             related_topics=None,
         )
 
-        for profile in faker_helpers.get_random_objects(source=wagtailpage_models.Profile, max_count=3):
+        for profile in faker_helpers.get_random_objects(source=wagtailpage_models.Profile, max_count=6):
             relations_factory.RCCAuthorRelationFactory.create(
                 rcc_detail_page=rcc_detail_page,
                 author_profile=profile,


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Fix URL to link RCC author detail page to pre-filtered library page.

Link to sample test page:
Related PRs/issues: #10437 

# Testing

Run `inv new-db` to create the data. Go to `en/responsible-computing-challenge-playbook/browse-authors` and find an author that is associated with more than 3 articles (or edit the CMS to get this).

On the *Latest articles* section, you should see 3 articles and a CTA with *Browse all projects (N)*, where `N` is the number of articles for that author:

![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/aa9583a4-7180-426a-8513-428a99e951bc)

Clicking on *Browse all projects* should send you to the library page pre-filtered by the author's name.

![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/40945ad7-8f33-44e1-b36f-505ee7da2151)



# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
