### PR TITLE
6650 - MozFest Dark Quote

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_dark_quote.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_dark_quote.html
@@ -4,12 +4,12 @@
     <div class="tw-py-16 tw-bg-black tw-dark">
         <div class="tw-container">
             <div class="tw-row tw-justify-center">
-                <blockquote class="feature-quote">
-                    <div class="tw-quote tw-px-2 [&_p]:tw-h2-heading">
+                <div class="feature-quote">
+                    <div class="quote-content [&_p]:tw-text-white">
                         {{ self.quote|richtext }}
                     </div>
-                    <cite class="tw-text-gray-40 tw-h6-heading tw-max-w-4xl">{{ self.cite }}</cite>
-                </blockquote>
+                    <p class="tw-text-gray-40 tw-h6-heading tw-text-lg tw-max-w-4xl">{{ self.cite }}</p>
+                </div>
             </div>
         </div>
     </div>

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_dark_quote.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_dark_quote.html
@@ -1,0 +1,16 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% block block_content %}
+    <div class="tw-py-16 tw-bg-black tw-dark">
+        <div class="tw-container">
+            <div class="tw-row tw-justify-center">
+                <blockquote class="feature-quote">
+                    <div class="tw-quote tw-px-2 [&_p]:tw-h2-heading">
+                        {{ self.quote|richtext }}
+                    </div>
+                    <cite class="tw-text-gray-40 tw-h6-heading tw-max-w-4xl">{{ self.cite }}</cite>
+                </blockquote>
+            </div>
+        </div>
+    </div>
+{% endblock block_content %}

--- a/source/sass/wagtail/blocks/feature-quote.scss
+++ b/source/sass/wagtail/blocks/feature-quote.scss
@@ -18,6 +18,10 @@
     content: "";
     display: block;
     margin: 0 auto 10px;
+
+    @at-root .tw-dark & {
+      opacity: 0.3;
+    }
   }
 
   .quote-content .rich-text {


### PR DESCRIPTION
# Description

- Changes the mozfest-base template to have one column
- Adds the `mozfest_dark_quote.html` template
- BE work to integrate this is to come

Desktop/Tablet/Mobile screens 

<details><summary>Details</summary>
<p>

![Screenshot 2023-12-13 at 14 03 10](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/6b4fb801-ba4a-4577-8b1c-a4596323f640)

![Screenshot 2023-12-13 at 14 03 19](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/5a91f22c-aa76-4935-9fce-35b21b2fc268)

![Screenshot 2023-12-13 at 14 03 51](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/d6672626-e46d-4091-974f-7e798ebba312)


</p>
</details> 

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
