### PR TITLE
Unlocalize strings from the Page types report

### DIFF
--- a/network-api/networkapi/templates/pages/reports/include/_list_page_types.html
+++ b/network-api/networkapi/templates/pages/reports/include/_list_page_types.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags wagtailcore_tags %}
+{% load wagtailadmin_tags wagtailcore_tags %}
 
 <table class="listing {% block table_classname %}{% endblock table_classname %}">
     <col width="20%" />
@@ -12,25 +12,25 @@
         {% block post_parent_page_headers %}
             <tr class="table-headers">
                 <th class="title">
-                    {% trans "Page Type" %}
+                    Page Type
                 </th>
                 <th class="app-label">
-                    {% trans "App Model" %}
+                    App Model
                 </th>
                 <th class="count">
-                    {% trans "Pages" %}
+                    Pages
                 </th>
                 <th class="default-locale-count">
-                    {% trans "Pages in" %} {{ active_locale_name }}
+                    Pages in {{ active_locale_name }}
                 </th>
                 <th class="last-edited-page">
-                    {% trans "Last edited page" %}
+                    Last edited page
                 </th>
                 <th class="last-edited-at">
-                    {% trans "Last edit" %}
+                    Last edit
                 </th>
                 <th class="last-edited-by">
-                    {% trans "Last edited by" %}
+                    Last edited by
                 </th>
                 {% block extra_columns %}
                 {% endblock extra_columns %}
@@ -85,7 +85,7 @@
             {% endfor %}
         {% else %}
             {% block no_results %}
-                <p>{% trans "No pages found." %}</p>
+                <p>No pages found.</p>
             {% endblock no_results %}
         {% endif %}
     </tbody>

--- a/network-api/networkapi/templates/pages/reports/page_types_report.html
+++ b/network-api/networkapi/templates/pages/reports/page_types_report.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/reports/base_report.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load wagtailadmin_tags %}
 
 {% block results %}
     {% with object_list as page_types %}
@@ -10,7 +10,7 @@
                 {% endblock listing %}
             {% else %}
                 {% block no_results %}
-                    <p>{% trans "No page types match this report's criteria." %}</p>
+                    <p>No page types match this report's criteria.</p>
                 {% endblock no_results %}
             {% endif %}
         </div>


### PR DESCRIPTION
Fixes #10956.

PR #10928 landed a few strings for a page that isn’t public-facing, we should rather hardcode these strings since they can only be seen by CMS users.

I appreciate the “Let’s localize everything by default” attitude, though!