### PR TITLE
Removed reference to old redirect static file

### DIFF
--- a/network-api/networkapi/wagtailcustomization/templates/wagtailredirects/index.html
+++ b/network-api/networkapi/wagtailcustomization/templates/wagtailredirects/index.html
@@ -18,12 +18,10 @@ This is a customized version of https://github.com/wagtail/wagtail/blob/v2.11.3/
 {% endblock %}
 
 {% block content %}
-    <link rel="stylesheet" type="text/css" href="{% static 'wagtailredirects/css/index.css' %}">
 
     {% trans "Redirects" as redirects_str %}
     {% if user_can_add %}
         {% url "wagtailredirects:add" as add_link %}
-        
         {% trans "Add redirect" as add_str %}
         {% url "wagtailredirects:start_import" as import_link %}
         {% trans "Import redirects" as import_str %}

--- a/network-api/networkapi/wagtailcustomization/templates/wagtailredirects/index.html
+++ b/network-api/networkapi/wagtailcustomization/templates/wagtailredirects/index.html
@@ -23,6 +23,7 @@ This is a customized version of https://github.com/wagtail/wagtail/blob/v2.11.3/
     {% trans "Redirects" as redirects_str %}
     {% if user_can_add %}
         {% url "wagtailredirects:add" as add_link %}
+        
         {% trans "Add redirect" as add_str %}
         {% url "wagtailredirects:start_import" as import_link %}
         {% trans "Import redirects" as import_str %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: https://foundation-s-redirect-p-g4zvyb.herokuapp.com/cms/redirects/
Review app admin credentials: Admin2/Admin2


This PR removes a reference to an old static file related to the wagtail redirect page that no longer exists as it is no longer needed.

The reference to a non-existent file produced a 500 error whenever trying to visit the redirect page in the CMS on either prod or staging.


## Steps to test:

1. Visit the review app link above, with the credentials "Admin2/Admin2".
2. The page should render as expected.
3. If everything seems to be working as it should, testing is complete! 