### PR TITLE
5225 MozFest Stats block

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_stats_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_stats_block.html
@@ -1,0 +1,16 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% block block_content %}
+    <div class="tw-bg-black tw-dark tw-py-16">
+        <div class="tw-container">
+            <div class="tw-row">
+                {% for stat in self.stats %}
+                    <div class="tw-mb-12 tw-px-8 tw-w-1/2 large:tw-w-1/4">
+                        <p class="tw-h1-heading tw-mb-0">{{ stat.number }}</p>
+                        <p class="tw-my-0">{{ stat.text }}</p>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+{% endblock block_content %}


### PR DESCRIPTION
# Description

- Changes the mozfest base template to a single column layout 
- Adds a dark themed stats block - this does not extend the `base_streamfield_block.html` as that restricts the width of the it using the container class whereas the stats need to be full width
- BE will be implemented in future work

Desktop/Tablet/Mobile screens:

<details><summary>Details</summary>
<p>

![Screenshot 2023-12-12 at 12 36 20](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/3b4b2b5e-dd65-4056-ba69-1b1acc8660bc)

![Screenshot 2023-12-12 at 12 36 28](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/ea59faa4-115c-47be-a43b-5cfe45931894)

![Screenshot 2023-12-12 at 12 36 34](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/97ff53fa-6aeb-4aad-bbe9-010a7e021f0a)


</p>
</details> 

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
