### PR TITLE
Hide multipage nav (secondary nav) if there's no links to show

### DIFF
--- a/source/js/multipage-nav.js
+++ b/source/js/multipage-nav.js
@@ -1,6 +1,5 @@
 /**
  * Inject mobile version of multipage navs (secondary navs)
- *
  */
 export default () => {
   const targetNode = document.querySelector(
@@ -8,31 +7,49 @@ export default () => {
   );
   const multipageLinks = document.querySelectorAll(`#multipage-nav a`);
 
-  if (targetNode && multipageLinks.length) {
-    let activeLinkLabel = window.gettext("Navigate to...");
+  // if there is no multipage nav, return early
+  if (!targetNode) {
+    return;
+  }
 
-    let links = Array.from(multipageLinks).map((link) => {
-      const [href, isActive] = [
-        link.getAttribute(`href`),
-        !!link.getAttribute(`class`).match(/active/),
-      ];
-      const label = link.dataset.mobile
-        ? link.dataset.mobile.trim()
-        : link.textContent.trim();
+  // if there are no multipage links, remove the parent multipage nav #multipage-nav-mobile and return early
+  if (!multipageLinks.length) {
+    let parent = targetNode.parentNode;
+    while (parent) {
+      if (parent.id === `multipage-nav-mobile`) {
+        parent.remove();
+        break;
+      }
+      parent = parent.parentNode;
+    }
 
-      let className = `multipage-link${isActive ? ` active` : ``}`;
+    return;
+  }
 
-      if (isActive) {
-        activeLinkLabel = `<div class="active-link-label d-inline-block ${className}">
+  let activeLinkLabel = window.gettext("Navigate to...");
+
+  let links = Array.from(multipageLinks).map((link) => {
+    const [href, isActive] = [
+      link.getAttribute(`href`),
+      !!link.getAttribute(`class`).match(/active/),
+    ];
+    const label = link.dataset.mobile
+      ? link.dataset.mobile.trim()
+      : link.textContent.trim();
+
+    let className = `multipage-link${isActive ? ` active` : ``}`;
+
+    if (isActive) {
+      activeLinkLabel = `<div class="active-link-label d-inline-block ${className}">
             ${label}
           </div>`;
-      }
+    }
 
-      return `<div><a href="${href}" class="${className}">${label}</a></div>`;
-    });
+    return `<div><a href="${href}" class="${className}">${label}</a></div>`;
+  });
 
-    links.unshift(
-      `<div>
+  links.unshift(
+    `<div>
         <button class="expander">
           <div class="d-flex justify-content-between">
             <div>${activeLinkLabel}</div>
@@ -40,15 +57,14 @@ export default () => {
           </div>
         </button>
       </div>`
-    );
+  );
 
-    targetNode.innerHTML = `<div class="dropdown-nav">${links.join("")}</div>`;
+  targetNode.innerHTML = `<div class="dropdown-nav">${links.join("")}</div>`;
 
-    const dropdown = document.querySelector(`.dropdown-nav`);
+  const dropdown = document.querySelector(`.dropdown-nav`);
 
-    dropdown.querySelector(`.expander`).addEventListener(`click`, (e) => {
-      e.preventDefault();
-      dropdown.classList.toggle(`dropdown-nav-open`);
-    });
-  }
+  dropdown.querySelector(`.expander`).addEventListener(`click`, (e) => {
+    e.preventDefault();
+    dropdown.classList.toggle(`dropdown-nav-open`);
+  });
 };

--- a/source/sass/formassembly-override.scss
+++ b/source/sass/formassembly-override.scss
@@ -7,7 +7,9 @@ $input-font-size: 1.25rem !important;
 .wFormContainer {
   font-family: $font-family-sans-serif;
 
-  .wFormHeader {
+  .wFormHeader,
+  .wFormFooter,
+  .supportInfo {
     display: none;
   }
 


### PR DESCRIPTION
- Hide multipage nav (secondary nav) if there's no links to show (#10919)
- Hide FA's .wFormFooter and .supportInfo (as mentioned in [#10920](https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10920#issuecomment-1648085670)) Note that the remaining tasks in #10920 will be tackled in new PRs.

### Test pages
- test page 1 (no secondary nav): https://foundation-s-10920-peti-ejxqei.herokuapp.com/en/campaigns/single-page/
- test page 2 (with secondary nav): https://foundation-s-10920-peti-ejxqei.herokuapp.com/en/campaigns/multi-page/

---

Tagging you @kristinashu as I'm unsure which designer I should assign this PR review to 😅 
