### PR TITLE
Install missing `gettext` dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,7 @@ RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-r
     libpq-dev \
     curl \
     git \
+    gettext \
     && apt-get autoremove && rm -rf /var/lib/apt/lists/*
 
 # Don't use the root user as it's an anti-pattern and Heroku does not run


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Install missing `gettext` dependency in Dockerfile. Without this dependency, `inv makemessages` would fail.

Link to sample test page:
Related PRs/issues: #10870 

## Testing

1. Run `inv setup`
2. Prepare to have translations done by following the [guide in the readme](https://github.com/MozillaFoundation/foundation.mozilla.org#translations)
3. Run `inv makemessages`
4. Check that the command runs without errors
