### PR TITLE
8161 - MozFest CTA Block

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_cta_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_cta_block.html
@@ -1,0 +1,17 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% block block_content %}
+    <div class="tw-py-16 tw-dark{% if self.dark_background %} tw-bg-black{% endif %}">
+        <div class="tw-container">
+            <div class="tw-row">
+                <div class="tw-bg-blue-40 tw-w-full tw-p-8 tw-mx-8 medium:tw-flex medium:tw-items-center medium:tw-justify-between medium:tw-py-12 medium:tw-px-24">
+                    <div class="medium:tw-max-w-[50%]">
+                        <h2 class="tw-h3-heading">{{ self.title }}</h2>
+                        <p class="tw-mt-0 medium:tw-m-0">{{ self.text }}</p>
+                    </div>
+                    <a class="tw-btn-secondary" href="{{ self.link_url }}">{{ self.link_text }}</a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock block_content %}

--- a/network-api/networkapi/mozfest/templates/partials/primary_hero.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_hero.html
@@ -2,7 +2,7 @@
 
 {% image page.banner fill-1500x620 as hero_image %}
 <div class="tw-relative tw-dark tw-w-full tw-h-[470px] large:tw-h-[620px] tw-bg-center tw-bg-cover" style="background-image:url('{{ hero_image.url }}')">
-    <div class="tw-bg-gradient-to-t tw-from-black tw-via-black tw-via-30% tw-to-festival-purple-200 tw-inset-0 tw-absolute tw-opacity-80"></div>
+    <div class="tw-bg-gradient-to-t tw-from-black tw-via-black tw-via-30% tw-to-festival-purple-200 tw-inset-0 tw-absolute tw-opacity-90"></div>
     <div class="tw-container">
         <div class="tw-row">
             <div class="tw-px-8 tw-absolute tw-w-full tw-bottom-12 tw-max-w-xl large:tw-bottom-24">


### PR DESCRIPTION
# Description

- Adds a template for the CTA block which can either be on a light or dark background.
- Tweak the opacity of the hero gradient so the transition between dark blocks is more seamless (previously you could see the line where the following block started)

This was decided to be new block instead of re-use because: 

> There is an existing CTA Card in Blog Pages, however that already contains three designs, adding an additional two (one for in page and another for in the dark text section) deviates enough for this to be new and only for MozFest.

Desktop/Tablet/Mobile:

<details><summary>Details</summary>
<p>

![Screenshot 2023-12-14 at 11 13 16](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/59a69283-3c51-4ebd-9777-444ced2892c3)

![Screenshot 2023-12-14 at 11 13 21](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/85eaf68d-b6f6-4993-8bdb-883c7f550997)

![Screenshot 2023-12-14 at 11 13 29](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/eb80d647-a497-444f-b1df-efc267828e12)


</p>
</details> 

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
