### PR TITLE
Revert "Long author names now wrap instead of breaking out of container"

### DIFF
--- a/network-api/networkapi/templates/fragments/libraries/author_card.html
+++ b/network-api/networkapi/templates/fragments/libraries/author_card.html
@@ -13,7 +13,7 @@
         {% endwith %}
     </div>
     <div>
-        <div class="tw-h5-heading tw-mb-2 tw-text-blue-80 tw-break-all group-hover:tw-underline">
+        <div class="tw-h5-heading tw-mb-2 tw-text-blue-80 group-hover:tw-underline">
             {{ author_profile.name }}
         </div>
         <div class="tw-text-xs medium:tw-text-sm large:tw-text-base tw-text-gray-60">


### PR DESCRIPTION
Reverts MozillaFoundation/foundation.mozilla.org#10807