### PR TITLE
Bugfix - Annual Creep O Meter Page - Twitter share opening Facebook share

### DIFF
--- a/source/js/buyers-guide/components/social-share/product-quiz-share-buttons.jsx
+++ b/source/js/buyers-guide/components/social-share/product-quiz-share-buttons.jsx
@@ -23,7 +23,7 @@ class ProductQuizShareButtons extends Component {
     return (
       <button
         className={`${this.shareButtonClasses} twitter-share`}
-        onClick={(e) => this.shareButtonClicked(e, "share-progress-fb")}
+        onClick={(e) => this.shareButtonClicked(e, "share-progress-tw")}
       >
         {child}
       </button>


### PR DESCRIPTION
# Description
This PR solves a bug where the `renderTwitterButton` method in `product-quiz-share-buttons.jsx` is rendering a Facebook share instead of a Twitter share

Related PRs/issues: #11255 

Review app:
https://foundation-s-pni-annual-drsqcj.herokuapp.com/en/privacynotincluded/articles/annual-consumer-creep-o-meter/
