### PR TITLE
[PNI] Prefetch product categories

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -526,6 +526,7 @@ def get_product_subset(cutoff_date, authenticated, key, products, language_code=
     products = products.prefetch_related(
         "evaluation__votes",
         "image__renditions",
+        "product_categories__category",
     )
 
     products = sort_average(products)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -193,7 +193,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 344
+        query_number = 249
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -207,7 +207,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 350
+        query_number = 255
         self.client.force_login(user=self.create_test_user())
 
         with self.assertNumQueries(query_number):
@@ -233,7 +233,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 11
+        query_number = 12
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -248,7 +248,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 11
+        query_number = 13
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -263,7 +263,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 11
+        query_number = 12
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -278,7 +278,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 11
+        query_number = 13
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -295,7 +295,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = user
         request.LANGUAGE_CODE = "en"
-        query_number = 11
+        query_number = 12
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Solves N+1 issue on `product_in_category` template tag used in `network-api/networkapi/templates/pages/buyersguide/catalog.html` by prefetching the categories associated with a product page so that they don't have to be queried at the template level.

Link to sample test page:
Related PRs/issues: #9812 and #9813

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[  ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

