### PR TITLE
Drop 'block' from naming convention

### DIFF
--- a/network-api/networkapi/mozfest/blocks/stats_block.py
+++ b/network-api/networkapi/mozfest/blocks/stats_block.py
@@ -12,4 +12,4 @@ class StatisticsBlock(blocks.StructBlock):
     class Meta:
         icon = "placeholder"
         template = "fragments/blocks/stats_block.html"
-        label = "Stats Block"
+        label = "Statistics"

--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -10,7 +10,7 @@ from networkapi.utility.faker.helpers import reseed
 from networkapi.wagtailpages.factory.image_factory import ImageFactory
 from networkapi.wagtailpages.factory.signup import SignupFactory
 
-streamfield_fields = ["paragraph", "image", "spacer", "quote", "stats_block", "listing"]
+streamfield_fields = ["paragraph", "image", "spacer", "quote", "statistics", "listing"]
 
 Faker.add_provider(StreamfieldProvider)
 

--- a/network-api/networkapi/mozfest/migrations/0031_adds_stats_block.py
+++ b/network-api/networkapi/mozfest/migrations/0031_adds_stats_block.py
@@ -1609,7 +1609,7 @@ class Migration(migrations.Migration):
                         ),
                     ),
                     (
-                        "stats_block",
+                        "statistics",
                         wagtail.blocks.StructBlock(
                             [
                                 (

--- a/network-api/networkapi/mozfest/migrations/0032_adds_meta_fields_to_listing_block.py
+++ b/network-api/networkapi/mozfest/migrations/0032_adds_meta_fields_to_listing_block.py
@@ -1648,7 +1648,7 @@ class Migration(migrations.Migration):
                         ),
                     ),
                     (
-                        "stats_block",
+                        "statistics",
                         wagtail.blocks.StructBlock(
                             [
                                 (

--- a/network-api/networkapi/mozfest/models.py
+++ b/network-api/networkapi/mozfest/models.py
@@ -52,7 +52,7 @@ class MozfestPrimaryPage(FoundationMetadataPageMixin, FoundationBannerInheritanc
             ("tito_widget", customblocks.TitoWidgetBlock()),
             ("tabbed_profile_directory", customblocks.TabbedProfileDirectory()),
             ("newsletter_signup", customblocks.NewsletterSignupBlock()),
-            ("stats_block", mozfest_blocks.StatisticsBlock()),
+            ("statistics", mozfest_blocks.StatisticsBlock()),
         ],
         use_json_field=True,
     )

--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -291,7 +291,7 @@ def generate_stats_block_field():
             }
         )
 
-    return generate_field("stats_block", {"statistics": statistics})
+    return generate_field("statistics", {"statistics": statistics})
 
 
 def generate_pulse_listing_field():
@@ -545,7 +545,7 @@ class StreamfieldProvider(BaseProvider):
             "current_events_slider": generate_current_events_slider_field,
             "callout_box": generate_blog_index_callout_box_field,
             "blog_newsletter_signup": generate_blog_newsletter_signup_field,
-            "stats_block": generate_stats_block_field,
+            "statistics": generate_stats_block_field,
             "listing": generate_listing_block_field,
         }
 


### PR DESCRIPTION
# Description

Small fixes to balance migrations out since we dropped 'block' from naming conventions.


# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [x] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
