### PR TITLE
[PNI] Prefetch product image renditions

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -523,7 +523,10 @@ def get_product_subset(cutoff_date, authenticated, key, products, language_code=
     if not authenticated:
         products = products.live()
 
-    products = products.prefetch_related("evaluation__votes")
+    products = products.prefetch_related(
+        "evaluation__votes",
+        "image__renditions",
+    )
 
     products = sort_average(products)
     cache.get_or_set(key, products, 24 * 60 * 60)  # Set cache for 24h

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -179,7 +179,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
     def test_serve_page_one_product(self):
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), 1)
-        query_number = 80
+        query_number = 78
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -193,7 +193,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 346
+        query_number = 344
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -207,7 +207,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 352
+        query_number = 350
         self.client.force_login(user=self.create_test_user())
 
         with self.assertNumQueries(query_number):
@@ -233,7 +233,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 9
+        query_number = 11
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -248,7 +248,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 9
+        query_number = 11
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -263,7 +263,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 9
+        query_number = 11
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -278,7 +278,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 9
+        query_number = 11
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -295,7 +295,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = user
         request.LANGUAGE_CODE = "en"
-        query_number = 9
+        query_number = 11
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Prefetch product image renditions to solve a N+1 query issue.

A little observation: the effect seems to be more prominent in local testing than the tests are showing. Kolo showed a reduction from ~400 queries to ~200 queries for 52 product pages.

Link to sample test page:
Related PRs/issues: #9812 and #9813.

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

