### PR TITLE
Adjusted spacing in the petition form

### DIFF
--- a/source/sass/formassembly-override.scss
+++ b/source/sass/formassembly-override.scss
@@ -128,13 +128,21 @@ $input-font-size: 1.25rem !important;
 }
 
 // Hide labels and extra line breaks:
-//   Privacy agreenment #tfa_492-L
-//   Email subscription #tfa_494-L
+//   Privacy agreenment #tfa_492-L #tfa_492-D
+//   Email subscription #tfa_494-L #tfa_494-D
 #tfa_492-L,
 #tfa_492-L br,
+#tfa_492-D br,
 #tfa_494-L,
-#tfa_494-L br {
+#tfa_494-L br,
+#tfa_494-D br {
   display: none;
+}
+
+// Increase margin above privacy agreement checkbox
+//   Privacy agreenment #tfa_492-D
+#tfa_492-D {
+  margin-top: 1.5rem;
 }
 
 // Reduce margin above email subscription checkbox


### PR DESCRIPTION
# Description

Adjusted spacing in the petition form. Due to restriction with FA, we aren't able to set the spacings to be the exact pixels we want. I tried to adjust them according to the specs in ticket. @nancyt1  Please let me know if I should adjust anything further.

Link to sample test page: https://foundation-s-10863-fa-s-lhiogl.herokuapp.com/en/campaigns/single-page/
Related PRs/issues: #10863 

