### PR TITLE
[PNI] Fix categories tags

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/catalog.html
+++ b/network-api/networkapi/templates/pages/buyersguide/catalog.html
@@ -86,7 +86,7 @@
 
                         {% for cat in categories %}
                             {% with selected_classes="active tw-bg-gray-80 tw-text-white tw-border-gray-80" default_classes="hover:tw-border-blue-10 hover:tw-bg-blue-10 tw-text-gray-60 tw-border-gray-20 tw-bg-white" tailwind_classes="tw-no-underline border tw-px-4 tw-py-2 tw-font-sans tw-rounded-3xl tw-font-normal tw-text-[12px] tw-leading-[1.3] tw-whitespace-nowrap" %}
-                                {% if not cat.parent %}
+                                {% if cat.parent %}
                                     {% if cat.is_being_used %}
                                         {% routablepageurl home_page 'category-view' cat.slug as cat_url %}
                                         <a class="{% if current_category.name != cat.parent.name and current_category.parent.name != cat.parent.name %} tw-hidden {% endif %} subcategories {{ tailwind_classes }} {% if current_category.name == cat.name %}{{ selected_classes }}{% else %}{{ default_classes }}{% endif %}"


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Categories tags should show only "Privacy Not Included" on PNI homepage:
![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/59b8ccd9-4245-4e2a-ae60-873786b044e5)

A bug was introduced where all categories are now shown:
![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/1db6e72b-73ad-4733-b2cf-535882842c22)

This PR fixes that.

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
