### PR TITLE
added donate help page title as translatable field

### DIFF
--- a/network-api/networkapi/donate/pagemodels/help_page.py
+++ b/network-api/networkapi/donate/pagemodels/help_page.py
@@ -40,6 +40,7 @@ class DonateHelpPage(BaseDonationPage):
         TranslatableField("search_description"),
         SynchronizedField("search_image"),
         # Content tab fields
+        TranslatableField("title"),
         TranslatableField("notice"),
         TranslatableField("body"),
     ]


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Related PRs/issues: #11447

This PR updates the DonateHelpPage model to include the page's `title` as a translatable field.
