### PR TITLE
Review App Admin Fix

### DIFF
--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         try:
             User.objects.get(username="admin")
             print("super user already exists")
-        except User.DoesNotExist:
+        except self.model.DoesNotExist:
             password = faker.password(
                 length=16,
                 special_chars=True,

--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         try:
             User.objects.get(username="admin")
             print("super user already exists")
-        except self.model.DoesNotExist:
+        except User.DoesNotExist:
             password = faker.password(
                 length=16,
                 special_chars=True,

--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -5,7 +5,6 @@ Creates an admin user and prints the password to the build logs.
 import requests
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
 from faker import Faker  # note: NOT from factory, but from faker. Different Faker!
 
@@ -19,7 +18,7 @@ class Command(BaseCommand):
         try:
             User.objects.get(username="admin")
             print("super user already exists")
-        except ObjectDoesNotExist:
+        except User.DoesNotExist:
             password = faker.password(
                 length=16,
                 special_chars=True,

--- a/network-api/networkapi/management/commands/review_app_admin.py
+++ b/network-api/networkapi/management/commands/review_app_admin.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             if pr_number:
                 # Get PR's title from Github
                 token = settings.GITHUB_TOKEN
-                org = "mozilla"
+                org = "MozillaFoundation"
                 repo = "foundation.mozilla.org"
                 headers = {"Authorization": f"token {token}"}
                 r = requests.get(


### PR DESCRIPTION
# Description

This PR changes two things:

 - The error type checked for admin user creation in `review_app_admin.py` from `ObjectDoesNotExist` to `User.DoesNotExist`
 - The GitHub Organization being used for the `org` variable in `review_app_admin.py` has been changed from `mozilla` to `MozillaFoundation`

Related to this PR, the `GITHUB_TOKEN` environment variable for this Heroku pipeline's review apps has been replaced with a valid token. It was created under the @mofodevops account. We should move to app authentication in the future, but this is fixed for now.

Link to sample test page:
Related PRs/issues: #11140 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
