### PR TITLE
[TEST PR] - added donate landing and help page to percy list

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -37,7 +37,7 @@ jobs:
       CSP_MEDIA_SRC: " 'self' data: https://s3.amazonaws.com/mofo-assets/foundation/video/ "
       CSP_SCRIPT_SRC: " 'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com https://js.tito.io https://js-plugins.tito.io/gtm.js https://tagmanager.google.com *.googletagmanager.com https://*.fundraiseup.com https://mozillafoundation.tfaforms.net https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-eval'"
       CSP_STYLE_SRC: " 'self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com https://platform.twitter.com https://js.tito.io https://tagmanager.google.com https://mozillafoundation.tfaforms.net https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
-      CSP_INCLUDE_NONCE_IN: script-src
+      CSP_INCLUDE_NONCE_IN: "script-src"
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/network
       DEBUG: True
       DJANGO_SECRET_KEY: secret

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -27,6 +27,8 @@ jobs:
       ALLOWED_HOSTS: 127.0.0.1,localhost,mozfest.localhost,default-site.com,secondary-site.com
       CONTENT_TYPE_NO_SNIFF: True
       CORS_ALLOWED_ORIGINS: "*"
+      CSP_FRAME_SRC: " 'self' https://www.youtube.com https://comments.mozillafoundation.org/ https://airtable.com https://docs.google.com/ https://platform.twitter.com https://public.zenkit.com https://calendar.google.com https://www.youtube-nocookie.com https://form.typeform.com https://js.tito.io https://datawrapper.dwcdn.net https://www.google.com/recaptcha/"
+      CSP_SCRIPT_SRC: " 'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com https://js.tito.io https://js-plugins.tito.io/gtm.js https://tagmanager.google.com *.googletagmanager.com https://*.fundraiseup.com https://mozillafoundation.tfaforms.net https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-eval' *****TEST******"
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/network
       DEBUG: True
       DJANGO_SECRET_KEY: secret

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -37,6 +37,7 @@ jobs:
       CSP_MEDIA_SRC: " 'self' data: https://s3.amazonaws.com/mofo-assets/foundation/video/ "
       CSP_SCRIPT_SRC: " 'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com https://js.tito.io https://js-plugins.tito.io/gtm.js https://tagmanager.google.com *.googletagmanager.com https://*.fundraiseup.com https://mozillafoundation.tfaforms.net https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-eval'"
       CSP_STYLE_SRC: " 'self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com https://platform.twitter.com https://js.tito.io https://tagmanager.google.com https://mozillafoundation.tfaforms.net https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      CSP_INCLUDE_NONCE_IN: script-src
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/network
       DEBUG: True
       DJANGO_SECRET_KEY: secret

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -27,8 +27,16 @@ jobs:
       ALLOWED_HOSTS: 127.0.0.1,localhost,mozfest.localhost,default-site.com,secondary-site.com
       CONTENT_TYPE_NO_SNIFF: True
       CORS_ALLOWED_ORIGINS: "*"
+      CSP_CHILD_SRC: " 'self' https://www.youtube.com https://www.youtube-nocookie.com "
+      CSP_CONNECT_SRC: " * "
+      CSP_DEFAULT_SRC: " 'none' "
+      CSP_FONT_SRC: " 'self' data: https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net https://static.fundraiseup.com/fonts/ https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/fonts/"
+      CSP_FRAME_ANCESTORS: " 'none' "
       CSP_FRAME_SRC: " 'self' https://www.youtube.com https://comments.mozillafoundation.org/ https://airtable.com https://docs.google.com/ https://platform.twitter.com https://public.zenkit.com https://calendar.google.com https://www.youtube-nocookie.com https://form.typeform.com https://js.tito.io https://datawrapper.dwcdn.net https://www.google.com/recaptcha/"
-      CSP_SCRIPT_SRC: " 'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com https://js.tito.io https://js-plugins.tito.io/gtm.js https://tagmanager.google.com *.googletagmanager.com https://*.fundraiseup.com https://mozillafoundation.tfaforms.net https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-eval' *****TEST******"
+      CSP_IMG_SRC: " * data: "
+      CSP_MEDIA_SRC: " 'self' data: https://s3.amazonaws.com/mofo-assets/foundation/video/ "
+      CSP_SCRIPT_SRC: " 'self' 'unsafe-inline' https://www.google-analytics.com/analytics.js http://*.shpg.org/ https://comments.mozillafoundation.org/ https://airtable.com https://platform.twitter.com https://cdn.syndication.twimg.com https://embed.typeform.com https://js.tito.io https://js-plugins.tito.io/gtm.js https://tagmanager.google.com *.googletagmanager.com https://*.fundraiseup.com https://mozillafoundation.tfaforms.net https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/ 'unsafe-eval'"
+      CSP_STYLE_SRC: " 'self' 'unsafe-inline' https://code.cdn.mozilla.net https://fonts.googleapis.com https://platform.twitter.com https://js.tito.io https://tagmanager.google.com https://mozillafoundation.tfaforms.net https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/network
       DEBUG: True
       DJANGO_SECRET_KEY: secret

--- a/tests/foundation-urls.js
+++ b/tests/foundation-urls.js
@@ -21,6 +21,8 @@ module.exports = {
     "/publication-page-with-chapter-pages/fixed-title-chapter-page",
   "Article page":
     "/publication-page-with-chapter-pages/fixed-title-chapter-page/fixed-title-article-page",
+  Donate: "/donate",
+  "Donate Help": "/donate/help",
   PNI: "/privacynotincluded",
   "PNI (filtered for category)": "/privacynotincluded/categories/toys-games",
   "PNI general product page": "/privacynotincluded/general-percy-product",


### PR DESCRIPTION
This PR was used to trouble shoot issues that we were having with percy not showing recaptcha or fundraise up forms.

Due to the troubleshooting of the percy issue, github experiencing issues with PR merging, and rebasing to `2023-eoy` on account of the code freeze, this PR has become quite messy and hard to follow.

So I have created https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11595 to house the actual fix in its place.