### PR TITLE
MozFest - class name spacing

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_cta_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/mozfest_cta_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% block block_content %}
-    <div class="tw-py-16 tw-dark{% if self.dark_background %} tw-bg-black{% endif %}">
+    <div class="tw-py-16 tw-dark{% if self.dark_background %} tw-bg-black {% endif %}">
         <div class="tw-container">
             <div class="tw-row">
                 <div class="tw-bg-blue-40 tw-w-full tw-p-8 tw-mx-8 medium:tw-flex medium:tw-items-center medium:tw-justify-between medium:tw-py-12 medium:tw-px-24">

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/tickets_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/tickets_block.html
@@ -7,7 +7,7 @@
             <div class="tw-row">
                 {% for tier in self.tickets %}
                     {% with count=self.tickets|length %}
-                        <div class="tw-mb-12 tw-w-full{% if count > 2 %} large:tw-w-1/3{% else %} large:tw-w-1/2{% endif %} tw-px-8{% if tier.sticker_text %} tw-relative{% endif %}">
+                        <div class="tw-mb-12 tw-w-full{% if count > 2 %} large:tw-w-1/3 {% else %} large:tw-w-1/2 {% endif %} tw-px-8 {% if tier.sticker_text %} tw-relative {% endif %}">
                             <div class="tw-bg-festival-black-100 tw-p-8 tw-h-full tw-flex tw-flex-col tw-items-start">
                                 <h3 class="tw-h2-heading">{{ tier.cost }}</h3>
                                 <p class="tw-mt-0">{{ tier.group }}</p>


### PR DESCRIPTION
# Description

Add spaces between class names and conditionals as per https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11537#discussion_r1425580234

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
