### PR TITLE
[PNI] Fix bug with "people voted" label on product pages

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/average_vote_rating.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/average_vote_rating.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 
 <span class="tw-body-small">
-    {% with vote_data=product.votes.get_vote_average %}
+    {% with vote_data=product.average_bin %}
         <a class="tw-body-small" href="#creepiness-vote">{% trans "People voted:" %}</a>
-        <span class="people-voted {{ vote_data.label|slugify }}">{{ vote_data }}</span>
+        <span class="people-voted {{ vote_data.label|slugify }}">{{ vote_data.localized }}</span>
     {% endwith %}
 </span>

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -147,6 +147,9 @@ class TestProductPageEvaluation(BuyersGuideTestCase):
         self.assertEqual(evaluation.average_creepiness, 50)
         self.assertEqual(evaluation.total_creepiness, 250)
         self.assertEqual(evaluation.total_votes, 5)
+        self.assertDictEqual(
+            evaluation.average_bin, {"label": "A little creepy", "localized": gettext("A little creepy")}
+        )
 
     def test_creepiness_per_bin_limits(self):
         product_page = buyersguide_factories.ProductPageFactory(parent=self.bg)
@@ -189,6 +192,9 @@ class TestProductPageEvaluation(BuyersGuideTestCase):
         self.assertEqual(evaluation.average_creepiness, 49.5)
         self.assertEqual(evaluation.total_creepiness, 495)
         self.assertEqual(evaluation.total_votes, 10)
+        self.assertDictEqual(
+            evaluation.average_bin, {"label": "A little creepy", "localized": gettext("A little creepy")}
+        )
 
 
 class TestProductPageEvaluationPrefetching(BuyersGuideTestCase):


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Fix issue where "people voted" section is not showing any info.

Fixed:
![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/379c13b8-3152-4806-842f-530a06f965c9)


Link to sample test page:
Related PRs/issues: #11387 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [X] Is my code documented?
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
