### PR TITLE
Add RCC Playbook pages to Percy

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/libraries/rcc/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/libraries/rcc/__init__.py
@@ -16,6 +16,22 @@ from networkapi.wagtailpages.factory.libraries.rcc import relations as relations
 from networkapi.wagtailpages.factory.libraries.rcc import (
     taxonomies as taxonomies_factory,
 )
+from networkapi.wagtailpages.pagemodels.profiles import Profile
+
+
+def create_detail_page_for_visual_regression_tests(seed, rcc_library_page):
+    faker_helpers.reseed(seed)
+
+    percy_author_profile = Profile.objects.get(name="Percy Profile")
+
+    percy_rcc_detail_page = detail_page_factory.RCCDetailPageFactory.create(
+        parent=rcc_library_page, title="Fixed Title RCC Detail Page"
+    )
+
+    relations_factory.RCCAuthorRelationFactory.create(
+        detail_page=percy_rcc_detail_page,
+        author_profile=percy_author_profile,
+    )
 
 
 def generate(seed):
@@ -38,6 +54,8 @@ def generate(seed):
     rcc_authors_index_page = wagtailpage_models.RCCAuthorsIndexPage.objects.first()
     if not rcc_authors_index_page:
         rcc_authors_index_page = author_index_factory.RCCAuthorsIndexPageFactory.create(parent=rcc_landing_page)
+
+    create_detail_page_for_visual_regression_tests(seed, rcc_library_page)
 
     for _ in range(4):
         taxonomies_factory.RCCContentTypeFactory.create()

--- a/tests/foundation-urls.js
+++ b/tests/foundation-urls.js
@@ -32,6 +32,12 @@ module.exports = {
     "/research/library/fixed-title-research-detail-page",
   "Research hub author index page": "/research/authors",
   "Research hub author detail page": "/research/authors/percy-profile-1",
+  "RCC Playbook landing page": "/responsible-computing-challenge-playbook",
+  "RCC Playbook library page": "/responsible-computing-challenge-playbook/curriculum-library",
+  "RCC Playbook detail page":
+    "/responsible-computing-challenge-playbook/curriculum-library/fixed-title-rcc-detail-page",
+  "RCC Playbook author index page": "/responsible-computing-challenge-playbook/browse-authors",
+  "RCC Playbook author detail page": "/responsible-computing-challenge-playbook/browse-authors/percy-profile-1",
   // Disabled Dear Internet for now as Percy been giving false positive visual diffs
   // "Dear Internet": "/campaigns/dearinternet",
   Styleguide: "/style-guide",


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: (Please refer to percy tests in the CI panel)
Related PRs/issues: #10822 

This PR adds the following pages to be tested by percy:
- RCC Landing page
- RCC Library Page
- RCC Detail page
- RCC Author Index Page
- RCC Author Detail Page

# Steps to test

1. Observe the Percy tests for this PR, note that all page types listed above are now being tested.
2. If everything looks as expected, testing is complete!

