### PR TITLE
Enable python parallel tests 

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Run type checks
         run: mypy network-api
       - name: Run Tests
-        run: cd network-api && pytest  --ds=networkapi.settings -cov=network-api/networkapi --cov-report=term-missing
+        run: cd network-api && pytest -n auto -v --ds=networkapi.settings -cov=network-api/networkapi --cov-report=term-missing
       - name: Coveralls
         run: coveralls
         continue-on-error: true

--- a/network-api/networkapi/wagtailpages/tests/base.py
+++ b/network-api/networkapi/wagtailpages/tests/base.py
@@ -37,6 +37,7 @@ class WagtailpagesTestCase(wagtail_test.WagtailPageTestCase):
         assert cls.fr_locale != cls.default_locale
 
     def setUp(self):
+        super().setUp()
         self.activate_locale(self.default_locale)
 
     def synchronize_tree(self):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -378,14 +378,6 @@ class TestProductPageEvaluationPrefetching(BuyersGuideTestCase):
 
 
 class CreateEvaluationPostSaveSignalTests(BuyersGuideTestCase):
-    @classmethod
-    def setUpTestData(cls):
-        # Override BuyersGuidePage.subpage_types to include ProductPage
-        # If we don't, the copy page action will fail with a Permission Error
-        # since we can't add a ProductPage as a child of BuyersGuidePage
-        BuyersGuidePage.subpage_types += ["wagtailpages.ProductPage"]
-        super().setUpTestData()
-
     def setUp(self):
         super().setUp()
         self.user = self.login()

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -1,4 +1,4 @@
-from unittest import expectedFailure
+from unittest.mock import patch, MagicMock
 
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -8,6 +8,7 @@ from wagtail import hooks
 from networkapi.wagtailpages.factory import buyersguide as buyersguide_factories
 from networkapi.wagtailpages.pagemodels.buyersguide.homepage import BuyersGuidePage
 from networkapi.wagtailpages.pagemodels.buyersguide.products import (
+    ProductPage,
     ProductPageEvaluation,
     reset_product_page_votes,
 )
@@ -435,8 +436,24 @@ class CreateEvaluationPostSaveSignalTests(BuyersGuideTestCase):
         product_page.refresh_from_db()
         self.assertEqual(product_page.evaluation, evaluation)
 
-    @expectedFailure
+# This is a bit weird, but somewhere along the copy page action 
+# the GeneralProductPage.specific_class is being resolved
+# to ProductPage, which is not allowed as a child of BuyersGuidePage.
+# Thus, we need to mock the subpage_types and allowed_subpage_models to allow for
+# ProductPage to be added as a child of BuyersGuidePage. If we don't, the
+# copy page action will fail with a Permission Error since we can't add a
+# ProductPage as a child of BuyersGuidePage. 
+MOCK_BG_SUBPAGE_TYPES = BuyersGuidePage.subpage_types + ["wagtailpages.ProductPage"]
+MOCK_BG_ALLOWED_SUBPAGE_MODELS = BuyersGuidePage.allowed_subpage_models() + [ProductPage]
+
+
+class CreateEvaluationPostSaveSignalTests(BuyersGuideTestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.login()
+
     @hooks.register_temporarily("after_copy_page", reset_product_page_votes)
+    @patch.multiple(BuyersGuidePage, subpage_types=MagicMock(return_value=MOCK_BG_SUBPAGE_TYPES), allowed_subpage_models=MagicMock(return_value=MOCK_BG_ALLOWED_SUBPAGE_MODELS))
     def test_that_copied_page_gets_evaluation(self):
         product_page = buyersguide_factories.GeneralProductPageFactory(
             parent=self.bg, title="My Product", slug="my-product"

--- a/network-api/networkapi/wagtailpages/tests/libraries/rcc/base.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/rcc/base.py
@@ -55,4 +55,5 @@ class RCCTestCase(test_base.WagtailpagesTestCase):
         )
 
     def setUp(self):
+        super().setUp()
         self.synchronize_tree()

--- a/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_library_page.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/rcc/test_library_page.py
@@ -24,7 +24,7 @@ class TestRCCLibraryPage(rcc_test_base.RCCTestCase):
         with open(os.devnull, "w") as f:
             management.call_command("update_index", verbosity=0, stdout=f)
 
-    def testget_sorted_filtered_detail_pages(self):
+    def test_get_sorted_filtered_detail_pages(self):
         detail_page_1 = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
         )
@@ -38,7 +38,7 @@ class TestRCCLibraryPage(rcc_test_base.RCCTestCase):
         self.assertIn(detail_page_1, rcc_detail_pages)
         self.assertIn(detail_page_2, rcc_detail_pages)
 
-    def testget_sorted_filtered_detail_pages_with_translation_aliases(self):
+    def test_get_sorted_filtered_detail_pages_with_translation_aliases(self):
         detail_page_1 = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
         )

--- a/network-api/networkapi/wagtailpages/tests/libraries/research_hub/base.py
+++ b/network-api/networkapi/wagtailpages/tests/libraries/research_hub/base.py
@@ -54,5 +54,6 @@ class ResearchHubTestCase(test_base.WagtailpagesTestCase):
         )
 
     def setUp(self):
+        super().setUp()
         self.synchronize_tree()
         self.activate_locale(self.default_locale)

--- a/tasks.py
+++ b/tasks.py
@@ -308,11 +308,13 @@ def makemigrations_dryrun(ctx, args=""):
 @task(aliases=["docker-test"])
 def test(ctx):
     """Run tests."""
+    djcheck(ctx)
+    makemigrations_dryrun(ctx, args="--check")
     test_python(ctx)
 
 
 @task(aliases=["docker-test-python"])
-def test_python(ctx, file="", n="1", verbose=False):
+def test_python(ctx, file="", n="auto", verbose=False):
     """
     Run python tests.
 
@@ -328,9 +330,6 @@ def test_python(ctx, file="", n="1", verbose=False):
     Default is 'auto' which allows pytest to automatically determine the optimal number.
     - verbose: Optional boolean flag indicating whether to print verbose output during testing. Default is False.
     """
-
-    djcheck(ctx)
-    makemigrations_dryrun(ctx, args="--check")
     parallel = f"-n {n}" if n != "1" else ""
     v = "-v" if verbose else ""
     # Don't run coverage if a file is specified


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Parallel python testing has been disabled because the RCC and Research Hub library page tests were failing when running in parallel mode.

This PR fixes the issues with those tests and re-enables parallel python testing for the repo.

Link to sample test page:
Related PRs/issues: #10597

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
