### PR TITLE
Better error handling when getting original object by slug

### DIFF
--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -480,7 +480,12 @@ def get_default_locale():
 
 def get_original_by_slug(Model, slug):
     (DEFAULT_LOCALE, DEFAULT_LOCALE_ID) = get_default_locale()
-    return Model.objects.get(slug=slug, locale=DEFAULT_LOCALE_ID)
+    try:
+        return Model.objects.get(slug=slug, locale=DEFAULT_LOCALE_ID)
+    except Model.DoesNotExist:
+        raise Model.DoesNotExist(
+            f"Could not find original for {Model.__name__} with slug {slug} at locale {DEFAULT_LOCALE}"
+        )
 
 
 def get_blog_authors(profiles: "QuerySet[Profile]") -> "QuerySet[Profile]":


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Improves the error message for the `get_original_by_slug` function from `networkapi.wagtailpages.utils`.

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
