### PR TITLE
Feature/11128 add blog page tests

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/blog.py
+++ b/network-api/networkapi/wagtailpages/factory/blog.py
@@ -2,7 +2,7 @@ from datetime import timezone
 from random import choice
 
 from django.conf import settings
-from factory import Faker, LazyAttribute
+from factory import Faker, LazyAttribute, SubFactory
 from factory.django import DjangoModelFactory
 from wagtail.models import Page as WagtailPage
 from wagtail_factories import PageFactory
@@ -13,6 +13,7 @@ from networkapi.wagtailpages.models import (
     BlogIndexPage,
     BlogPage,
     BlogPageTopic,
+    RelatedBlogPosts,
     Profile,
 )
 from networkapi.wagtailpages.pagemodels.blog import blog_index
@@ -70,6 +71,14 @@ class BlogIndexPageFactory(IndexPageFactory):
         model = BlogIndexPage
 
     callout_box = Faker("streamfield", fields=["callout_box"])
+
+
+class RelatedBlogPostsFactory(DjangoModelFactory):
+    class Meta:
+        model = RelatedBlogPosts
+
+    page = SubFactory("networkapi.wagtailpages.factory.blog.BlogPageFactory")
+    related_post = SubFactory("networkapi.wagtailpages.factory.blog.BlogPageFactory")
 
 
 class BlogPageFactory(PageFactory):

--- a/network-api/networkapi/wagtailpages/factory/blog.py
+++ b/network-api/networkapi/wagtailpages/factory/blog.py
@@ -13,8 +13,8 @@ from networkapi.wagtailpages.models import (
     BlogIndexPage,
     BlogPage,
     BlogPageTopic,
-    RelatedBlogPosts,
     Profile,
+    RelatedBlogPosts,
 )
 from networkapi.wagtailpages.pagemodels.blog import blog_index
 

--- a/network-api/networkapi/wagtailpages/models.py
+++ b/network-api/networkapi/wagtailpages/models.py
@@ -14,7 +14,7 @@ from .pagemodels.base import (
     PrimaryPage,
     Styleguide,
 )
-from .pagemodels.blog.blog import BlogAuthors, BlogPage
+from .pagemodels.blog.blog import BlogAuthors, BlogPage, RelatedBlogPosts
 from .pagemodels.blog.blog_index import BlogIndexPage
 from .pagemodels.blog.blog_topic import BlogPageTopic
 from .pagemodels.buyersguide.article_page import (

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -297,7 +297,8 @@ class BlogPage(BasePage):
         post_count = self.related_posts.all().count()
         missing_count = self.related_post_count - post_count
 
-        if missing_count == 0:
+        if missing_count <= 0:
+            # We have enough related posts already, so return an empty list
             return additional_posts
 
         related_posts = get_content_related_by_tag(self)

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -272,10 +272,9 @@ class BlogPage(BasePage):
         context["related_posts"] = related_posts
 
         default_locale = Locale.get_default()
-        blog_page = BlogIndexPage.objects.filter(locale=default_locale).live().first()
-
-        if blog_page:
-            context["blog_index"] = blog_page
+        blog_index = BlogIndexPage.objects.filter(locale=default_locale).live().first()
+        if blog_index:
+            context["blog_index"] = blog_index
 
         return context
 

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -271,7 +271,6 @@ class BlogPage(BasePage):
             related_posts = related_posts + self.get_missing_related_posts()
         context["related_posts"] = related_posts
 
-        # Pull this object specifically using the English page title
         default_locale = Locale.get_default()
         blog_page = BlogIndexPage.objects.filter(locale=default_locale).live().first()
 

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -269,7 +269,6 @@ class BlogPage(BasePage):
             # see that same padded list during preview. However, `clean` is not called,
             # when previewing. Therefore, we manually extend the related posts.
             related_posts = related_posts + self.get_missing_related_posts()
-
         context["related_posts"] = related_posts
 
         # Pull this object specifically using the English page title

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -303,17 +303,16 @@ class BlogPage(BasePage):
 
         related_posts = get_content_related_by_tag(self)
 
-        if len(related_posts) > 0:
-            # Add as many posts as there are missing, or until
-            # we run out of related posts, whichever comes first.
-            for post in related_posts:
-                if missing_count == 0:
-                    break
-                if self.related_posts.filter(related_post=post).count() > 0:
-                    # Make sure to skip over duplicates
-                    continue
-                additional_posts.append(post)
-                missing_count = missing_count - 1
+        # Add as many posts as there are missing, or until
+        # we run out of related posts, whichever comes first.
+        for post in related_posts:
+            if missing_count == 0:
+                break
+            if self.related_posts.filter(related_post=post).count() > 0:
+                # Make sure to skip over duplicates
+                continue
+            additional_posts.append(post)
+            missing_count = missing_count - 1
 
         return additional_posts
 

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -265,15 +265,12 @@ class BlogPage(BasePage):
 
         related_posts = [post.related_post for post in self.related_posts.all()]
         if request.is_preview:
-            # While we automatically pad out the related posts during save, we want to
-            # see that same padded list during preview, but *without* actually updating
-            # the model, so we control this property at render context retrieval time:
+            # While we automatically pad out the related posts during `clean`, we want to
+            # see that same padded list during preview. However, `clean` is not called,
+            # when previewing. Therefore, we manually extend the related posts.
             related_posts = related_posts + self.get_missing_related_posts()
 
-        # Make sure to filter out any None entries, which may happen if the
-        # self.ensure_related_posts() function was unable to find any related
-        # posts to pad the related posts set with.
-        context["related_posts"] = list(filter(None, related_posts))
+        context["related_posts"] = related_posts
 
         # Pull this object specifically using the English page title
         default_locale = Locale.get_default()

--- a/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/blog/blog.py
@@ -160,7 +160,7 @@ class BlogPage(BasePage):
         help_text="Check this box to add a comment section for this blog post.",
     )
 
-    related_post_count = 3
+    RELATED_POSTS_MAX = 3
 
     content_panels = [
         FieldPanel(
@@ -187,7 +187,7 @@ class BlogPage(BasePage):
             "If you pick fewer than three (or none), saving will "
             "automatically bind some related posts based on tag matching.",
             min_num=0,
-            max_num=related_post_count,
+            max_num=RELATED_POSTS_MAX,
         ),
     ]
 
@@ -295,7 +295,7 @@ class BlogPage(BasePage):
         """
         additional_posts = list()
         post_count = self.related_posts.all().count()
-        missing_count = self.related_post_count - post_count
+        missing_count = self.RELATED_POSTS_MAX - post_count
 
         if missing_count <= 0:
             # We have enough related posts already, so return an empty list

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -9,7 +9,7 @@ from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory import homepage as home_factory
 from networkapi.wagtailpages.factory import blog as blog_factory
-
+from networkapi.wagtailpages.pagemodels.mixin import foundation_metadata
 
 
 class TestBlogPage(test.TestCase):
@@ -227,4 +227,11 @@ class TestBlogPage(test.TestCase):
 
         self.assertEqual(result, "Search description on the parent.")
 
+    def test_get_meta_description_no_search_description_no_body_no_search_description_on_parent(self):
+        self.blog_page.search_description = ""
+        self.blog_page.body = None
+        self.blog_index.search_description = ""
 
+        result = self.blog_page.get_meta_description()
+
+        self.assertEqual(result, foundation_metadata.FoundationMetadataPageMixin.default_description)

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -206,3 +206,14 @@ class TestBlogPage(test.TestCase):
         self.assertEqual(len(result), 153)
         expected = "This is the body content in a paragraph block. This is the body content in a paragraph block. This is the body content in a paragraph block. This is the…"  # noqa: E501
         self.assertEqual(result, expected)
+
+    def test_get_meta_description_no_search_description_but_body_with_mutiple_paragraph_blocks(self):
+        self.blog_page.search_description = ""
+        self.blog_page.body = [
+            ("paragraph", "<p>This is the body content in the first paragraph block.</p>"),
+            ("paragraph", "<p>This is the body content in the second paragraph block.</p>"), ]
+
+        result = self.blog_page.get_meta_description()
+
+        # Only the first paragraph block is used.
+        self.assertEqual(result, "This is the body content in the first paragraph block.")

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -121,3 +121,15 @@ class TestBlogPage(test.TestCase):
 
         # We don't want to see the directly related post being returned as a tag related post.
         self.assertEqual(len(result), 0)
+
+    def test_get_missing_related_posts_limit_smaller_than_directly_related(self):
+        self.blog_page.related_post_count = 1
+        self.blog_page.save()
+        self.create_directly_related_post()
+        self.create_directly_related_post()
+        self.create_tag_related_post()
+
+        result = self.blog_page.get_missing_related_posts()
+
+        # We have more directly related posts than the limit, so we don't get any tag related posts.
+        self.assertEqual(len(result), 0)

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -7,8 +7,8 @@ from django.core import exceptions
 from taggit import models as tag_models
 from wagtail import models as wagtail_models
 
-from networkapi.wagtailpages.factory import homepage as home_factory
 from networkapi.wagtailpages.factory import blog as blog_factory
+from networkapi.wagtailpages.factory import homepage as home_factory
 from networkapi.wagtailpages.pagemodels.mixin import foundation_metadata
 
 
@@ -65,7 +65,7 @@ class TestBlogPage(test.TestCase):
         self.assertEqual(mock_get_missing_related_posts.call_count, 0)
 
     @mock.patch("networkapi.wagtailpages.pagemodels.blog.blog.BlogPage.get_missing_related_posts")
-    def test_get_context_with_no_related_posts_no_tag_related_posts_not_preview(self, mock_get_missing_related_posts):
+    def test_get_context_with_no_related_posts_no_tag_related_posts_when_preview(self, mock_get_missing_related_posts):
         request = self.create_get_request(self.blog_page.url)
         request.is_preview = True
         # We test the method specifically below to see that it will actually return an empty list when there are no
@@ -260,7 +260,8 @@ class TestBlogPage(test.TestCase):
         self.blog_page.search_description = ""
         self.blog_page.body = [
             ("paragraph", "<p>This is the body content in the first paragraph block.</p>"),
-            ("paragraph", "<p>This is the body content in the second paragraph block.</p>"), ]
+            ("paragraph", "<p>This is the body content in the second paragraph block.</p>"),
+        ]
 
         result = self.blog_page.get_meta_description()
 

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -182,3 +182,27 @@ class TestBlogPage(test.TestCase):
 
         self.assertEqual(result, "This is the body content in a paragraph block.")
 
+    def test_get_meta_description_no_search_description_but_body_has_other_block_and_paragraph(self):
+        self.blog_page.search_description = ""
+        self.blog_page.body = [
+            ("image_text", {"text": "Text in a different block than paragraph."}),
+            ("paragraph", "<p>This is the body content in a paragraph block.</p>"),
+        ]
+
+        result = self.blog_page.get_meta_description()
+
+        # Other body blocks until the first paragraph block are ignored.
+        self.assertEqual(result, "This is the body content in a paragraph block.")
+
+    def test_get_meta_description_no_search_description_but_long_body(self):
+        self.blog_page.search_description = ""
+        content = "<p>This is the body content in a paragraph block.</p><p>This is the body content in a paragraph block.</p><p>This is the body content in a paragraph block.</p><p>This is the body content in a paragraph block.</p>"  # noqa: E501
+        self.blog_page.body = [
+            ("paragraph", content),
+        ]
+
+        result = self.blog_page.get_meta_description()
+
+        self.assertEqual(len(result), 153)
+        expected = "This is the body content in a paragraph block. This is the body content in a paragraph block. This is the body content in a paragraph block. This is the…"  # noqa: E501
+        self.assertEqual(result, expected)

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -47,29 +47,6 @@ class TestBlogPage(test.TestCase):
 
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
 
-    def test_clean_when_hero_image_and_hero_video_set(self):
-        self.blog_page.hero_image = wagtail_factories.ImageFactory()
-        self.blog_page.hero_video = "https://example.com/video.mp4"
-
-        with self.assertRaises(exceptions.ValidationError):
-            self.blog_page.clean()
-
-    def test_clean_when_hero_image_but_not_hero_video_set(self):
-        self.blog_page.hero_image = wagtail_factories.ImageFactory()
-        self.blog_page.hero_video = ""
-
-        result = self.blog_page.clean()
-
-        self.assertIsNone(result)
-
-    def test_clean_when_not_hero_image_but_hero_video_set(self):
-        self.blog_page.hero_image = None
-        self.blog_page.hero_video = "https://example.com/video.mp4"
-
-        result = self.blog_page.clean()
-
-        self.assertIsNone(result)
-
     def test_get_missing_related_posts_no_directly_related_posts_no_tag_related_posts(self):
         self.assertEqual(self.blog_page.related_posts.count(), 0)
 
@@ -164,6 +141,29 @@ class TestBlogPage(test.TestCase):
         self.blog_page.clean()
 
         self.assertEqual(mock_ensure_related_posts.call_count, 1)
+
+    def test_clean_when_hero_image_and_hero_video_set(self):
+        self.blog_page.hero_image = wagtail_factories.ImageFactory()
+        self.blog_page.hero_video = "https://example.com/video.mp4"
+
+        with self.assertRaises(exceptions.ValidationError):
+            self.blog_page.clean()
+
+    def test_clean_when_hero_image_but_not_hero_video_set(self):
+        self.blog_page.hero_image = wagtail_factories.ImageFactory()
+        self.blog_page.hero_video = ""
+
+        result = self.blog_page.clean()
+
+        self.assertIsNone(result)
+
+    def test_clean_when_not_hero_image_but_hero_video_set(self):
+        self.blog_page.hero_image = None
+        self.blog_page.hero_video = "https://example.com/video.mp4"
+
+        result = self.blog_page.clean()
+
+        self.assertIsNone(result)
 
     def test_get_meta_description_with_search_description(self):
         self.blog_page.search_description = "test description"

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -86,8 +86,8 @@ class TestBlogPage(test.TestCase):
 
         # Because we already have 3 directly related posts, we don't get the tag related post
         self.assertListEqual(result, [])
-        # The limit is defined by the BlotPage.related_post_count property
-        self.assertEqual(self.blog_page.related_post_count, 3)
+        # The limit is defined by the BlotPage.RELATED_POSTS_MAX property
+        self.assertEqual(self.blog_page.RELATED_POSTS_MAX, 3)
 
     def test_get_missing_related_posts_no_directly_related_posts_four_tag_related_posts(self):
         self.create_tag_related_post()
@@ -100,7 +100,7 @@ class TestBlogPage(test.TestCase):
         # Because we don't have any directly related posts, we get three tag related posts.
         self.assertEqual(len(result), 3)
         # We don't get the fourth tag related post because the limit is 3.
-        self.assertEqual(self.blog_page.related_post_count, 3)
+        self.assertEqual(self.blog_page.RELATED_POSTS_MAX, 3)
 
     def test_get_missing_related_posts_one_directly_related_posts_three_tag_related_post(self):
         self.create_directly_related_post()
@@ -123,7 +123,7 @@ class TestBlogPage(test.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_get_missing_related_posts_limit_smaller_than_directly_related(self):
-        self.blog_page.related_post_count = 1
+        self.blog_page.RELATED_POSTS_MAX = 1
         self.blog_page.save()
         self.create_directly_related_post()
         self.create_directly_related_post()

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -165,3 +165,20 @@ class TestBlogPage(test.TestCase):
 
         self.assertEqual(mock_ensure_related_posts.call_count, 1)
 
+    def test_get_meta_description_with_search_description(self):
+        self.blog_page.search_description = "test description"
+
+        result = self.blog_page.get_meta_description()
+
+        self.assertEqual(result, "test description")
+
+    def test_get_meta_description_no_search_description_but_body_has_paragraph(self):
+        self.blog_page.search_description = ""
+        self.blog_page.body = [
+            ("paragraph", "<p>This is the body content in a paragraph block.</p>"),
+        ]
+
+        result = self.blog_page.get_meta_description()
+
+        self.assertEqual(result, "This is the body content in a paragraph block.")
+

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -1,0 +1,28 @@
+import http
+
+from django import test
+from wagtail import models as wagtail_models
+
+from networkapi.wagtailpages.factory import homepage as home_factory
+from networkapi.wagtailpages.factory import blog as blog_factory
+
+
+
+class TestBlogPage(test.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        root_node = wagtail_models.Page.get_first_root_node()
+        site = wagtail_models.Site.objects.get(is_default_site=True)
+        cls.homepage = home_factory.WagtailHomepageFactory(parent=root_node)
+        site.root_page = cls.homepage
+        site.clean()
+        site.save()
+        cls.blog_index = blog_factory.BlogIndexPageFactory(parent=cls.homepage)
+
+    def test_page_loads(self):
+        page = blog_factory.BlogPageFactory(parent=self.blog_index)
+
+        response = self.client.get(page.url)
+
+        self.assertEqual(response.status_code, http.HTTPStatus.OK)
+

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -217,3 +217,14 @@ class TestBlogPage(test.TestCase):
 
         # Only the first paragraph block is used.
         self.assertEqual(result, "This is the body content in the first paragraph block.")
+
+    def test_get_meta_description_no_search_description_no_body_but_search_description_on_parent(self):
+        self.blog_page.search_description = ""
+        self.blog_page.body = None
+        self.blog_index.search_description = "Search description on the parent."
+
+        result = self.blog_page.get_meta_description()
+
+        self.assertEqual(result, "Search description on the parent.")
+
+

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -27,9 +27,25 @@ class TestBlogPage(test.TestCase):
 
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
 
-    def test_clean_when_both_hero_image_and_video_are_set(self):
+    def test_clean_when_hero_image_and_hero_video_set(self):
         self.blog_page.hero_image = wagtail_factories.ImageFactory()
         self.blog_page.hero_video = "https://example.com/video.mp4"
 
         with self.assertRaises(exceptions.ValidationError):
             self.blog_page.clean()
+
+    def test_clean_when_hero_image_but_not_hero_video_set(self):
+        self.blog_page.hero_image = wagtail_factories.ImageFactory()
+        self.blog_page.hero_video = ""
+
+        result = self.blog_page.clean()
+
+        self.assertIsNone(result)
+
+    def test_clean_when_not_hero_image_but_hero_video_set(self):
+        self.blog_page.hero_image = None
+        self.blog_page.hero_video = "https://example.com/video.mp4"
+
+        result = self.blog_page.clean()
+
+        self.assertIsNone(result)

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog.py
@@ -1,6 +1,8 @@
 import http
 
+import wagtail_factories
 from django import test
+from django.core import exceptions
 from wagtail import models as wagtail_models
 
 from networkapi.wagtailpages.factory import homepage as home_factory
@@ -18,11 +20,16 @@ class TestBlogPage(test.TestCase):
         site.clean()
         site.save()
         cls.blog_index = blog_factory.BlogIndexPageFactory(parent=cls.homepage)
+        cls.blog_page = blog_factory.BlogPageFactory(parent=cls.blog_index)
 
     def test_page_loads(self):
-        page = blog_factory.BlogPageFactory(parent=self.blog_index)
-
-        response = self.client.get(page.url)
+        response = self.client.get(self.blog_page.url)
 
         self.assertEqual(response.status_code, http.HTTPStatus.OK)
 
+    def test_clean_when_both_hero_image_and_video_are_set(self):
+        self.blog_page.hero_image = wagtail_factories.ImageFactory()
+        self.blog_page.hero_video = "https://example.com/video.mp4"
+
+        with self.assertRaises(exceptions.ValidationError):
+            self.blog_page.clean()

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog_index.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog_index.py
@@ -936,29 +936,3 @@ class TestBlogIndexAuthors(test_base.WagtailpagesTestCase):
         # Check if the French page returns French topics (when available)
         self.assertIn(topic_1_fr, frequent_topics_fr)
         self.assertIn(topic_2_en, frequent_topics_fr)
-
-
-class TestBlogPageTopics(test.TestCase):
-    def test_factory(self):
-        blog_factories.BlogPageTopicFactory()
-
-    def test_get_topics_method(self):
-        # Clearing test instance of any existing topics
-        blog_models.BlogPageTopic.objects.all().delete()
-
-        test_topic = blog_factories.BlogPageTopicFactory(name="Test_Topic_1")
-        blog_factories.BlogPageTopicFactory(name="Test_Topic_2")
-        blog_factories.BlogPageTopicFactory(name="Test_Topic_3")
-
-        # Creating a list of all created BlogPageTopics sorted by name,
-        # with an additional option of "All".
-        list_of_sorted_topics = [
-            ("All", "All"),
-            ("Test_Topic_1", "Test_Topic_1"),
-            ("Test_Topic_2", "Test_Topic_2"),
-            ("Test_Topic_3", "Test_Topic_3"),
-        ]
-
-        topic_choices_from_method = test_topic.get_topics()
-
-        self.assertEqual(list_of_sorted_topics, topic_choices_from_method)

--- a/network-api/networkapi/wagtailpages/tests/blog/test_blog_topic.py
+++ b/network-api/networkapi/wagtailpages/tests/blog/test_blog_topic.py
@@ -1,0 +1,30 @@
+from django import test
+
+from networkapi.wagtailpages.factory import blog as blog_factories
+from networkapi.wagtailpages.pagemodels.blog import blog as blog_models
+
+
+class TestBlogPageTopics(test.TestCase):
+    def test_factory(self):
+        blog_factories.BlogPageTopicFactory()
+
+    def test_get_topics_method(self):
+        # Clearing test instance of any existing topics
+        blog_models.BlogPageTopic.objects.all().delete()
+
+        test_topic = blog_factories.BlogPageTopicFactory(name="Test_Topic_1")
+        blog_factories.BlogPageTopicFactory(name="Test_Topic_2")
+        blog_factories.BlogPageTopicFactory(name="Test_Topic_3")
+
+        # Creating a list of all created BlogPageTopics sorted by name,
+        # with an additional option of "All".
+        list_of_sorted_topics = [
+            ("All", "All"),
+            ("Test_Topic_1", "Test_Topic_1"),
+            ("Test_Topic_2", "Test_Topic_2"),
+            ("Test_Topic_3", "Test_Topic_3"),
+        ]
+
+        topic_choices_from_method = test_topic.get_topics()
+
+        self.assertEqual(list_of_sorted_topics, topic_choices_from_method)

--- a/network-api/networkapi/wagtailpages/tests/test_utils.py
+++ b/network-api/networkapi/wagtailpages/tests/test_utils.py
@@ -47,7 +47,6 @@ class TestGetContentRelatedByTag(TestCase):
         other_page.tags.add(tag)
         other_page.save()
 
-        breakpoint()
         result = get_content_related_by_tag(page)
 
         self.assertEqual(len(result), 1)

--- a/network-api/networkapi/wagtailpages/tests/test_utils.py
+++ b/network-api/networkapi/wagtailpages/tests/test_utils.py
@@ -6,9 +6,10 @@ from django.utils.translation.trans_real import (
     parse_accept_lang_header as django_parse_accept_lang_header,
 )
 from django.utils.translation.trans_real import to_language as django_to_language
+from taggit import models as tag_models
 from wagtail.core.models import Locale
 from wagtail.images.models import Image
-from wagtail.models import Collection
+from wagtail.models import Collection, Page, Site
 
 from networkapi.wagtailpages import (
     language_code_to_iso_3166,
@@ -26,10 +27,31 @@ from networkapi.wagtailpages.pagemodels.blog.blog import BlogAuthors, BlogPage
 from networkapi.wagtailpages.pagemodels.profiles import Profile
 from networkapi.wagtailpages.tests.base import WagtailpagesTestCase
 from networkapi.wagtailpages.utils import (
+    get_content_related_by_tag,
     create_wagtail_image,
     get_blog_authors,
     localize_queryset,
 )
+
+
+class TestGetContentRelatedByTag(TestCase):
+    def test_single_page_has_same_tag(self):
+        # Not using the factories here because that was throwing errors due to missing images for some reason.
+        # It is unclear why this was happening, but it was not the focus of this test, so we just create the
+        # objects manually.
+        page = BlogPage.objects.create(title="The page", path="00010002", depth=2)
+        other_page = BlogPage.objects.create(title="The other page", path="00010003", depth=2)
+        tag = tag_models.Tag.objects.create(name="Test tag")
+        page.tags.add(tag)
+        page.save()
+        other_page.tags.add(tag)
+        other_page.save()
+
+        breakpoint()
+        result = get_content_related_by_tag(page)
+
+        self.assertEqual(len(result), 1)
+        self.assertListEqual(result, [other_page])
 
 
 class TestCreateWagtailImageUtility(TestCase):

--- a/network-api/networkapi/wagtailpages/tests/test_utils.py
+++ b/network-api/networkapi/wagtailpages/tests/test_utils.py
@@ -9,7 +9,7 @@ from django.utils.translation.trans_real import to_language as django_to_languag
 from taggit import models as tag_models
 from wagtail.core.models import Locale
 from wagtail.images.models import Image
-from wagtail.models import Collection, Page, Site
+from wagtail.models import Collection
 
 from networkapi.wagtailpages import (
     language_code_to_iso_3166,
@@ -27,9 +27,9 @@ from networkapi.wagtailpages.pagemodels.blog.blog import BlogAuthors, BlogPage
 from networkapi.wagtailpages.pagemodels.profiles import Profile
 from networkapi.wagtailpages.tests.base import WagtailpagesTestCase
 from networkapi.wagtailpages.utils import (
-    get_content_related_by_tag,
     create_wagtail_image,
     get_blog_authors,
+    get_content_related_by_tag,
     localize_queryset,
 )
 


### PR DESCRIPTION
# Description

This PR adds test for the `BlogPage` model. Previously this model was not tested directly. The only coverage this model received was through side-effects of other page tests. 

The initial test coverage for the `BlogPage` model was 60%. With the new added tests specifically for this model, the coverage is increased to 98%.

The majority of features should now be covered by tests. Only trivial parts are not covered directly. 

Some of the functionality relies on widely used utilities like `get_content_related_by_tag`. A first test for it was added in the PR, but that work should be continued. See also #11557. 

Link to sample test page: 
Related PRs/issues: #11128

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [-] Did I update or add new fake data?
- [-] Did I squash my migration?
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [-] Is my code documented?
- [-] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
