### PR TITLE
Add nofollow attribute to external links in rich text

### DIFF
--- a/env.default
+++ b/env.default
@@ -92,5 +92,5 @@ STATIC_HOST=
 # Comma separated list of domains to be exempted from rel="nofollow" attribute.
 # e.g. 'mozilla.org,mozilla.design' will match 
 # 'anything.mozilla.org/path' or 'mozilla.design.anything/path'
-# Or alternatively set WHITELISTED_LINKS="*" to exempt all links.
-WHITELISTED_LINKS="mozilla.org,mozilla.design"
+# Or alternatively set WHITELISTED_EXTERNAL_LINKS="*" to exempt all links.
+WHITELISTED_EXTERNAL_LINKS="mozilla.org,mozilla.design"

--- a/env.default
+++ b/env.default
@@ -88,3 +88,9 @@ SENTRY_ENVIRONMENT=
 
 # CDN configuration
 STATIC_HOST=
+
+# Comma separated list of domains to be exempted from rel="nofollow" attribute.
+# e.g. 'mozilla.org,mozilla.design' will match 
+# 'anything.mozilla.org/path' or 'mozilla.design.anything/path'
+# Or alternatively set WHITELISTED_LINKS="*" to exempt all links.
+WHITELISTED_LINKS="mozilla.org,mozilla.design"

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -91,6 +91,7 @@ env = environ.Env(
     XSS_PROTECTION=bool,
     SCOUT_KEY=(str, ""),
     WAGTAILADMIN_BASE_URL=(str, ""),
+    WHITELISTED_LINKS=(list, []),
 )
 
 # Read in the environment
@@ -733,3 +734,8 @@ if DEBUG:
         "127.0.0.1",
         "10.0.2.2",
     ]
+
+# List of domains to be exempted from the rel="nofollow" attribute.
+# e.g. 'mozilla.org' will match 'anything.mozilla.org/path'
+# Or alternatively set WHITELISTED_LINKS="*" to exempt all links.
+WHITELISTED_LINKS = env("WHITELISTED_LINKS", default=["mozilla.org", "mozilla.design"])

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -91,7 +91,7 @@ env = environ.Env(
     XSS_PROTECTION=bool,
     SCOUT_KEY=(str, ""),
     WAGTAILADMIN_BASE_URL=(str, ""),
-    WHITELISTED_LINKS=(list, []),
+    WHITELISTED_EXTERNAL_LINKS=(list, []),
 )
 
 # Read in the environment
@@ -737,5 +737,5 @@ if DEBUG:
 
 # List of domains to be exempted from the rel="nofollow" attribute.
 # e.g. 'mozilla.org' will match 'anything.mozilla.org/path'
-# Or alternatively set WHITELISTED_LINKS="*" to exempt all links.
-WHITELISTED_LINKS = env("WHITELISTED_LINKS", default=["mozilla.org", "mozilla.design"])
+# Or alternatively set WHITELISTED_EXTERNAL_LINKS="*" to exempt all links.
+WHITELISTED_EXTERNAL_LINKS = env("WHITELISTED_EXTERNAL_LINKS", default=["mozilla.org", "mozilla.design"])

--- a/network-api/networkapi/wagtailpages/tests/test_external_links.py
+++ b/network-api/networkapi/wagtailpages/tests/test_external_links.py
@@ -6,26 +6,26 @@ from networkapi.wagtailpages.wagtail_hooks import (
 
 
 class RichTextExternalLinkTest(test.TestCase):
-    def test_whitelisted_links_all(self):
+    def test_whitelisted_external_links_all(self):
         attrs = {"href": "https://www.google.com/"}
-        external_link_handler.whitelisted_links = ["*"]
+        external_link_handler.whitelisted_external_links = ["*"]
         expected_output = '<a href="https://www.google.com/" target="_blank">'
         self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)
 
-    def test_whitelisted_links_none(self):
+    def test_whitelisted_external_links_none(self):
         attrs = {"href": "https://www.google.com/"}
-        external_link_handler.whitelisted_links = []
+        external_link_handler.whitelisted_external_links = []
         expected_output = '<a href="https://www.google.com/" target="_blank" rel="nofollow">'
         self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)
 
-    def test_whitelisted_links_negative(self):
+    def test_whitelisted_external_links_negative(self):
         attrs = {"href": "https://www.google.com/"}
-        external_link_handler.whitelisted_links = ["bing.", "yahoo."]
+        external_link_handler.whitelisted_external_links = ["bing.", "yahoo."]
         expected_output = '<a href="https://www.google.com/" target="_blank" rel="nofollow">'
         self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)
 
-    def test_whitelisted_links_positive(self):
+    def test_whitelisted_external_links_positive(self):
         attrs = {"href": "https://www.google.com/"}
-        external_link_handler.whitelisted_links = ["google.", "yahoo."]
+        external_link_handler.whitelisted_external_links = ["google.", "yahoo."]
         expected_output = '<a href="https://www.google.com/" target="_blank">'
         self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)

--- a/network-api/networkapi/wagtailpages/tests/test_external_links.py
+++ b/network-api/networkapi/wagtailpages/tests/test_external_links.py
@@ -1,0 +1,31 @@
+from django import test
+
+from networkapi.wagtailpages.wagtail_hooks import (
+    RichTextExternalLinkNewTabHandler as external_link_handler,
+)
+
+
+class RichTextExternalLinkTest(test.TestCase):
+    def test_whitelisted_links_all(self):
+        attrs = {"href": "https://www.google.com/"}
+        external_link_handler.whitelisted_links = ["*"]
+        expected_output = '<a href="https://www.google.com/" target="_blank">'
+        self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)
+
+    def test_whitelisted_links_none(self):
+        attrs = {"href": "https://www.google.com/"}
+        external_link_handler.whitelisted_links = []
+        expected_output = '<a href="https://www.google.com/" target="_blank" rel="nofollow">'
+        self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)
+
+    def test_whitelisted_links_negative(self):
+        attrs = {"href": "https://www.google.com/"}
+        external_link_handler.whitelisted_links = ["bing.", "yahoo."]
+        expected_output = '<a href="https://www.google.com/" target="_blank" rel="nofollow">'
+        self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)
+
+    def test_whitelisted_links_positive(self):
+        attrs = {"href": "https://www.google.com/"}
+        external_link_handler.whitelisted_links = ["google.", "yahoo."]
+        expected_output = '<a href="https://www.google.com/" target="_blank">'
+        self.assertEqual(external_link_handler.expand_db_attributes(attrs), expected_output)

--- a/network-api/networkapi/wagtailpages/wagtail_hooks.py
+++ b/network-api/networkapi/wagtailpages/wagtail_hooks.py
@@ -80,14 +80,14 @@ def register_large_feature(features):
 # Updating external links in rich text blocks to open in a new tab
 class RichTextExternalLinkNewTabHandler(LinkHandler):
     identifier = "external"
-    whitelisted_links = settings.WHITELISTED_LINKS
+    whitelisted_external_links = settings.WHITELISTED_EXTERNAL_LINKS
 
     @classmethod
     def expand_db_attributes(cls, attrs):
         href = attrs["href"]
 
         # Skip rel="nofollow" for links matching our whitelist
-        if cls.whitelisted_links == ["*"] or any(substring in href for substring in cls.whitelisted_links):
+        if cls.whitelisted_external_links == ["*"] or any(substring in href for substring in cls.whitelisted_external_links):
             return '<a href="%s" target="_blank">' % escape(href)
         else:
             return '<a href="%s" target="_blank" rel="nofollow">' % escape(href)


### PR DESCRIPTION
# Description
Implement "no follow" (i.e. rel="nofollow"') to external links in blog posts unless the links matches domains in WHITELISTED_LINKS settings. 

The whitelist can be updated by updating the WHITELISTED_LINKS env variable. It is a comma-separated list of domains. E.g. "mozilla." will match "www.mozilla.org" and "buzilla.mozilla.org" and "mozilla.design". Alternatively if the value is set as "*", no link will be assigned nofollow.

The default setting if no env variable is set, is "mozilla.org,mozilla.design".

Related PRs/issues: #10678 

# Checklist
<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**


* [x] Is the code I'm adding covered by tests?

**Changes in Models:**


* [x] Did I update or add new fake data?
* [x] Did I squash my migration?
* [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**


* [x] Is my code documented?
* [x] Did I update the READMEs or wagtail documentation?



┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/TP1-170)
