### PR TITLE
Make sure 'formassembly_head.html' is also included on PNI campaign pages

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -35,6 +35,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Zilla+Slab:300,400,600,700,300i,400i,600i">
 {% endblock %}
 
+{% block extended_head %}{% endblock %}
 
 {% block icons %}
     {% include "fragments/favicons.html" %}

--- a/network-api/networkapi/templates/pages/buyersguide/campaign_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/campaign_page.html
@@ -4,6 +4,10 @@
 
 {% block body_id %}campaign{% endblock %}
 
+{% block extended_head %}
+    {% include "../../wagtailpages/fragments/formassembly_head.html" %}
+{% endblock %}
+
 {% block guts %}
     <div class="tw-container">
         <div class="tw-row">


### PR DESCRIPTION
Reasons of why [PNI campaign pages](https://foundation.mozilla.org/en/privacynotincluded/articles/tell-tiktok-stop-misleading-android-users-and-provide-full-transparency-about-your-privacy-practices/?show_formassembly=true) aren't showing FA form correctly is because `formassembly_head.html` isn't included on PNI campaign pages. This PR fixes that.

![boxborders](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/f58d47be-a9fe-41a4-9da4-422050f275ab)


---

Test page on review app: https://foundation-s-fa-include-kbitxl.mofostaging.net/en/privacynotincluded/articles/test-pni-campaign-pages/