### PR TITLE
Fix PNI average bin calc

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -421,7 +421,7 @@ class ProductPageEvaluation(models.Model):
             }
 
         average_vote = self.average_creepiness
-        mode_bin = round(average_vote / 20) - 1
+        mode_bin = int(average_vote // 20)
         label = self.BIN_LABELS[f"bin_{mode_bin}"]
 
         return {

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -310,6 +310,8 @@ class ProductPageEvaluation(models.Model):
         "bin_4": {"key": "Super creepy", "label": gettext_lazy("Super creepy")},
     }
 
+    BIN_SIZE = 20
+
     objects = ProductPageEvaluationQuerySet.as_manager()
 
     @property
@@ -421,7 +423,7 @@ class ProductPageEvaluation(models.Model):
             }
 
         average_vote = self.average_creepiness
-        mode_bin = int(average_vote // 20)
+        mode_bin = int(average_vote // self.BIN_SIZE)
         label = self.BIN_LABELS[f"bin_{mode_bin}"]
 
         return {

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -230,7 +230,7 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         self.assertEqual(evaluation.average_creepiness, 0)
         self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
 
-    def test_avg_bin_with_avg_vote_between_0_and_20(self):
+    def test_avg_bin_with_avg_vote_between_1_and_20(self):
         vote_value = self.fake.random_int(min=1, max=19)
         buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=vote_value)
         evaluation = (

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -225,8 +225,6 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         )
 
         self.assertEqual(evaluation.average_creepiness, 0)
-        mode_bin = round(evaluation.average_creepiness // 20)
-        print(f"Mode bin: {mode_bin}")
         self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
 
     def test_avg_bin_with_avg_vote_between_0_and_20(self):
@@ -239,8 +237,6 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         )
 
         self.assertEqual(evaluation.average_creepiness, 10)
-        mode_bin = round(evaluation.average_creepiness // 20)
-        print(f"Mode bin: {mode_bin}")
         self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
 
     def test_avg_bin_with_avg_vote_between_20_and_40(self):
@@ -253,8 +249,6 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         )
 
         self.assertEqual(evaluation.average_creepiness, 30)
-        mode_bin = round(evaluation.average_creepiness // 20)
-        print(f"Mode bin: {mode_bin}")
         self.assertDictEqual(
             evaluation.average_bin, {"label": "A little creepy", "localized": gettext("A little creepy")}
         )
@@ -269,8 +263,6 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         )
 
         self.assertEqual(evaluation.average_creepiness, 50)
-        mode_bin = round(evaluation.average_creepiness // 20)
-        print(f"Mode bin: {mode_bin}")
         self.assertDictEqual(
             evaluation.average_bin, {"label": "Somewhat creepy", "localized": gettext("Somewhat creepy")}
         )
@@ -285,8 +277,6 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         )
 
         self.assertEqual(evaluation.average_creepiness, 70)
-        mode_bin = round(evaluation.average_creepiness // 20)
-        print(f"Mode bin: {mode_bin}")
         self.assertDictEqual(evaluation.average_bin, {"label": "Very creepy", "localized": gettext("Very creepy")})
 
     def test_avg_bin_with_avg_vote_between_80_and_100(self):
@@ -299,8 +289,6 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         )
 
         self.assertEqual(evaluation.average_creepiness, 90)
-        mode_bin = round(evaluation.average_creepiness // 20)
-        print(f"Mode bin: {mode_bin}")
         self.assertDictEqual(evaluation.average_bin, {"label": "Super creepy", "localized": gettext("Super creepy")})
 
 

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -148,7 +148,7 @@ class TestProductPageEvaluation(BuyersGuideTestCase):
         self.assertEqual(evaluation.total_creepiness, 250)
         self.assertEqual(evaluation.total_votes, 5)
         self.assertDictEqual(
-            evaluation.average_bin, {"label": "A little creepy", "localized": gettext("A little creepy")}
+            evaluation.average_bin, {"label": "Somewhat creepy", "localized": gettext("Somewhat creepy")}
         )
 
     def test_creepiness_per_bin_limits(self):
@@ -193,8 +193,115 @@ class TestProductPageEvaluation(BuyersGuideTestCase):
         self.assertEqual(evaluation.total_creepiness, 495)
         self.assertEqual(evaluation.total_votes, 10)
         self.assertDictEqual(
+            evaluation.average_bin, {"label": "Somewhat creepy", "localized": gettext("Somewhat creepy")}
+        )
+
+
+class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
+    def setUp(self):
+        super().setUp()
+        self.admin_user = self.create_superuser(username="admin", password="password")
+        self.login(self.admin_user)
+        self.product_page = buyersguide_factories.ProductPageFactory(parent=self.bg)
+
+    def test_avg_bin_with_no_votes(self):
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.total_votes, 0)
+        self.assertDictEqual(evaluation.average_bin, {"label": "No votes", "localized": gettext("No votes")})
+
+    def test_avg_bin_with_avg_vote_equal_0(self):
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=0)
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.average_creepiness, 0)
+        mode_bin = round(evaluation.average_creepiness // 20)
+        print(f"Mode bin: {mode_bin}")
+        self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
+
+    def test_avg_bin_with_avg_vote_between_0_and_20(self):
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=10)
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.average_creepiness, 10)
+        mode_bin = round(evaluation.average_creepiness // 20)
+        print(f"Mode bin: {mode_bin}")
+        self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
+
+    def test_avg_bin_with_avg_vote_between_20_and_40(self):
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=30)
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.average_creepiness, 30)
+        mode_bin = round(evaluation.average_creepiness // 20)
+        print(f"Mode bin: {mode_bin}")
+        self.assertDictEqual(
             evaluation.average_bin, {"label": "A little creepy", "localized": gettext("A little creepy")}
         )
+
+    def test_avg_bin_with_avg_vote_between_40_and_60(self):
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=50)
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.average_creepiness, 50)
+        mode_bin = round(evaluation.average_creepiness // 20)
+        print(f"Mode bin: {mode_bin}")
+        self.assertDictEqual(
+            evaluation.average_bin, {"label": "Somewhat creepy", "localized": gettext("Somewhat creepy")}
+        )
+
+    def test_avg_bin_with_avg_vote_between_60_and_80(self):
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=70)
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.average_creepiness, 70)
+        mode_bin = round(evaluation.average_creepiness // 20)
+        print(f"Mode bin: {mode_bin}")
+        self.assertDictEqual(evaluation.average_bin, {"label": "Very creepy", "localized": gettext("Very creepy")})
+
+    def test_avg_bin_with_avg_vote_between_80_and_100(self):
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=90)
+        evaluation = (
+            ProductPageEvaluation.objects.with_total_votes()
+            .with_total_creepiness()
+            .with_average_creepiness()
+            .get(pk=self.product_page.evaluation.pk)
+        )
+
+        self.assertEqual(evaluation.average_creepiness, 90)
+        mode_bin = round(evaluation.average_creepiness // 20)
+        print(f"Mode bin: {mode_bin}")
+        self.assertDictEqual(evaluation.average_bin, {"label": "Super creepy", "localized": gettext("Super creepy")})
 
 
 class TestProductPageEvaluationPrefetching(BuyersGuideTestCase):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_product_page_evaluation.py
@@ -2,6 +2,7 @@ from unittest import expectedFailure
 
 from django.urls import reverse
 from django.utils.translation import gettext
+from faker import Faker
 from wagtail import hooks
 
 from networkapi.wagtailpages.factory import buyersguide as buyersguide_factories
@@ -203,6 +204,8 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         self.admin_user = self.create_superuser(username="admin", password="password")
         self.login(self.admin_user)
         self.product_page = buyersguide_factories.ProductPageFactory(parent=self.bg)
+        self.fake = Faker()
+        Faker.seed(0)
 
     def test_avg_bin_with_no_votes(self):
         evaluation = (
@@ -228,7 +231,8 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
         self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
 
     def test_avg_bin_with_avg_vote_between_0_and_20(self):
-        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=10)
+        vote_value = self.fake.random_int(min=1, max=19)
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=vote_value)
         evaluation = (
             ProductPageEvaluation.objects.with_total_votes()
             .with_total_creepiness()
@@ -236,11 +240,12 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
             .get(pk=self.product_page.evaluation.pk)
         )
 
-        self.assertEqual(evaluation.average_creepiness, 10)
+        self.assertEqual(evaluation.average_creepiness, vote_value)
         self.assertDictEqual(evaluation.average_bin, {"label": "Not creepy", "localized": gettext("Not creepy")})
 
     def test_avg_bin_with_avg_vote_between_20_and_40(self):
-        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=30)
+        vote_value = self.fake.random_int(min=20, max=39)
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=vote_value)
         evaluation = (
             ProductPageEvaluation.objects.with_total_votes()
             .with_total_creepiness()
@@ -248,13 +253,14 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
             .get(pk=self.product_page.evaluation.pk)
         )
 
-        self.assertEqual(evaluation.average_creepiness, 30)
+        self.assertEqual(evaluation.average_creepiness, vote_value)
         self.assertDictEqual(
             evaluation.average_bin, {"label": "A little creepy", "localized": gettext("A little creepy")}
         )
 
     def test_avg_bin_with_avg_vote_between_40_and_60(self):
-        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=50)
+        vote_value = self.fake.random_int(min=40, max=59)
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=vote_value)
         evaluation = (
             ProductPageEvaluation.objects.with_total_votes()
             .with_total_creepiness()
@@ -262,13 +268,14 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
             .get(pk=self.product_page.evaluation.pk)
         )
 
-        self.assertEqual(evaluation.average_creepiness, 50)
+        self.assertEqual(evaluation.average_creepiness, vote_value)
         self.assertDictEqual(
             evaluation.average_bin, {"label": "Somewhat creepy", "localized": gettext("Somewhat creepy")}
         )
 
     def test_avg_bin_with_avg_vote_between_60_and_80(self):
-        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=70)
+        vote_value = self.fake.random_int(min=60, max=79)
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=vote_value)
         evaluation = (
             ProductPageEvaluation.objects.with_total_votes()
             .with_total_creepiness()
@@ -276,11 +283,12 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
             .get(pk=self.product_page.evaluation.pk)
         )
 
-        self.assertEqual(evaluation.average_creepiness, 70)
+        self.assertEqual(evaluation.average_creepiness, vote_value)
         self.assertDictEqual(evaluation.average_bin, {"label": "Very creepy", "localized": gettext("Very creepy")})
 
     def test_avg_bin_with_avg_vote_between_80_and_100(self):
-        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=90)
+        vote_value = self.fake.random_int(min=80, max=100)
+        buyersguide_factories.ProductVoteFactory(evaluation=self.product_page.evaluation, value=vote_value)
         evaluation = (
             ProductPageEvaluation.objects.with_total_votes()
             .with_total_creepiness()
@@ -288,7 +296,7 @@ class TestProductPageEvaluationAverageBin(BuyersGuideTestCase):
             .get(pk=self.product_page.evaluation.pk)
         )
 
-        self.assertEqual(evaluation.average_creepiness, 90)
+        self.assertEqual(evaluation.average_creepiness, vote_value)
         self.assertDictEqual(evaluation.average_bin, {"label": "Super creepy", "localized": gettext("Super creepy")})
 
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Average bin calculation was using round instead of flooring and off-by-one. This gave the wrong labels for "people voted" and would cause `KeyError`s if the average vote was less than 20.

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
