### PR TITLE
Fix petition fields migration

### DIFF
--- a/network-api/networkapi/wagtailpages/migrations/0096_add_show_country_field_and_remove_old_fields.py
+++ b/network-api/networkapi/wagtailpages/migrations/0096_add_show_country_field_and_remove_old_fields.py
@@ -9,13 +9,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
+        migrations.RenameField(
             model_name="petition",
-            name="requires_country_code",
+            old_name="requires_country_code",
+            new_name="show_country_field",
         ),
-        migrations.RemoveField(
+        migrations.RenameField(
             model_name="petition",
-            name="requires_postal_code",
+            old_name="requires_postal_code",
+            new_name="show_postal_code_field",
         ),
         migrations.AddField(
             model_name="petition",
@@ -24,14 +26,14 @@ class Migration(migrations.Migration):
                 default=False, help_text="This toggles the visibility of the optional comment field."
             ),
         ),
-        migrations.AddField(
+        migrations.AlterField(
             model_name="petition",
             name="show_country_field",
             field=models.BooleanField(
                 default=False, help_text="This toggles the visibility of the optional country dropdown field."
             ),
         ),
-        migrations.AddField(
+        migrations.AlterField(
             model_name="petition",
             name="show_postal_code_field",
             field=models.BooleanField(


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Rename the old boolean fields `requires_country_code` and `requires_postal_code` to `show_country_field` and `show_postal_code_field` to preserve the data.

Previous migration file was deleting the fields and then creating the new fields, so the data was lost.

Link to sample test page:
Related PRs/issues: #10961 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
