### PR TITLE
[PNI] Remove `.localized` usage in templates

### DIFF
--- a/network-api/networkapi/project_styleguide/templatetags/localization.py
+++ b/network-api/networkapi/project_styleguide/templatetags/localization.py
@@ -10,5 +10,3 @@ from networkapi.wagtailpages.templatetags.localization import register
 # not affect appearance. Overriding them centrally here is a convenient way
 # to avoid having to override the tags in each individual YAML file.
 override_tag(register, name="get_unlocalized_url", default_html="/dummy")
-override_tag(register, name="relocalized_url", default_html="/en/dummy")
-override_tag(register, name="localizedroutablepageurl", default_html="/en/routed-dummy")

--- a/network-api/networkapi/templates/fragments/buyersguide/article_card_body.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/article_card_body.html
@@ -1,4 +1,4 @@
-{% load localization %}
+{% load wagtailcore_tags %}
 
 <div class="tw-flex tw-flex-col tw-h-full tw-justify-between">
     <div>
@@ -7,9 +7,9 @@
             <span class="tw-h6-heading tw-text-gray-40 tw-mb-0">{{ page.first_published_at|date:"DATE_FORMAT" }}</span>
         </div>
 
-        <a href="{% relocalized_url page.localized.url %}" class="tw-group tw-block hover:tw-no-underline">
-            <p class="tw-h4-heading d-inline-block tw-mb-2 medium:tw-my-0 group-hover:tw-underline">{{ page.localized.title }}</p>
-            <p class="tw-text-xs medium:tw-text-lg tw-body tw-line-clamp-3 tw-leading-3 medium:tw-leading-6 medium:tw-mt-4 tw-mb-0">{{ page.localized.get_meta_description }}</p>
+        <a href="{% pageurl page %}" class="tw-group tw-block hover:tw-no-underline">
+            <p class="tw-h4-heading d-inline-block tw-mb-2 medium:tw-my-0 group-hover:tw-underline">{{ page.title }}</p>
+            <p class="tw-text-xs medium:tw-text-lg tw-body tw-line-clamp-3 tw-leading-3 medium:tw-leading-6 medium:tw-mt-4 tw-mb-0">{{ page.get_meta_description }}</p>
         </a>
     </div>
 

--- a/network-api/networkapi/templates/fragments/buyersguide/article_card_horizontal.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/article_card_horizontal.html
@@ -1,9 +1,9 @@
-{% load localization wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="tw-flex tw-flex-row tw-gap-6 medium:tw-gap-12 tw-w-full">
-    <a href="{% relocalized_url page.localized.url %}" class="tw-block tw-shrink-0 tw-max-w-[256px]">
-        {% image page.localized.get_meta_image fill-512x288 class="tw-hidden medium:tw-block tw-w-128 tw-aspect-video tw-object-cover" %}
-        {% image page.localized.get_meta_image fill-160x160 class="tw-block medium:tw-hidden tw-w-40 tw-aspect-square tw-rounded-2xl tw-object-cover" %}
+    <a href="{% pageurl page %}" class="tw-block tw-shrink-0 tw-max-w-[256px]">
+        {% image page.get_meta_image fill-512x288 class="tw-hidden medium:tw-block tw-w-128 tw-aspect-video tw-object-cover" %}
+        {% image page.get_meta_image fill-160x160 class="tw-block medium:tw-hidden tw-w-40 tw-aspect-square tw-rounded-2xl tw-object-cover" %}
     </a>
 
     {% include "./article_card_body.html" with page=page %}

--- a/network-api/networkapi/templates/fragments/buyersguide/article_card_vertical.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/article_card_vertical.html
@@ -1,12 +1,12 @@
-{% load localization wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="tw-flex tw-flex-col tw-gap-6 medium:tw-gap-12 tw-w-full">
-    <a href="{% relocalized_url page.localized.url %}" class="tw-block tw-w-full">
+    <a href="{% pageurl page %}" class="tw-block tw-w-full">
         {% comment %}
       Using 16 / 9 aspect ratio for the image at double the display size.
       Only specifiying the image width with CSS to upscale small images (like the example image during development).
     {% endcomment %}
-        {% image page.localized.get_meta_image fill-768x432 class="tw-object-cover tw-w-192 tw-aspect-video" %}
+        {% image page.get_meta_image fill-768x432 class="tw-object-cover tw-w-192 tw-aspect-video" %}
     </a>
 
     {% include "./article_card_body.html" with page=page %}

--- a/network-api/networkapi/templates/fragments/buyersguide/average_vote_rating.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/average_vote_rating.html
@@ -3,6 +3,6 @@
 <span class="tw-body-small">
     {% with vote_data=product.votes.get_vote_average %}
         <a class="tw-body-small" href="#creepiness-vote">{% trans "People voted:" %}</a>
-        <span class="people-voted {{ vote_data.label|slugify }}">{{ vote_data.localized }}</span>
+        <span class="people-voted {{ vote_data.label|slugify }}">{{ vote_data }}</span>
     {% endwith %}
 </span>

--- a/network-api/networkapi/templates/fragments/buyersguide/editorial_content_list_product_update_card.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/editorial_content_list_product_update_card.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <a href="{{ update.source }}" class="tw-group tw-block hover:tw-no-underline">
-    <p class="tw-h4-heading d-inline-block tw-mb-2 medium:tw-my-0 group-hover:tw-underline">{{ update.localized.title }}</p>
+    <p class="tw-h4-heading d-inline-block tw-mb-2 medium:tw-my-0 group-hover:tw-underline">{{ update.title }}</p>
     <span class="tw-text-blue-40 tw-text-xs tw-font-bold tw-uppercase tw-pt-0 medium:tw-pt-2 tw-pb-4 medium:tw-pb-2 tw-leading-5 tw-flex tw-no-underline">
         {{ update.author }}
         <img src="{% static "_images/buyers-guide/product-update-card-external-link.svg" %}" class="tw-ml-4" />

--- a/network-api/networkapi/templates/fragments/buyersguide/item.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/item.html
@@ -1,4 +1,4 @@
-{% load static i18n wagtailimages_tags l10n localization %}
+{% load static i18n wagtailcore_tags wagtailimages_tags l10n %}
 
 <figure
     class="
@@ -27,7 +27,7 @@
 
     {% include "fragments/buyersguide/adult_content_badge.html" with product=product %}
 
-    <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% relocalized_url product.url %}">
+    <a class="product-image text-center mt-4 h-100 d-flex flex-column justify-content-between" href="{% pageurl product %}">
         <picture class="product-thumbnail">
             <source
                 {% image product.image fill-360x360 as img_1x %}
@@ -47,7 +47,7 @@
     </a>
 
     <figcaption class="d-block mt-md-2 text-left">
-        <a class="product-links" href="{% relocalized_url product.url %}">
+        <a class="product-links" href="{% pageurl product %}">
             <div class="product-company tw-body-small">{{ product.company }}</div>
             <div class="product-name tw-body">{{ product.title }}</div>
         </a>
@@ -55,7 +55,7 @@
         <input type="hidden" class="product-worst-case" value="{{ product.worst_case }}">
         {% for cat in product.product_categories.all %}
             {% with category=cat.category %}
-                <input type="hidden" class="product-categories" value="{{ category.localized.name }}">
+                <input type="hidden" class="product-categories" value="{{ category.name }}">
             {% endwith %}
         {% endfor %}
     </figcaption>

--- a/network-api/networkapi/templates/fragments/buyersguide/no_search_results.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/no_search_results.html
@@ -1,4 +1,4 @@
-{% load bg_nav_tags i18n static localization %}
+{% load bg_nav_tags wagtailcore_tags i18n static %}
 {% get_bg_home_page as home_page %}
 
 <div class="container">
@@ -9,7 +9,7 @@
     </h3>
 
     <p class="mb-0">
-        {% relocalized_url home_page.localized.url as home_url %}
+        {% pageurl home_page as home_url %}
         {% blocktrans trimmed with home_url=home_url %}
             Try going back to <a href="{{ home_url }}" class="go-back-to-all-link">All</a>. You might find it there.
         {% endblocktrans %}

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_category_nav.html
@@ -1,11 +1,11 @@
-{% load bg_nav_tags localization i18n static wagtailroutablepage_tags wagtailmetadata_tags %}
+{% load bg_nav_tags i18n static wagtailcore_tags wagtailroutablepage_tags wagtailmetadata_tags %}
 <nav id="multipage-nav" class="pni-category-nav text-center d-none d-md-block tw-no-scrollbar tw-border-b tw-border-blue-10" title="{% trans "site navigation" context "Tooltip on menu items" %}">
     <div class="container tw-py-4" id="product-review">
         <div class="row">
             <div class="col">
                 <div id="pni-category-wrapper" class="tw-flex tw-items-center ">
                     <div id="buyersguide-category-link-container" class="tw-flex tw-items-center tw-w-full large:tw-w-4/5 tw-overflow-x-auto tw-mr-8">
-                        <a class="multipage-link tw-block {% if show_all_reviews_as_active_category %} active {% endif %}" data-name="None" data-mobile="{% trans "All Categories" %}" href="{% relocalized_url home_page.localized.url %}">{% trans "All Reviews" %}</a>
+                        <a class="multipage-link tw-block {% if show_all_reviews_as_active_category %} active {% endif %}" data-name="None" data-mobile="{% trans "All Categories" %}" href="{% pageurl home_page %}">{% trans "All Reviews" %}</a>
                         {% for cat in categories %}
                             {% if not cat.parent %}
                                 {% if cat.is_being_used %}

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
@@ -1,4 +1,4 @@
-{% load bg_nav_tags localization i18n static wagtailroutablepage_tags %}
+{% load bg_nav_tags i18n static wagtailcore_tags wagtailroutablepage_tags %}
 {% get_bg_home_page as home_page %}
 
 <div class="d-md-none mt-0 mb-0 tw-bg-white" id="pni-nav-mobile">
@@ -12,9 +12,9 @@
                                 <div>
                                     <div class="active-link-label d-inline-block multipage-link active">
                                         {% if current_category.parent %}
-                                            {{ current_category.parent.localized.name }}
+                                            {{ current_category.parent.name }}
                                         {% elif current_category %}
-                                            {{ current_category.localized.name }}
+                                            {{ current_category.name }}
                                         {% else %}
                                             {% trans "All Categories" %}
                                         {% endif %}
@@ -26,9 +26,9 @@
                     </div>
                     <div>
                         {% if pagetype == "product" or pagetype == "about" %}
-                            <a class="multipage-link active" data-name="None" href="{% relocalized_url home_page.localized.url %}">{% trans "All Categories" %}</a>
+                            <a class="multipage-link active" data-name="None" href="{% pageurl home_page %}">{% trans "All Categories" %}</a>
                         {% else %}
-                            <a class="multipage-link {% if not category %} active{% endif %}" data-name="None" href="{% relocalized_url home_page.localized.url %}">{% trans "All Categories" %}</a>
+                            <a class="multipage-link {% if not category %} active{% endif %}" data-name="None" href="{% pageurl home_page %}">{% trans "All Categories" %}</a>
                         {% endif %}
                     </div>
                     {% for cat in categories %}

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_search.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_search.html
@@ -1,4 +1,4 @@
-{% load bg_nav_tags i18n localization static %}
+{% load bg_nav_tags i18n static %}
 
 <div id="pni-mobile-search-container" class="tw-hidden large:tw-hidden tw-w-full tw-left-0 tw-bg-blue-05">
     <div class="tw-container">

--- a/network-api/networkapi/templates/fragments/buyersguide/pni_nav_links.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_nav_links.html
@@ -1,9 +1,9 @@
-{% load bg_nav_tags i18n localization wagtailcore_tags static %}
+{% load bg_nav_tags i18n wagtailroutablepage_tags wagtailcore_tags static %}
 {% get_bg_home_page as home_page %}
 
 {{ pre }}
 {% with home_page.get_editorial_content_index as editorial_content_index %}
-    <a class="{{ class }} product-review-link" href="{% relocalized_url home_page.url %}#product-review">{% trans "Product Reviews" %}</a>
+    <a class="{{ class }} product-review-link" href="{% pageurl home_page %}#product-review">{% trans "Product Reviews" %}</a>
     <img
         class="tw-mr-8 tw-hidden large:tw-block {{ class }}"
         src="{% static "_images/buyers-guide/asterick-mini.svg" %}"
@@ -12,7 +12,7 @@
         <a class="{{ class }} {% bg_active_nav request.get_full_path editorial_content_index.url %} " href="{% pageurl editorial_content_index %}">{{ editorial_content_index }}</a>
     {% endif %}
 {% endwith %}
-{% localizedroutablepageurl home_page 'about-why-view' as about_why_url %}
+{% routablepageurl home_page 'about-why-view' as about_why_url %}
 <a class="{{ class }} {% bg_active_nav request.get_full_path about_why_url %}" href="{{ about_why_url }}">{% trans "About" %}</a>
 <a id="donate-header-btn" class="{{ class }}" href="?form=donate&utm_medium=FMO&utm_source=PNI&utm_campaign=23-PNI&utm_content=header&c_id=7014x000000eQOD">{% trans "Donate" %}</a>
 {{ post }}

--- a/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/primary_nav.html
@@ -1,6 +1,6 @@
 {% extends "partials/primary_nav.html" %}
 
-{% load bg_nav_tags i18n localization static %}
+{% load bg_nav_tags i18n wagtailcore_tags static %}
 
 {% block wrapper_classes %} tw-border-0 {% endblock %}
 
@@ -10,7 +10,7 @@
     {% get_bg_home_page as home_page %}
     <div class="tw-flex tw-flex-col logo-section tw-mx-auto large:tw-mx-0">
         <p class="mb-0 tw-h3-heading tw-max-w-none flex-wrap">
-            <a class="link-back tw-flex" href="{% relocalized_url home_page.url %}">
+            <a class="link-back tw-flex" href="{% pageurl home_page %}">
                 <img
                     class="tw-mr-2 tw-w-6 tw-h-6 large:tw-w-8 large:tw-h-8"
                     src="{% static "_images/buyers-guide/asterick-mini.svg" %}"

--- a/network-api/networkapi/templates/fragments/buyersguide/product_tab.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/product_tab.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags bg_selector_tags l10n i18n localization static bg_nav_tags %}
+{% load wagtailcore_tags bg_selector_tags l10n i18n wagtailroutablepage_tags static bg_nav_tags %}
 {% get_bg_home_page as home_page %}
 
 <div id="product-tab" class="tw-w-full tw-mb-8">
@@ -108,7 +108,7 @@
             </div>
 
             <div class="tw-w-full tw-shrink-0 medium:tw-px-24" data-product-label="1">
-                {% localizedroutablepageurl home_page 'methodology-view' as min_sec_url %}
+                {% routablepageurl home_page 'methodology-view' as min_sec_url %}
                 {% blocktrans with url=min_sec_url|add:"#minimum-security-standards" asvar minimum_security_standards trimmed %}
                     Does this product meet our <span class="tw-ml-2"></span> <a id="mss-link" class="" href="{{ url }}">Minimum Security Standards</a>?
                 {% endblocktrans %}

--- a/network-api/networkapi/templates/fragments/buyersguide/product_tab_header.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/product_tab_header.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags bg_selector_tags l10n i18n localization static %}
+{% load wagtailcore_tags bg_selector_tags l10n i18n static %}
 
 {% with li_class="tw-mb-0 medium:tw-flex-1 tw-shrink-0 medium:tw-w-auto tw-relative" button_class="tw-mx-auto tw-no-underline tw-bg-white tw-text-black tw-font-zilla tw-text-3xl tw-py-4 tw-px-12 medium:tw-w-full tw-flex tw-justify-center tw-items-center tw-ease-in tw-transform tw-duration-150" %}
     <ul id="product-tab-group"

--- a/network-api/networkapi/templates/fragments/buyersguide/related_product.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/related_product.html
@@ -1,7 +1,7 @@
-{% load localization wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="related-product">
-    <a class="tw-block {% if related_product.adult_content %} adult-content{% endif %}" href="{% relocalized_url related_product.url %}">
+    <a class="tw-block {% if related_product.adult_content %} adult-content{% endif %}" href="{% pageurl related_product %}">
         <div class="img-container tw-p-12">
             {% image related_product.image width-600 as img %}
             <img

--- a/network-api/networkapi/templates/fragments/buyersguide/research_details.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/research_details.html
@@ -1,4 +1,4 @@
-{% load static i18n localization %}
+{% load static i18n %}
 
 {% comment %}
  This is the section underneath the title of the products heading, where we display date and time spent researching, as well as creepiness level people have voted.

--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -7,8 +7,8 @@
 {% block main_content_class %}{% endblock %}
 
 {% block hero %}
-    <input type="hidden" class="category-title" value="{% if current_category %}{{ current_category.localized.name }}{% else %}None{% endif %}">
-    <input type="hidden" class="parent-title" value="{{ current_category.parent.localized.name }}">
+    <input type="hidden" class="category-title" value="{% if current_category %}{{ current_category.name }}{% else %}None{% endif %}">
+    <input type="hidden" class="parent-title" value="{{ current_category.parent.name }}">
     <div class="tw-container">
         <div class="tw-row">
             <div class="tw-px-8 tw-py-12 large:tw-py-24 tw-w-full">
@@ -36,9 +36,9 @@
                         class="tw-text-2xl tw-font-zilla category-header tw-text-black hover:tw-text-pni-blue tw-no-underline tw-cursor-pointer tw-block"
                     >
                         {% if current_category.parent %}
-                            {{ current_category.parent.localized.name }}
+                            {{ current_category.parent.name }}
                         {% elif current_category %}
-                            {{ current_category.localized.name }}
+                            {{ current_category.name }}
                         {% else %}
                             {% trans "Product Reviews" %}
                         {% endif %}
@@ -91,7 +91,7 @@
                                         {% routablepageurl home_page 'category-view' cat.slug as cat_url %}
                                         <a class="{% if current_category.name != cat.parent.name and current_category.parent.name != cat.parent.name %} tw-hidden {% endif %} subcategories {{ tailwind_classes }} {% if current_category.name == cat.name %}{{ selected_classes }}{% else %}{{ default_classes }}{% endif %}"
                                            href="{{ cat_url }}"
-                                           data-parent="{{ cat.parent.localized.name }}"
+                                           data-parent="{{ cat.parent.name }}"
                                            data-name="{{ cat.name }}">
                                             {{ cat.name }}
                                         </a>
@@ -142,14 +142,14 @@
                     {% cache 86400 pni_home_page template_cache_key_fragment %}
                         {% for product in products %}
                             {% product_in_category product category as matched %}
-                            {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
+                            {% include "fragments/buyersguide/item.html" with product=product matched=matched %}
                         {% endfor %}
                     {% endcache %}
                 {% else %}
                     {# User is logged in. Don't cache their results so they can see live and draft products here. #}
                     {% for product in products %}
                         {% product_in_category product category as matched %}
-                        {% include "fragments/buyersguide/item.html" with product=product.localized matched=matched %}
+                        {% include "fragments/buyersguide/item.html" with product=product matched=matched %}
                     {% endfor %}
                 {% endif %}
             </div>

--- a/network-api/networkapi/templates/pages/buyersguide/product_page.html
+++ b/network-api/networkapi/templates/pages/buyersguide/product_page.html
@@ -62,7 +62,7 @@
                                 {% with category=cat.category %}
                                     {% routablepageurl home_page 'category-view' category.slug as cat_url %}
                                     <a href="{{ cat_url }}" class="category-tag {% if category.parent == None %}category{% else %}subcategory{% endif %} tw-no-underline tw-text-gray-60 border tw-border-gray-20 tw-px-4 tw-py-1 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3]">
-                                        {{ category.localized.name }}
+                                        {{ category.name }}
                                     </a>
                                 {% endwith %}
                             {% endfor %}
@@ -179,7 +179,7 @@
                         </div>
                         <div class="tw-grid tw-grid-cols-2 medium:tw-grid-cols-4 tw-gap-16">
                             {% for related_product_page in related_products %}
-                                {% include "fragments/buyersguide/related_product.html" with related_product=related_product_page.related_product.localized %}
+                                {% include "fragments/buyersguide/related_product.html" with related_product=related_product_page.related_product %}
                             {% endfor %}
                         </div>
                     </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_author_detail_header.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_author_detail_header.html
@@ -1,4 +1,4 @@
-{% load l10n i18n localization static wagtailimages_tags wagtailroutablepage_tags wagtailcore_tags %}
+{% load l10n i18n static wagtailimages_tags wagtailroutablepage_tags wagtailcore_tags %}
 
 <div class="tw-grid tw-grid-cols-12 large:tw-gap-40">
     <div class="tw-col-span-12 large:tw-col-span-8">
@@ -27,7 +27,7 @@
             <div class="tw-inline-flex tw-gap-6 tw-flex-wrap">
                 {% with link_classes="tw-text-black tw-px-8 tw-border-black tw-border tw-rounded-full tw-text-lg tw-font-normal tw-whitespace-nowrap tw-block tw-transition-colors" link_hover_classes="hover:tw-bg-black hover:tw-text-white hover:tw-no-underline hover:tw-border-white" %}
                     {% for topic in frequent_topics %}
-                        <a href="{% localizedroutablepageurl page "entries_by_topic" topic.slug %}" class="{{ link_classes }} {{ link_hover_classes }}">
+                        <a href="{% routablepageurl page "entries_by_topic" topic.slug %}" class="{{ link_classes }} {{ link_hover_classes }}">
                             {{ topic.name }}
                         </a>
                     {% endfor %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_index_feature.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_index_feature.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags wagtailembeds_tags wagtailimages_tags i18n localization homepage_tags blog_tags static %}
+{% load wagtailcore_tags wagtailembeds_tags wagtailimages_tags i18n homepage_tags blog_tags static %}
 
 
 <div class="tw-grid tw-grid-cols-12 tw-gap-x-12 tw-gap-y-6">
@@ -11,7 +11,7 @@
                 {% endif %}
                 <span class="tw-h6-heading tw-text-gray-40 tw-py-2 tw-mb-0">{{ blog_page.first_published_at|date:"DATE_FORMAT" }}</span>
             </div>
-            <a href="{% relocalized_url blog_page.localized.url %}" class="tw-group tw-block hover:tw-no-underline">
+            <a href="{% pageurl blog_page %}" class="tw-group tw-block hover:tw-no-underline">
                 <h1 class="tw-h4-heading medium:tw-h1-heading medium:tw-text-[34px] tw-mt-2 tw-mb-4 group-hover:tw-underline">{{ blog_page.localized.title }}</h1>
                 <p class="tw-body tw-line-clamp-3 medium:tw-line-clamp-none">{{ blog_page.localized.get_meta_description }}</p>
             </a>
@@ -38,7 +38,7 @@
             {% endif %}
         {% else %}
             <div id="featured-image-container" class="tw-w-full tw-h-full">
-                <a href="{% relocalized_url blog_page.localized.url %}">
+                <a href="{% pageurl blog_page %}">
                     {% image blog_page.localized.specific.get_meta_image fill-1200x628 class='tw-h-full tw-w-full tw-object-contain tw-object-top' %}
                 </a>
             </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_topics.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/blog_topics.html
@@ -1,4 +1,4 @@
-{% load blog_tags localization %}
+{% load blog_tags localization wagtailroutablepage_tags %}
 
 {% for topic in topics %}
     {% localized_version topic as localized_topic %}
@@ -6,7 +6,7 @@
     {# If we have a "root" context variable, we know this card is generated on an index page (or index page subroute) #}
 
     {% with classes="tw-h6-heading tw-text-blue-80 tw-mr-4 tw-py-2 tw-mb-0" %}
-        <a class="{{ classes }} {{ extra_classes }}" href="{% localizedroutablepageurl parent_page "entries_by_topic" topic.slug %}">{{ localized_topic }}</a>
+        <a class="{{ classes }} {{ extra_classes }}" href="{% routablepageurl parent_page "entries_by_topic" topic.slug %}">{{ localized_topic }}</a>
         {% if not forloop.last %}
             <span class="{{ classes }} {{ extra_classes }}">/</span>
         {% endif %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags wagtailimages_tags localization %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 <div
     class="
@@ -17,7 +17,7 @@
             class="medium:tw-max-w-xs large:tw-max-w-sm medium:tw-shrink-0"
         {% endif %}
     >
-        <a href="{% relocalized_url page.localized.url %}">
+        <a href="{% pageurl page %}">
             {% image page.localized.specific.get_meta_image fill-1200x628 %}
         </a>
     </div>
@@ -28,7 +28,7 @@
             {% block published_date %}{% endblock %}
         </div>
 
-        <a href="{% relocalized_url page.localized.url %}" class="tw-group tw-block hover:tw-no-underline">
+        <a href="{% pageurl page %}" class="tw-group tw-block hover:tw-no-underline">
             <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">{{ page.localized.title }}</p>
             <p class="tw-body-small my-0">
                 {% block description %}{% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/related_topics_cutout.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/related_topics_cutout.html
@@ -1,4 +1,4 @@
-{% load blog_tags localization i18n %}
+{% load blog_tags localization wagtailroutablepage_tags i18n %}
 
 <div class="tw-border tw-px-12 tw-py-16 tw-popout">
     <h2 class="tw-mb-8 tw-font-bold tw-text-lg tw-font-sans tw-uppercase">{% trans 'Related Topics' %} </h2>
@@ -8,7 +8,7 @@
             {% get_root_or_page as parent_page %}
             {# If we have a "root" context variable, we know this template is generated on an index page (or index page subroute) #}
             {% with link_classes="tw-text-black tw-px-8 tw-border-black tw-my-4 tw-border tw-rounded-full tw-mr-6 tw-text-lg tw-font-normal tw-whitespace-nowrap tw-block tw-transition-colors" link_hover_classes="hover:tw-bg-black hover:tw-text-white hover:tw-no-underline hover:tw-border-white" %}
-                <a href="{% localizedroutablepageurl parent_page "entries_by_topic" topic.slug %}" class="{{ link_classes }} {{ link_hover_classes }}">
+                <a href="{% routablepageurl parent_page "entries_by_topic" topic.slug %}" class="{{ link_classes }} {{ link_hover_classes }}">
                     {{ localized_topic }}
                 </a>
             {% endwith %}

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -71,21 +71,6 @@ def relocalize_url(url, locale_code):
     return url.replace(f"/{DEFAULT_LOCALE_CODE}/", f"/{locale_code}/")
 
 
-# Force-relocalize a URL
-@register.simple_tag(takes_context=True)
-def relocalized_url(context, url):
-    request = context["request"]
-    locale_code = get_language_from_request(request)
-    return relocalize_url(url, locale_code)
-
-
-# Overcome a limitation of the routablepageurl tag
-@register.simple_tag(takes_context=True)
-def localizedroutablepageurl(context, page, url_name, *args, **kwargs):
-    url = relocalized_url(context, routablepageurl(context, page, url_name, *args, **kwargs))
-    return url
-
-
 # Get the "current locale" version of some content object from Wagtail
 @register.simple_tag(takes_context=True)
 def localized_version(context, thing):

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -5,12 +5,8 @@ from django import template
 from django.conf import settings
 from django.db.models.base import ObjectDoesNotExist
 from django.utils.translation import get_language_info
-from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import (
-    routablepageurl,
-)
 
 from networkapi.wagtailpages.utils import (
-    get_language_from_request,
     get_locale_from_request,
 )
 

--- a/network-api/networkapi/wagtailpages/templatetags/localization.py
+++ b/network-api/networkapi/wagtailpages/templatetags/localization.py
@@ -6,9 +6,7 @@ from django.conf import settings
 from django.db.models.base import ObjectDoesNotExist
 from django.utils.translation import get_language_info
 
-from networkapi.wagtailpages.utils import (
-    get_locale_from_request,
-)
+from networkapi.wagtailpages.utils import get_locale_from_request
 
 register = template.Library()
 

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -169,7 +169,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         products = ProductPage.objects.descendant_of(self.bg)
         products.delete()
         self.assertEqual(products.count(), 0)
-        query_number = 58
+        query_number = 43
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -179,7 +179,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
     def test_serve_page_one_product(self):
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), 1)
-        query_number = 78
+        query_number = 60
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -193,7 +193,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 249
+        query_number = 61
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -207,7 +207,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 255
+        query_number = 67
         self.client.force_login(user=self.create_test_user())
 
         with self.assertNumQueries(query_number):


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

- Remove usage of `.localized` in Buyers Guide templates as they introduce N+1 queries
- Remove usage of `relocalized_url` and `localizedroutablepageurl` tags in templates, as they do the same as the builtin `pageurl` and `routablepageurl` respectively. Localization should be done at context/view method to avoid performance issues.

Closes:
- #10031 
- #10030 
- #10029 
- #10028 
- #10027
- #10026 
- #10025
- #10024 
- #10023 
- #10021 

Link to sample test page:
Related PRs/issues: #9812 and #9813 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

