### PR TITLE
Revert "Bump django-storages from 1.13.2 to 1.14.2 (#11228)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ django-querystring-tag==1.0.3
     # via -r requirements.in
 django-redis==5.4.0
     # via -r requirements.in
-django-storages==1.14.2
+django-storages==1.13.2
     # via -r requirements.in
 django-taggit==2.1.0
     # via wagtail


### PR DESCRIPTION
This reverts commit 06f8bfb30fc010687afb0623914dc37e8a0eec68.
