### PR TITLE
Feature/9269 speakers block / profiles

### DIFF
--- a/network-api/networkapi/mozfest/factory.py
+++ b/network-api/networkapi/mozfest/factory.py
@@ -26,6 +26,7 @@ streamfield_fields = [
     "listing",
     "tickets",
     "session_slider",
+    "profiles",
 ]
 
 

--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -601,6 +601,17 @@ def generate_session_slider_field():
     return generate_field("session_slider", {"title": title, "session_items": session_items, "button": button})
 
 
+def generate_profiles_field():
+    profiles = []
+    from networkapi.wagtailpages.factory.profiles import ProfileFactory
+
+    for n in range(9):
+        profile_snippet = ProfileFactory.create()
+        profiles.append({"profile": profile_snippet.id})
+
+    return generate_field("profiles", {"profiles": profiles})
+
+
 class StreamfieldProvider(BaseProvider):
     """
     A custom Faker Provider for relative image urls, for use with factory_boy
@@ -657,6 +668,7 @@ class StreamfieldProvider(BaseProvider):
             "dark_quote": generate_dark_quote_field,
             "cta": generate_cta_field,
             "session_slider": generate_session_slider_field,
+            "profiles": generate_profiles_field,
         }
 
         streamfield_data = []


### PR DESCRIPTION
# Description

This PR adds a new streamfield provider for profiles, we will be using these on the mozfest pages and thought we might need a new block so this has been added for evidence that we don't.

Link to sample test page: http://mozfest.localhost:8000/en/landing-page-1/
Related PRs/issues: https://torchbox.monday.com/boards/1334760528/pulses/1336909269

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [x] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
