### PR TITLE
8278 - MozFest header CTA

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/primary_cta.html
+++ b/network-api/networkapi/mozfest/templates/fragments/primary_cta.html
@@ -1,3 +1,3 @@
 {% if root.cta_button_destination and root.cta_button_label %}
-    <a class="tw-btn-secondary" href="{{ root.cta_button_destination }}">{{ root.cta_button_label }}</a>
+    <a class="tw-btn-primary" href="{{ root.cta_button_destination }}">{{ root.cta_button_label }}</a>
 {% endif %}


### PR DESCRIPTION
# Description

- Updates the colour of the header CTA
- The template (`mozfest/templates/fragments/primary_cta.html`) is only used on the MozFest base template so there should be no knock-on effects anywhere else on the site. 

Desktop/Tablet/Mobile:

<details><summary>Details</summary>
<p>

![Screenshot 2023-12-18 at 16 29 32](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/706d812f-1447-4306-ab2e-9be43d309630)

![Screenshot 2023-12-18 at 16 29 37](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/23922850-6d87-417d-9076-2361bdb00500)

![Screenshot 2023-12-18 at 16 29 46](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/b545cd9b-587e-4501-93af-b1358ea27f90)


</p>
</details> 

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
