### PR TITLE
[PNI] Reduce product vote/creepiness memory consumption

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -5,6 +5,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
+from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
 from django.utils.translation import gettext
@@ -24,7 +25,6 @@ from wagtail_localize.fields import SynchronizedField, TranslatableField
 
 from networkapi.utility import orderables
 from networkapi.wagtailpages.pagemodels.base import BasePage
-from networkapi.wagtailpages.pagemodels.buyersguide.utils import sort_average
 from networkapi.wagtailpages.templatetags.localization import relocalize_url
 from networkapi.wagtailpages.utils import (
     get_language_from_request,
@@ -524,11 +524,11 @@ def get_product_subset(cutoff_date, authenticated, key, products, language_code=
         products = products.live()
 
     products = products.prefetch_related(
-        "evaluation__votes",
         "image__renditions",
         "product_categories__category",
-    )
+    ).annotate(
+        _average_creepiness=Coalesce(models.Avg("evaluation__votes__value"), float(0))
+    ).order_by("_average_creepiness")
 
-    products = sort_average(products)
     cache.get_or_set(key, products, 24 * 60 * 60)  # Set cache for 24h
     return products

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -523,12 +523,14 @@ def get_product_subset(cutoff_date, authenticated, key, products, language_code=
     if not authenticated:
         products = products.live()
 
-    products = products.prefetch_related(
-        "image__renditions",
-        "product_categories__category",
-    ).annotate(
-        _average_creepiness=Coalesce(models.Avg("evaluation__votes__value"), float(0))
-    ).order_by("_average_creepiness")
+    products = (
+        products.prefetch_related(
+            "image__renditions",
+            "product_categories__category",
+        )
+        .annotate(_average_creepiness=Coalesce(models.Avg("evaluation__votes__value"), float(0)))
+        .order_by("_average_creepiness")
+    )
 
     cache.get_or_set(key, products, 24 * 60 * 60)  # Set cache for 24h
     return products

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -5,7 +5,6 @@ from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import slugify
 from django.utils.translation import gettext
@@ -528,7 +527,7 @@ def get_product_subset(cutoff_date, authenticated, key, products, language_code=
             "image__renditions",
             "product_categories__category",
         )
-        .annotate(_average_creepiness=Coalesce(models.Avg("evaluation__votes__value"), float(0)))
+        .with_average_creepiness()
         .order_by("_average_creepiness")
     )
 

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -327,12 +327,12 @@ class ProductPageEvaluation(models.Model):
         """
         try:
             return self._total_creepiness
-        except AttributeError:
-            raise ValueError(
+        except AttributeError as e:
+            raise AttributeError(
                 "Can't calculate total creepiness without `_total_creepiness` annotation. "
                 "Make sure to annotate the evaluation queryset by calling `.with_total_creepiness()` "
                 "method before accessing this property."
-            )
+            ) from e
 
     @property
     def average_creepiness(self):
@@ -352,12 +352,12 @@ class ProductPageEvaluation(models.Model):
         """
         try:
             return self._average_creepiness
-        except AttributeError:
-            raise ValueError(
+        except AttributeError as e:
+            raise AttributeError(
                 "Can't calculate average creepiness without `_average_creepiness` annotation. "
                 "Make sure to annotate the evaluation queryset by calling `.with_average_creepiness()` "
                 "method before accessing this property."
-            )
+            ) from e
 
     @property
     def votes_per_bin(self):

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -328,7 +328,11 @@ class ProductPageEvaluation(models.Model):
         try:
             return self._total_creepiness
         except AttributeError:
-            return sum([vote.value for vote in self.votes.all()])
+            raise ValueError(
+                "Can't calculate total creepiness without `_total_creepiness` annotation. "
+                "Make sure to annotate the evaluation queryset by calling `.with_total_creepiness()` "
+                "method before accessing this property."
+            )
 
     @property
     def average_creepiness(self):
@@ -349,9 +353,11 @@ class ProductPageEvaluation(models.Model):
         try:
             return self._average_creepiness
         except AttributeError:
-            if self.total_votes == 0:
-                return 0
-            return self.total_creepiness / self.total_votes
+            raise ValueError(
+                "Can't calculate average creepiness without `_average_creepiness` annotation. "
+                "Make sure to annotate the evaluation queryset by calling `.with_average_creepiness()` "
+                "method before accessing this property."
+            )
 
     @property
     def votes_per_bin(self):

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -293,6 +293,17 @@ class ProductPageEvaluation(models.Model):
 
     @property
     def total_votes(self):
+        """Total number of votes for this product evaluation.
+
+        To populate the prefetched `_total_votes` annotation, call
+
+        ```
+        ProductPageEvaluation.objects.with_total_votes()
+        ```
+
+        Returns:
+            int: Total number of votes for this product evaluation.
+        """
         try:
             return self._total_votes
         except AttributeError:
@@ -300,6 +311,20 @@ class ProductPageEvaluation(models.Model):
 
     @property
     def total_creepiness(self):
+        """Aggregate of vote values for this product evaluation.
+
+        To use this property, make sure to first populate the prefetched `_total_creepiness`
+        annotation, i.e.:
+
+        ```
+        evaluations = ProductPageEvaluation.objects.with_total_creepiness()
+        my_evaluation = evaluations.get(pk=1)
+        my_evaluation.total_creepiness
+        ```
+
+        Returns:
+            int: Sum of creepiness value for all votes for this product evaluation.
+        """
         try:
             return self._total_creepiness
         except AttributeError:
@@ -307,6 +332,20 @@ class ProductPageEvaluation(models.Model):
 
     @property
     def average_creepiness(self):
+        """Average of vote values for this product evaluation.
+
+        To use this property, make sure to first populate the prefetched `_average_creepiness`
+        annotation, i.e.:
+
+        ```
+        evaluations = ProductPageEvaluation.objects.with_average_creepiness()
+        my_evaluation = evaluations.get(pk=1)
+        my_evaluation.average_creepiness
+        ```
+
+        Returns:
+            int: Average of creepiness value for all votes for this product evaluation.
+        """
         try:
             return self._average_creepiness
         except AttributeError:

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/utils.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/utils.py
@@ -38,13 +38,6 @@ def get_categories_for_locale(language_code):
     ]
 
 
-def sort_average(products):
-    """
-    `products` is a QuerySet of ProductPages.
-    """
-    return sorted(products, key=lambda p: p.creepiness)
-
-
 def get_buyersguide_featured_cta(page):
     """
     This function takes a page, finds the Buyer's Guide home page in its list

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -179,7 +179,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
     def test_serve_page_one_product(self):
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), 1)
-        query_number = 60
+        query_number = 58
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -193,7 +193,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 61
+        query_number = 59
 
         with self.assertNumQueries(query_number):
             response = self.client.get(self.bg.url)
@@ -207,7 +207,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
             buyersguide_factories.ProductPageFactory(parent=self.bg, with_random_categories=True)
         products = ProductPage.objects.descendant_of(self.bg)
         self.assertEqual(products.count(), additional_products_count + 1)
-        query_number = 67
+        query_number = 65
         self.client.force_login(user=self.create_test_user())
 
         with self.assertNumQueries(query_number):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_homepage.py
@@ -222,7 +222,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 7
+        query_number = 6
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -233,7 +233,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 12
+        query_number = 6
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -248,7 +248,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 13
+        query_number = 6
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -263,7 +263,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 12
+        query_number = 6
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -278,7 +278,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = AnonymousUser()
         request.LANGUAGE_CODE = "en"
-        query_number = 13
+        query_number = 6
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)
@@ -295,7 +295,7 @@ class TestBuyersGuidePage(BuyersGuideTestCase):
         request = self.request_factory.get(self.bg.url)
         request.user = user
         request.LANGUAGE_CODE = "en"
-        query_number = 12
+        query_number = 6
 
         with self.assertNumQueries(query_number):
             self.bg.get_context(request=request)

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -217,7 +217,7 @@ class TestProductPageEvaluationPrefetching(BuyersGuideTestCase):
 
     def test_cant_get_total_creepiness_without_prefetching(self):
         evaluation = self.evaluation
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttributeError):
             evaluation.total_creepiness
 
     def test_total_creepiness_with_no_votes(self):
@@ -235,7 +235,7 @@ class TestProductPageEvaluationPrefetching(BuyersGuideTestCase):
 
     def test_cant_get_average_creepiness_without_prefetching(self):
         evaluation = self.evaluation
-        with self.assertRaises(ValueError):
+        with self.assertRaises(AttributeError):
             evaluation.average_creepiness
 
     def test_average_creepiness_with_no_votes(self):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
@@ -44,9 +44,8 @@ class TestProductPage(BuyersGuideTestCase):
         for _ in range(5):
             buyersguide_factories.ProductVoteFactory(value=90, evaluation=product_page.evaluation)
 
-        evaluation = product_page.evaluation
-        evaluation.refresh_from_db()
         product_page.refresh_from_db()
+        evaluation = product_page.annotated_evaluation
 
         self.assertEqual(evaluation.total_creepiness, 950)
         self.assertEqual(product_page.total_vote_count, 15)
@@ -516,7 +515,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
         self.assertEqual(response.status_code, 200)
 
         product_page.refresh_from_db()
-        evaluation = product_page.evaluation
+        evaluation = product_page.annotated_evaluation
 
         self.assertEqual(evaluation.total_votes, 1)
         self.assertEqual(evaluation.total_creepiness, 25)
@@ -534,7 +533,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
         self.assertEqual(response.status_code, 200)
 
         product_page.refresh_from_db()
-        evaluation = product_page.evaluation
+        evaluation = product_page.annotated_evaluation
 
         self.assertEqual(evaluation.total_votes, 2)
         self.assertEqual(evaluation.total_creepiness, 124)
@@ -563,7 +562,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
         self.assertEqual(response.status_code, 200)
 
         fr_product_page.refresh_from_db()
-        fr_evaluation = fr_product_page.evaluation
+        fr_evaluation = fr_product_page.annotated_evaluation
 
         self.assertEqual(fr_evaluation.total_votes, 1)
         self.assertEqual(fr_evaluation.total_creepiness, 25)
@@ -575,7 +574,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
         # so the data should be the same:
 
         product_page.refresh_from_db()
-        evaluation = product_page.evaluation
+        evaluation = product_page.annotated_evaluation
 
         self.assertEqual(evaluation.total_votes, 1)
         self.assertEqual(evaluation.total_creepiness, 25)
@@ -593,7 +592,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
         self.assertEqual(response.status_code, 200)
 
         product_page.refresh_from_db()
-        evaluation = product_page.evaluation
+        evaluation = product_page.annotated_evaluation
 
         self.assertEqual(evaluation.total_votes, 2)
         self.assertEqual(evaluation.total_creepiness, 124)
@@ -602,7 +601,7 @@ class WagtailBuyersGuideVoteTest(APITestCase, BuyersGuideTestCase):
         self.assertEqual(product_page.creepiness, 62)
 
         fr_product_page.refresh_from_db()
-        fr_evaluation = fr_product_page.evaluation
+        fr_evaluation = fr_product_page.annotated_evaluation
 
         self.assertEqual(fr_evaluation.total_votes, 2)
         self.assertEqual(fr_evaluation.total_creepiness, 124)


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Reduces the memory consumption on PNI's homepage by pre-calculating all product's creepiness on the database via an annotation. This way, we don't need to prefetch all vote objects (a significant number), which was causing an increase in memory usage.

Link to sample test page:
Related PRs/issues:

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
