### PR TITLE
Get original PNI product by translation key

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -1,5 +1,4 @@
 import json
-import re
 import typing
 
 from bs4 import BeautifulSoup

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/base.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/base.py
@@ -27,7 +27,7 @@ class BuyersGuideTestCase(test_base.WagtailpagesTestCase):
         buyersguide = BuyersGuidePage.objects.first()
         if not buyersguide:
             # Create the buyersguide page.
-            buyersguide = BuyersGuidePage()
+            buyersguide = BuyersGuidePage(locale=cls.default_locale)
             buyersguide.title = "Privacy not included"
             buyersguide.slug = "privacynotincluded"
             cls.homepage.add_child(instance=buyersguide)
@@ -50,6 +50,7 @@ class BuyersGuideTestCase(test_base.WagtailpagesTestCase):
                 title="Product Page",
                 live=True,
                 image=wagtail_image,
+                locale=cls.default_locale,
             )
             cls.bg.add_child(instance=product_page)
             product_page.save_revision().publish()

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -179,7 +179,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
     def test_serve_page_one_product(self):
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), 1)
-        query_number = 189
+        query_number = 188
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -193,7 +193,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 958
+        query_number = 917
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -207,7 +207,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 964
+        query_number = 923
         self.client.force_login(user=self.create_test_user())
 
         with self.assertNumQueries(query_number):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
@@ -74,6 +74,28 @@ class TestProductPage(BuyersGuideTestCase):
         creepiness = product_page.creepiness
         self.assertEqual(creepiness, 50)
 
+    def test_creepiness_with_translated_page(self):
+        product_page = self.product_page
+        product_page.creepiness_value = 100
+        product_page.slug = "product-page"
+        product_page.save()
+        self.assertEqual(product_page.creepiness_value, 100)
+
+        product_page.votes.set_votes([5, 5, 5, 5, 5])
+        self.assertEqual(product_page.total_vote_count, 25)
+
+        self.homepage.copy_for_translation(self.fr_locale)
+        self.bg.copy_for_translation(self.fr_locale)
+        fr_product_page = product_page.copy_for_translation(self.fr_locale)
+        self.synchronize_tree()
+
+        self.assertEqual(fr_product_page.original_product, product_page)
+        # Currently relies on slugs matching
+        self.assertEqual(fr_product_page.slug, product_page.slug)
+
+        creepiness = fr_product_page.creepiness
+        self.assertEqual(creepiness, 4)
+
     def test_get_voting_json(self):
         product_page = self.product_page
 

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
@@ -87,11 +87,12 @@ class TestProductPage(BuyersGuideTestCase):
         self.homepage.copy_for_translation(self.fr_locale)
         self.bg.copy_for_translation(self.fr_locale)
         fr_product_page = product_page.copy_for_translation(self.fr_locale)
+        # Slugs don't match (CMS data entry error, for instance)
+        fr_product_page.slug = "another-product-page"
+        fr_product_page.save()
         self.synchronize_tree()
 
         self.assertEqual(fr_product_page.original_product, product_page)
-        # Currently relies on slugs matching
-        self.assertEqual(fr_product_page.slug, product_page.slug)
 
         creepiness = fr_product_page.creepiness
         self.assertEqual(creepiness, 4)

--- a/network-api/networkapi/wagtailpages/utils.py
+++ b/network-api/networkapi/wagtailpages/utils.py
@@ -478,11 +478,6 @@ def get_default_locale():
     )
 
 
-def get_original_by_slug(Model, slug):
-    (DEFAULT_LOCALE, DEFAULT_LOCALE_ID) = get_default_locale()
-    return Model.objects.get(slug=slug, locale=DEFAULT_LOCALE_ID)
-
-
 def get_blog_authors(profiles: "QuerySet[Profile]") -> "QuerySet[Profile]":
     """Filter a queryset of profiles to only those who are blog authors."""
     return profiles.filter(blogauthors__isnull=False).distinct()


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Use default wagtail method to get the original `ProductPage` instead of relying on matching `slug`s (which has been causing server errors on PNI pages lately).

Link to sample test page: `fr/privacynotincluded/about`
Related PRs/issues: #11042 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
