### PR TITLE
Make FormAssembly petition form the default

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta.html
@@ -1,7 +1,7 @@
 {{ cta.type }}
 
 {% if cta_type == 'petition' %}
-    {% include './cta/petition.html' with source_url=source_url lang=lang show_formassembly=show_formassembly %}
+    {% include './cta/petition.html' with source_url=source_url lang=lang %}
 {% endif %}
 
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/petition.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/petition.html
@@ -17,8 +17,7 @@
         <div id="share-progress-em" class='{{ cta.share_email }} sp_em_small tw-hidden'></div>
     {% endif %}
 
-    {% comment %} The condition to show FormAssembly form {% endcomment %}
-    {% if show_formassembly and not show_formassembly_thank_you %}
+    {% if not show_formassembly_thank_you %}
         <h5 class="tw-h5-heading">{{ cta.header | escape }}</h5>
         {{ cta.description | richtext }}
         {% comment %}
@@ -28,9 +27,7 @@
         {% endcomment %}
         {% include "../../fragments/formassembly_body.html" with show_country_field=cta.requires_country_code show_postal_code_field=cta.requires_postal_code show_comment_field=cta.comment_requirements campaign_id_tfa_1=cta.campaign_id source_url_tfa_498=source_url lang_tfa_499=lang thank_you_url_tfa_500=thank_you_url %}
         <link rel="stylesheet" href="{% static "_css/formassembly-override.compiled.css" %}">
-
-        {% comment %} The condition to show FormAssembly form {% endcomment %}
-    {% elif show_formassembly_thank_you and not show_formassembly %}
+    {% else %}
         <div
             class="formassembly-petition-thank-you"
             data-cta-slug="{{ page.slug }}"
@@ -42,33 +39,6 @@
             data-thank-you="{{ cta.thank_you }}"
             data-modals="{{ modals_json }}"
         ></div>
-    {% endif %}
-
-    {% comment %}
-        The following code {% if not show_formassembly_thank_you %} ... {% endif %}
-        is to be deleted after FormAssembly petition is fully implemented and tested.
-    {% endcomment %}
-    {% comment %} The condition to show the original form {% endcomment %}
-    {% if not show_formassembly and not show_formassembly_thank_you %}
-        <div
-            class="sign-petition tw-w-full tw-mb-12"
-            data-petition-id="{{ cta.id|unlocalize }}"
-            data-cta-slug="{{ page.slug }}"
-            data-form-location="{{ page.url }}"
-            data-cta-name="{{ cta.name }}"
-            data-cta-header="{{ cta.header | escape }}"
-            data-cta-description="{{ cta.description | escape }}"
-            data-requires-country-code="{{ cta.requires_country_code }}"
-            data-requires-postal-code="{{ cta.requires_postal_code }}"
-            data-comment-requirements="{{ cta.comment_requirements }}"
-            data-newsletter="{{ cta.newsletter }}"
-            data-checkbox1="{{ cta.checkbox_1 | escape }}"
-            data-checkbox2="{{ cta.checkbox_2 | escape }}"
-            data-share-link="{{ cta.share_link }}"
-            data-share-text="{{ cta.share_link_text }}"
-            data-thank-you="{{ cta.thank_you }}"
-            data-modals="{{ modals_json }}"
-        >{% trans "Loading form…" %}</div>
     {% endif %}
 
     <script src="https://c.shpg.org/352/sp.js"></script>

--- a/network-api/networkapi/wagtailpages/templatetags/mini_site_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/mini_site_tags.py
@@ -30,7 +30,6 @@ def cta(context, page):
         "lang": context["request"].LANGUAGE_CODE,
         "source_url": context["request"].build_absolute_uri(),
         "thank_you_url": context["request"].build_absolute_uri(context["request"].path + "?thank_you=true"),
-        "show_formassembly": context["request"].GET.get("show_formassembly") == "true",
         "show_formassembly_thank_you": context["request"].GET.get("thank_you") == "true",
     }
 

--- a/tests/foundation-urls.js
+++ b/tests/foundation-urls.js
@@ -11,15 +11,9 @@ module.exports = {
   "Fixed blog post": "/blog/initial-test-blog-post-with-fixed-title",
   "Campaign index": "/campaigns",
   "Single-page campaign": "/campaigns/single-page",
-  "Single-page campaign with FormAssembly form":
-    "/campaigns/single-page/?show_formassembly=true",
   "Multi-page campaign": "/campaigns/multi-page",
-  "Multi-page campaign with FormAssembly form":
-    "/campaigns/multi-page/?show_formassembly=true",
   "Bannered campaign":
     "/campaigns/initial-test-bannered-campaign-with-fixed-title",
-  "Bannered campaign with FormAssembly form":
-    "/campaigns/initial-test-bannered-campaign-with-fixed-title/?show_formassembly=true",
   "Publication page with child article":
     "/publication-page-with-child-article-pages",
   "Publication page with child chapter": "/publication-page-with-chapter-pages",
@@ -34,7 +28,8 @@ module.exports = {
   "YouTube regrets  reporter": "/campaigns/regrets-reporter",
   "Research hub landing page": "/research",
   "Research hub library page": "/research/library",
-  "Research hub detail page": "/research/library/fixed-title-research-detail-page",
+  "Research hub detail page":
+    "/research/library/fixed-title-research-detail-page",
   "Research hub author index page": "/research/authors",
   "Research hub author detail page": "/research/authors/percy-profile-1",
   // Disabled Dear Internet for now as Percy been giving false positive visual diffs

--- a/tests/integration/petition/001-petition-form.spec.js
+++ b/tests/integration/petition/001-petition-form.spec.js
@@ -2,20 +2,6 @@ const { test, expect } = require("@playwright/test");
 const waitForImagesToLoad = require("../../wait-for-images.js");
 const utility = require("./utility.js");
 
-test.describe("React form", () => {
-  test("Visibility", async ({ page }) => {
-    await page.goto(utility.generateUrl("en"));
-    await page.locator("body.react-loaded");
-    await waitForImagesToLoad(page);
-
-    // test if the React form is visible
-    const reactForm = page.locator("#petition-form");
-    // wait for the form to be attached to the DOM
-    await reactForm.waitFor({ state: "visible" });
-    expect(await reactForm.count()).toBe(1);
-  });
-});
-
 test.describe("FormAssembly petition form", () => {
   const TIMESTAMP = Date.now();
   // locales we support on foundation.mozilla.org
@@ -33,7 +19,10 @@ test.describe("FormAssembly petition form", () => {
   let localeToTest = supportedLocales[0];
 
   test.beforeEach(async ({ page }, testInfo) => {
-    await page.goto(utility.generateUrl(localeToTest, utility.FA_PAGE_QUERY));
+    const response = await page.goto(utility.generateUrl(localeToTest));
+    const status = await response.status();
+    expect(status).not.toBe(404);
+
     await page.locator("body.react-loaded");
     await waitForImagesToLoad(page);
 

--- a/tests/integration/petition/002-thank-you.spec.js
+++ b/tests/integration/petition/002-thank-you.spec.js
@@ -4,7 +4,11 @@ const utility = require("./utility.js");
 
 test.describe("Donation modal", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(utility.generateUrl("en", utility.THANK_YOU_PAGE_QUERY));
+    const response = await page.goto(
+      utility.generateUrl("en", utility.THANK_YOU_PAGE_QUERY)
+    );
+    const status = await response.status();
+    expect(status).not.toBe(404);
     await page.locator("body.react-loaded");
     await waitForImagesToLoad(page);
 
@@ -60,7 +64,11 @@ test.describe("Donation modal", () => {
 
 test.describe("Share buttons", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(utility.generateUrl("en", utility.THANK_YOU_PAGE_QUERY));
+    const response = await page.goto(
+      utility.generateUrl("en", utility.THANK_YOU_PAGE_QUERY)
+    );
+    const status = await response.status();
+    expect(status).not.toBe(404);
     await page.locator("body.react-loaded");
     await waitForImagesToLoad(page);
 

--- a/tests/integration/petition/utility.js
+++ b/tests/integration/petition/utility.js
@@ -1,6 +1,5 @@
 module.exports = {
   TEST_CAMPAIGN_ID: "7017i000000bIgTAAU",
-  FA_PAGE_QUERY: "show_formassembly=true",
   THANK_YOU_PAGE_QUERY: "thank_you=true",
   FA_FIELDS: {
     firstName: `input[name="tfa_28"]`,

--- a/tests/integration/petition/utility.js
+++ b/tests/integration/petition/utility.js
@@ -1,5 +1,5 @@
 module.exports = {
-  TEST_CAMPAIGN_ID: "7017i000000bIgTAAU",
+  TEST_CAMPAIGN_ID: "7017i000000bIgTAAU", // test campaign id used for Salesforce Sandbox
   THANK_YOU_PAGE_QUERY: "thank_you=true",
   FA_FIELDS: {
     firstName: `input[name="tfa_28"]`,

--- a/tests/integration/petition/utility.js
+++ b/tests/integration/petition/utility.js
@@ -1,5 +1,5 @@
 module.exports = {
-  TEST_CAMPAIGN_ID: "7017i000000bIgTAAU", // test campaign id used for Salesforce Sandbox
+  TEST_CAMPAIGN_ID: "7014x0000001RPRAA2", // test campaign id used for Salesforce Production
   THANK_YOU_PAGE_QUERY: "thank_you=true",
   FA_FIELDS: {
     firstName: `input[name="tfa_28"]`,


### PR DESCRIPTION
# Description

- Basically just making the FA form as the default form when users visit a campaign page that has a petition CTA (without including the `show_formassembly=true` query param)
- More cleanup work to remove obsolete petition related code will be tackled in https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10472

Related PRs/issues: #10796 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Documentation:**
- [x] Is my code documented?
