### PR TITLE
localized DonateHelpPage recaptcha box

### DIFF
--- a/network-api/networkapi/templates/donate/fragments/formassembly_head.html
+++ b/network-api/networkapi/templates/donate/fragments/formassembly_head.html
@@ -18,6 +18,9 @@ Please follow the steps below every time after you paste a new version of FormAs
     - Update script file name https://mozillafoundation.tfaforms.net/wForms/3.11/js/localization-en_US.js?v=...
         with {% fa_locale_code %}
         e.g., https://mozillafoundation.tfaforms.net/wForms/3.11/js/localization-{% fa_locale_code %}.js?v=...
+    - Update script file name https://www.google.com/recaptcha/enterprise.js?onload=gCaptchaReadyCallback&render=explicit&hl=en_US...
+        with {{ LANGUAGE_CODE }}
+        e.g., https://www.google.com/recaptcha/enterprise.js?onload=gCaptchaReadyCallback&render=explicit&hl={{ LANGUAGE_CODE }}...
     - Go to formassembly_body.html and make sure everything has been updated according to the instructions
 
 5. Update the revision note on the next line. Revision number can be found on https://mozillafoundation.tfaforms.net/versions/index/12
@@ -156,7 +159,7 @@ The code snippet below is based on FormAssembly form revision #45
         }
     }
 </script>
-<script src='https://www.google.com/recaptcha/enterprise.js?onload=gCaptchaReadyCallback&render=explicit&hl=en_US' nonce="{{ request.csp_nonce }}" async
+<script src='https://www.google.com/recaptcha/enterprise.js?onload=gCaptchaReadyCallback&render=explicit&hl={{ LANGUAGE_CODE }}' nonce="{{ request.csp_nonce }}" async
         defer></script>
 <script type="text/javascript" nonce="{{ request.csp_nonce }}">
     document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues: #11448


This PR updates the `src` of the script `<script src='https://www.google.com/recaptcha/enterprise.js?onload=gCaptchaReadyCallback&render=explicit&hl=en_US' nonce="{{ request.csp_nonce }}" async defer></script>` to include `hl={{ LANGUAGE_CODE }}` instead of being hardcoded to `en_US`. That way the recaptcha box renders with the users active locale.


# Screenshots

EN (English):
<img width="1304" alt="Screenshot 2023-11-20 at 3 38 41 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/b009fe84-c78a-4678-8aae-f2660d86d983">


ES (Spanish):
<img width="1304" alt="Screenshot 2023-11-20 at 3 38 53 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/460977b5-fa85-4e2f-8e27-540acf13954e">

DE (German):
<img width="1304" alt="Screenshot 2023-11-20 at 3 39 10 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/20daab49-7af7-4b98-abb3-bccb32fa6134">

FR (French):
<img width="1304" alt="Screenshot 2023-11-20 at 3 39 22 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/8d77bb63-9405-46fa-abb0-50e24df74958">

fy-NL (Frisian):
<img width="1304" alt="Screenshot 2023-11-20 at 3 39 40 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/8f54490f-7e27-43f1-b952-eedc3ca37911">

NL (Dutch):
<img width="1304" alt="Screenshot 2023-11-20 at 3 39 54 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/f0af626b-a501-47eb-835c-70c2e0ef192f">

PL (Polish):
<img width="1304" alt="Screenshot 2023-11-20 at 3 40 08 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/79db9aec-0ec9-4dd0-ac6f-513e70ad478a">

pt-BR (Portuguese (Brazil)):
<img width="1304" alt="Screenshot 2023-11-20 at 3 40 24 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/96e847f5-f97f-4208-97f2-250c54ba34ae">

SW (Swahili):
<img width="1304" alt="Screenshot 2023-11-20 at 3 40 38 PM" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/3b10580d-1ca2-4bb5-85e0-f4e7ca2d1a4a">
