### PR TITLE
Added nonces to FA scripts

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/formassembly_head.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/formassembly_head.html
@@ -15,9 +15,11 @@ Please follow the steps below every time after you paste a new version of FormAs
         e.g., https://mozillafoundation.tfaforms.net/wForms/3.11/js/localization-{% fa_locale_code %}.js?v=...
     - Go to formassembly_body.html and make sure everything has been updated according to the instructions
 
-4. Update the revision note on the next line. Revision number can be found on https://mozillafoundation.tfaforms.net/versions/index/9
+4. Until we find a better solution, remember to include hot fix for source url field like what we did in https://github.com/MozillaFoundation/foundation.mozilla.org/pull/10902
 
-5. Until we find a better solution, remember to include hot fix for source url field like what we did in https://github.com/MozillaFoundation/foundation.mozilla.org/pull/10902
+5. Add nonce="{{ request.csp_nonce }}" to all <script> tags in this file
+
+6. Update the revision note on the next line. Revision number can be found on https://mozillafoundation.tfaforms.net/versions/index/9
 
 The code snippet below is based on FormAssembly form revision #32
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/formassembly_head.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/formassembly_head.html
@@ -27,8 +27,8 @@ The code snippet below is based on FormAssembly form revision #32
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="referrer" content="no-referrer-when-downgrade">
 <!-- THIS SCRIPT NEEDS TO BE LOADED FIRST BEFORE wforms.js -->
-<script type="text/javascript" data-for="FA__DOMContentLoadedEventDispatch" src="https://mozillafoundation.tfaforms.net/js/FA__DOMContentLoadedEventDispatcher.js" defer></script>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}" data-for="FA__DOMContentLoadedEventDispatch" src="https://mozillafoundation.tfaforms.net/js/FA__DOMContentLoadedEventDispatcher.js" defer></script>
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     document.addEventListener("FA__DOMContentLoaded", function(){
         const FORM_TIME_START = Math.floor((new Date).getTime()/1000);
         let formElement = document.getElementById("tfa_0");
@@ -68,13 +68,13 @@ The code snippet below is based on FormAssembly form revision #32
 
 <link href="https://mozillafoundation.tfaforms.net/uploads/themes/theme-23.css" rel="stylesheet" type="text/css" />
 <link href="https://mozillafoundation.tfaforms.net/dist/form-builder/5.0.0/wforms-jsonly.css?v=127d5d34f78f067204f2463a3699a1688fbf2ca7" rel="alternate stylesheet" title="This stylesheet activated by javascript" type="text/css" />
-<script type="text/javascript" src="https://mozillafoundation.tfaforms.net/wForms/3.11/js/wforms.js?v=127d5d34f78f067204f2463a3699a1688fbf2ca7"></script>
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}" src="https://mozillafoundation.tfaforms.net/wForms/3.11/js/wforms.js?v=127d5d34f78f067204f2463a3699a1688fbf2ca7"></script>
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     wFORMS.behaviors.prefill.skip = false;
 </script>
-<script type="text/javascript" src="https://mozillafoundation.tfaforms.net/wForms/3.11/js/localization-{% fa_locale_code %}.js?v=127d5d34f78f067204f2463a3699a1688fbf2ca7"></script>
+<script type="text/javascript" nonce="{{ request.csp_nonce }}" src="https://mozillafoundation.tfaforms.net/wForms/3.11/js/localization-{% fa_locale_code %}.js?v=127d5d34f78f067204f2463a3699a1688fbf2ca7"></script>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
     // [TO FIX]
     // hot fix for source url bug on petition form
     // see GitHub ticket: https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10901


### PR DESCRIPTION
# Description

This PR adds `nonce` to the scripts being included in `<head>` for FormAssembly

Link to sample test page: https://foundation.mozilla.org/en/campaigns/tell-tiktok-stop-misleading-android-users-and-provide-full-transparency-about-your-privacy-practices/?utm_source=mofo&utm_campaign=23-TikTok-4&utm_medium=email&utm_term=en&utm_content=Text_Petition_1
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?
