### PR TITLE
Deprecate Redirecting Page

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/redirect.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/redirect.py
@@ -11,6 +11,9 @@ class RedirectingPage(Page):
         FieldPanel("URL"),
     ]
 
+    # This page is deprecated. While we keep the existing pages around,
+    # we don't want to create new ones.
+    is_creatable = False
     show_in_menus_default = True
 
     def serve(self, request):


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: http://localhost:8000/cms/pages/usage/wagtailpages/redirectingpage/
Related PRs/issues: #10675

I have not done anything with the existing Redirecting Pages as there are only 18 in production, and can be easily created as Wagtail Redirects by hand. I'll leave it to the editors to decide what to do with it.

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
