### PR TITLE
Add streamfield provider for session slider

### DIFF
--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -25,6 +25,7 @@ streamfield_fields = [
     "cta",
     "listing",
     "tickets",
+    "session_slider",
 ]
 
 
@@ -58,7 +59,7 @@ class MozfestHomepageFactory(MozfestPrimaryPageFactory):
     banner_link_url = Faker("url")
     banner_link_text = Faker("sentence", nb_words=2, variable_nb_words=True)
 
-    body = Faker("streamfield", fields=streamfield_fields + ["current_events_slider"])
+    body = Faker("streamfield", fields=streamfield_fields)
 
     signup = SubFactory(SignupFactory)
 

--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -569,6 +569,38 @@ def generate_tickets_block_field():
     return generate_field("tickets", {"heading": heading, "tickets": tickets})
 
 
+def generate_session_slider_item():
+    title = fake.sentence(nb_words=4, variable_nb_words=True)
+    author_subheading = fake.sentence(nb_words=3, variable_nb_words=True)
+
+    image = choice(Image.objects.all()).id
+    body = fake.paragraph(nb_sentences=3, variable_nb_sentences=True)
+    return generate_field(
+        "session_item",
+        {
+            "title": title,
+            "author_subheading": author_subheading,
+            "image": image,
+            "body": body,
+            "link": [generate_labelled_external_link_field()],
+        },
+    )
+
+
+def generate_session_slider_field():
+    title = fake.sentence(nb_words=3, variable_nb_words=True)
+    button = [generate_labelled_external_link_field()]
+    session_items = [
+        generate_session_slider_item(),
+        generate_session_slider_item(),
+        generate_session_slider_item(),
+        generate_session_slider_item(),
+        generate_session_slider_item(),
+    ]
+
+    return generate_field("session_slider", {"title": title, "session_items": session_items, "button": button})
+
+
 class StreamfieldProvider(BaseProvider):
     """
     A custom Faker Provider for relative image urls, for use with factory_boy
@@ -624,6 +656,7 @@ class StreamfieldProvider(BaseProvider):
             "tickets": generate_tickets_block_field,
             "dark_quote": generate_dark_quote_field,
             "cta": generate_cta_field,
+            "session_slider": generate_session_slider_field,
         }
 
         streamfield_data = []


### PR DESCRIPTION
# Description

This PR adds a streamfield provider for the session slider.
It also removes the events carousel from the body content because we aren't interested in that on mozfest pages.

Link to sample test page:
Related PRs/issues: https://torchbox.monday.com/boards/1334760528/pulses/1346903381

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [x] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
