### PR TITLE
Adjusted logic used in PNI's quiz on creep-o-meter page

### DIFF
--- a/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
+++ b/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
@@ -132,7 +132,6 @@ class ProductQuiz extends Component {
               </p>
               <p className="text-font-sans tw-mb-0 tw-font-light">
                 {productName}
-                <span className="tw-block tw-text-red-40">(points: {product.points})</span>
               </p>
             </div>
           </label>

--- a/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
+++ b/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
@@ -132,6 +132,7 @@ class ProductQuiz extends Component {
               </p>
               <p className="text-font-sans tw-mb-0 tw-font-light">
                 {productName}
+                <span className="tw-block tw-text-red-40">(points: {product.points})</span>
               </p>
             </div>
           </label>
@@ -287,12 +288,13 @@ class ProductQuiz extends Component {
     const { selectedChoices, score } = this.state;
 
     let resultType = null;
+    // Result type is based on the total score.
+    // There is only one exception - when at least half of the selected products are bad.
+    let specialCase =
+      selectedChoices.length > 0 &&
+      this.state.numBad >= selectedChoices.length / 2;
 
-    if (
-      score >= RESULTS["open book"].minPoints ||
-      (selectedChoices.length > 0 &&
-        selectedChoices.length === this.state.numBad)
-    ) {
+    if (score >= RESULTS["open book"].minPoints || specialCase) {
       resultType = RESULTS["open book"];
     } else if (score >= RESULTS["soso"].minPoints) {
       resultType = RESULTS["soso"];


### PR DESCRIPTION
# Description

Related ticket: #11284

Per stakeholder request - (see the very bottom section of [this doc](https://docs.google.com/document/d/1xY3-NacjCfaMKoYM1EHhd6KNhPRowkdKnGwd5PBd5TA/edit))
Adjusted the special case logic so that "when **at least half** of the selected product are bad, show 'open book' result".

# Test Link

To make QA easier, I've added a new note `(points: x)` in each product in the quiz, this will be removed before PR gets merged.

https://foundation-s-pni-quiz-l-2lmidu.mofostaging.net/en/privacynotincluded/articles/annual-consumer-creep-o-meter/