### PR TITLE
added Kiswahili to list of Tito's supported languages

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/tito_widget.py
@@ -37,7 +37,7 @@ class TitoWidgetBlock(blocks.StructBlock):
         If not, default to English, to prevent the Tito widget from crashing due to an unsupported language.
         For more info see: https://github.com/mozilla/foundation.mozilla.org/issues/9790
         """
-        tito_supported_language_codes = ["en", "de", "es", "fr", "nl", "pl"]
+        tito_supported_language_codes = ["en", "de", "es", "fr", "nl", "pl", "sw"]
         default_language_code = settings.LANGUAGE_CODE
 
         if request_language_code in tito_supported_language_codes:


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: https://mozfest-foundation-s-10926-kisw-r9pfr1.mofostaging.net/sw/tickets/
Related PRs/issues: #10926

This PR updates our list of languages that both the Foundation Site and Tito.js support. 

For example: if a user is visiting our site in any of the supported languages, the tito widget will also render in that language. However, if they visit our site in a language that is **not** supported by tito, the widget should then fall back to English.