### PR TITLE
7028 - MozFest sign up block FE

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/cta_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/cta_block.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailcore_tags %}
 
 {% block block_content %}
     <div class="tw-py-16 tw-dark{% if self.dark_background %} tw-bg-black {% endif %}">

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/sign_up_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/sign_up_block.html
@@ -1,0 +1,23 @@
+{% load i18n l10n static %}
+
+{% block block_content %}
+    <div class="tw-mx-8 large:tw-mx-0 tw-my-14">
+        <div class="tw-container">
+            <div class="tw-row tw-bg-black tw-dark">
+                <div class="tw-relative tw-p-10 large:tw-py-14 large:tw-px-20 tw-w-full large:tw-w-7/12 after:tw-content-[''] after:tw-bg-gradient-to-r after:tw-from-black after:tw-to-transparent after:tw-h-full after:tw-w-[100px] after:tw-top-0 after:tw-absolute after:tw-right-[-100px] after:tw-to-90% after:tw-hidden large:after:tw-block">
+                    <div
+                        class="join-us"
+                        data-form-position="callout-box"
+                        data-form-style="mozfest"
+                        data-signup-id="{{ self.signup.id | unlocalize }}"
+                        data-cta-header="{{ self.signup.header | escape }}"
+                        data-cta-description="{{ self.signup.description | escape }}"
+                        data-newsletter="{{ self.signup.newsletter }}"
+                    >
+                    </div>
+                </div>
+                <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat" style="background-image: url('{% static "_images/banner-black-white-marble.jpg" %}')"></div>
+            </div>
+        </div>
+    </div>
+{% endblock block_content %}

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -327,6 +327,8 @@ class JoinUs extends Component {
           ? "tw-h1-heading large:tw-pr-24"
           : this.props.formStyle == "pni"
           ? "tw-text-3xl tw-font-zilla tw-mb-4 medium:tw-w-4/5"
+          : this.props.formStyle == "mozfest"
+          ? "tw-h3-heading"
           : "tw-h5-heading"
       }`
     );
@@ -401,7 +403,7 @@ class JoinUs extends Component {
     let inputClasses = classNames(`${FORM_CONTROL_CLASS} tw-pr-18`, {
       "tw-border-1 tw-border-black placeholder:tw-text-gray-40 focus:tw-border-blue-40 focus:tw-shadow-none focus-visible:tw-drop-shadow-none tw-mt-8":
         this.props.formStyle == `pop`,
-      "tw-h-24": this.props.formStyle == `pni`,
+      "tw-h-24": this.props.formStyle == `pni` || this.props.formStyle == `mozfest`,
     });
 
     let errorWrapperClasses = classNames("glyph-container", {
@@ -574,7 +576,7 @@ class JoinUs extends Component {
         "tw-border-1 tw-btn-secondary tw-mt-24 medium:-tw-mb-16 medium:tw-mt-12"
       );
       buttonText = getText("Subscribe");
-    } else if (this.props.formStyle == "pni") {
+    } else if (this.props.formStyle == "pni" || this.props.formStyle == "mozfest") {
       classnames = classNames(
         "tw-btn",
         "tw-btn-primary",
@@ -626,7 +628,7 @@ class JoinUs extends Component {
       buttonsWrapperClass = `w-auto tw-text-right`;
     }
 
-    if (this.props.formStyle === "pni") {
+    if (this.props.formStyle === "pni" || this.props.formStyle === "mozfest") {
       formClass = `tw-w-full tw-flex tw-flex-row`;
       buttonsWrapperClass = `w-auto`;
     }

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -403,7 +403,8 @@ class JoinUs extends Component {
     let inputClasses = classNames(`${FORM_CONTROL_CLASS} tw-pr-18`, {
       "tw-border-1 tw-border-black placeholder:tw-text-gray-40 focus:tw-border-blue-40 focus:tw-shadow-none focus-visible:tw-drop-shadow-none tw-mt-8":
         this.props.formStyle == `pop`,
-      "tw-h-24": this.props.formStyle == `pni` || this.props.formStyle == `mozfest`,
+      "tw-h-24":
+        this.props.formStyle == `pni` || this.props.formStyle == `mozfest`,
     });
 
     let errorWrapperClasses = classNames("glyph-container", {
@@ -576,7 +577,10 @@ class JoinUs extends Component {
         "tw-border-1 tw-btn-secondary tw-mt-24 medium:-tw-mb-16 medium:tw-mt-12"
       );
       buttonText = getText("Subscribe");
-    } else if (this.props.formStyle == "pni" || this.props.formStyle == "mozfest") {
+    } else if (
+      this.props.formStyle == "pni" ||
+      this.props.formStyle == "mozfest"
+    ) {
       classnames = classNames(
         "tw-btn",
         "tw-btn-primary",


### PR DESCRIPTION
# Description

- Adds a sign up block template for use on the MozFest page. I added a new 'mozfest' prop that is used to achieve the styling in the design. 
- The BG image will come from the BE work as well as updating any variable names.
- Also removes an unused `wagtailimagetags` import in the CTA block

Desktop/Tablet/Mobile:

<details><summary>Details</summary>
<p>

![Screenshot 2023-12-18 at 15 49 07](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/59d37aae-61db-44ad-b322-5e94a79b2d2e)

![Screenshot 2023-12-18 at 15 49 13](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/475af725-9e02-4954-bcd7-7db6b1b5ad73)

![Screenshot 2023-12-18 at 15 49 21](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/b8dbdb33-9f37-4e06-ab77-a716bbc3317b)


</p>
</details> 
 
Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
