### PR TITLE
8895 - MozFest Session slider updates

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/carousel/carousel_navigation.html
+++ b/network-api/networkapi/mozfest/templates/fragments/carousel/carousel_navigation.html
@@ -1,4 +1,4 @@
-<div class="swiper-navigation tw-container tx-p-0 tw-relative tw-z-10 tw-mb-12 tw-ml-auto tw-hidden large:tw-flex large:tw-justify-end tw-items-center {% if page.signup != None %} tw-ml-0 tw-container{% endif %}">
+<div class="swiper-navigation tw-container tx-p-0 tw-relative tw-z-10 tw-mb-12 tw-ml-auto tw-hidden large:tw-flex large:tw-justify-end tw-items-center {% if page.signup != None %} tw-ml-0 tw-container{% endif %} [body.mozfest_&]:tw-p-0 [body.mozfest_&]:tw-mb-0">
     {% if fraction %}<div class="swiper-fraction tw-min-w-min tw-w-auto tw-mr-12 tw-text-xl tw-leading-none"></div>{% endif %}
     <div class="tw-flex tw-flex-row tw-justify-between tw-items-center">
         <div class="swiper-button-prev">

--- a/network-api/networkapi/mozfest/templates/fragments/session_card.html
+++ b/network-api/networkapi/mozfest/templates/fragments/session_card.html
@@ -2,11 +2,11 @@
 <a class="tw-block tw-group tw-no-underline tw-p-6 tw-border tw-border-gray-60/20 tw-text-[22px] tw-h-full" href="{{ url }}">
     <div class="tw-relative w-full medium:w-[250px] tw-h-[290px] tw-overflow-hidden tw-mb-8">
         {% if animated_thumbnail %}
-            <img class="tw-absolute tw-top-1/2 tw--translate-y-1/2 tw-left-1/2 tw--translate-x-1/2 tw-transform tw-w-12 tw-h-12 tw-z-10 group-hover:tw-opacity-0 tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
+            <img class="tw-absolute tw-top-1/2 tw--translate-y-1/2 tw-left-1/2 tw--translate-x-1/2 tw-transform tw-w-12 tw-h-12 tw-z-10 motion-reduce:tw-hidden motion-safe:group-hover:tw-opacity-0 tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
                  src="{% static '_images/mozfest/play-triangle.svg' %}" alt="">
-            <video class="tw-absolute tw-object-cover tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2" src="{{ animated_thumbnail }}" autoplay loop muted width="500" height="200"></video>
+            <video class="tw-absolute tw-object-cover tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2 motion-reduce:tw-hidden" src="{{ animated_thumbnail }}" autoplay loop muted width="500" height="200"></video>
         {% endif %}
-        <img class="tw-w-full tw-object-cover tw-absolute tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2 {% if animated_thumbnail %}group-hover:tw-opacity-0 {% endif %} tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
+        <img class="tw-w-full tw-object-cover tw-absolute tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2 {% if animated_thumbnail %}motion-safe:group-hover:tw-opacity-0 {% endif %} tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
              src="{{ image }}" alt="">
     </div>
     <div class=" tw-text-black">

--- a/network-api/networkapi/mozfest/templates/fragments/session_card.html
+++ b/network-api/networkapi/mozfest/templates/fragments/session_card.html
@@ -3,11 +3,11 @@
     <div class="tw-relative w-full medium:w-[250px] tw-h-[290px] tw-overflow-hidden tw-mb-8">
         {% if animated_thumbnail %}
             <img class="tw-absolute tw-top-1/2 tw--translate-y-1/2 tw-left-1/2 tw--translate-x-1/2 tw-transform tw-w-12 tw-h-12 tw-z-10 group-hover:tw-opacity-0 tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
-                    src="{% static '_images/mozfest/play-triangle.svg' %}" alt="">
+                 src="{% static '_images/mozfest/play-triangle.svg' %}" alt="">
             <video class="tw-absolute tw-object-cover tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2" src="{{ animated_thumbnail }}" autoplay loop muted width="500" height="200"></video>
         {% endif %}
         <img class="tw-w-full tw-object-cover tw-absolute tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2 {% if animated_thumbnail %}group-hover:tw-opacity-0 {% endif %} tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
-                src="{{ image }}" alt="">
+             src="{{ image }}" alt="">
     </div>
     <div class=" tw-text-black">
         <div class="tw-h3-heading tw-inline-block group-hover:tw-underline tw-font-zilla tw-transition tw-mb-6">{{ title }}</div>

--- a/network-api/networkapi/mozfest/templates/fragments/session_card.html
+++ b/network-api/networkapi/mozfest/templates/fragments/session_card.html
@@ -1,32 +1,21 @@
 {% load static wagtailcore_tags %}
-<a class="tw-block tw-group tw-no-underline tw-p-12 tw-border tw-border-gray-60/20 tw-text-[22px]"
-   href="{{ url }}">
-
-    <div class="tw-grid tw-grid-cols-1 medium:tw-grid-cols-5 tw-gap-8">
-
-        <div class="medium:tw-col-span-3">
-            <div class="tw-mb-8 tw-text-black">
-                <div class="tw-h3-heading tw-inline-block group-hover:tw-underline tw-font-zilla tw-transition tw-mb-6">{{ title }}</div>
-                {% if author_subheading %}
-                    <div class="tw-body-small">{{ author_subheading }}</div>
-                {% endif %}
-            </div>
-            <div class="tw-text-lg">
-                {{ text|richtext }}
-            </div>
-        </div>
-
-        <div class="medium:tw-order-2 tw-shrink-0 medium:tw-col-span-2">
-            <div class="tw-relative w-full medium:w-[250px] tw-h-[140px] tw-overflow-hidden">
-                {% if animated_thumbnail %}
-                    <img class="tw-absolute tw-top-1/2 tw--translate-y-1/2 tw-left-1/2 tw--translate-x-1/2 tw-transform tw-w-12 tw-h-12 tw-z-10 group-hover:tw-opacity-0 tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
-                         src="{% static '_images/mozfest/play-triangle.svg' %}" alt="">
-                    <video class="tw-absolute tw-object-cover tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2" src="{{ animated_thumbnail }}" autoplay loop muted width="500" height="200"></video>
-                {% endif %}
-                <img class="tw-w-full tw-object-cover tw-absolute tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2 {% if animated_thumbnail %}group-hover:tw-opacity-0 {% endif %} tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
-                     src="{{ image }}" alt="">
-            </div>
-        </div>
+<a class="tw-block tw-group tw-no-underline tw-p-6 tw-border tw-border-gray-60/20 tw-text-[22px] tw-h-full" href="{{ url }}">
+    <div class="tw-relative w-full medium:w-[250px] tw-h-[290px] tw-overflow-hidden tw-mb-8">
+        {% if animated_thumbnail %}
+            <img class="tw-absolute tw-top-1/2 tw--translate-y-1/2 tw-left-1/2 tw--translate-x-1/2 tw-transform tw-w-12 tw-h-12 tw-z-10 group-hover:tw-opacity-0 tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
+                    src="{% static '_images/mozfest/play-triangle.svg' %}" alt="">
+            <video class="tw-absolute tw-object-cover tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2" src="{{ animated_thumbnail }}" autoplay loop muted width="500" height="200"></video>
+        {% endif %}
+        <img class="tw-w-full tw-object-cover tw-absolute tw-left-1/2 tw-top-1/2 tw-h-full tw--translate-y-1/2 tw--translate-x-1/2 {% if animated_thumbnail %}group-hover:tw-opacity-0 {% endif %} tw-transition tw-duration-500 tw-ease-in-out tw-delay-100"
+                src="{{ image }}" alt="">
     </div>
-
+    <div class=" tw-text-black">
+        <div class="tw-h3-heading tw-inline-block group-hover:tw-underline tw-font-zilla tw-transition tw-mb-6">{{ title }}</div>
+        {% if author_subheading %}
+            <div class="tw-body-small tw-mb-4">{{ author_subheading }}</div>
+        {% endif %}
+    </div>
+    <div class="tw-text-lg tw-line-clamp-3 [&_p]:tw-text-base">
+        {{ text|richtext }}
+    </div>
 </a>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/session_slider_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/session_slider_block.html
@@ -1,44 +1,47 @@
 {% load static wagtailimages_tags %}
 
 {% block block_content %}
-    <div class="tw-mb-16 tw-mt-12 first:tw-mt-0">
-        <div class="tw-relative tw-overflow-hidden {% if page.signup != None %} large:tw-mr-[calc(50%-50vw)] {% else %} tw-container{% endif %}">
-            <div class="swiper tw-px-6 tw-pb-24 tw-mx-0 tw-overflow-hidden tw-container" data-carousel>
+    <div class="tw-container tw-py-16">
+        <div class="tw-row">
+            <div class="tw-relative tw-overflow-hidden">
+                <div
+                    class="swiper tw-relative tw-pb-16 tw-mx-0 tw-overflow-hidden tw-container after:tw-hidden large:after:tw-block after:tw-content-[''] after:tw-bg-gradient-to-l after:tw-from-white tw-from-70% after:tw-to-transparent after:tw-h-[475px] after:tw-w-[40px] after:tw-top-[60px] after:tw-absolute after:tw-right-0 after:tw-z-10"
+                    data-carousel
+                    data-slides-per-view="1.2"
+                    data-desktop-slides-per-view="2.4"
+                >
 
-                {% block navigation %}
-                    <div class="tw-flex tw-justify-center tw-items-start tw-flex-col tw-mb-12 medium:tw-flex-row medium:tw-justify-between medium:tw-items-center">
-                        <h2 class="tw-h3-heading tw-font-semibold tw-mb-0 tw-w-full">{{ value.title }}</h2>
-                        {% if self.session_items|length > 2 %}
-                            {% include 'fragments/carousel/carousel_navigation.html' %}
-                        {% endif %}
-                    </div>
-                {% endblock %}
+                    {% block navigation %}
+                        <div class="tw-flex tw-justify-center tw-items-start tw-flex-col tw-mb-10 medium:tw-flex-row medium:tw-justify-between medium:tw-items-center">
+                            <h2 class="tw-h3-heading tw-mb-0 tw-w-full">{{ value.title }}</h2>
+                            {% if self.session_items|length > 2 %}
+                                {% include 'fragments/carousel/carousel_navigation.html' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
 
-                {% block slides %}
-                    <div class="swiper-wrapper">
-                        {% for item in self.session_items %}
-                            {% image item.value.image fill-250x140 as img %}
-                            <div class="swiper-slide">
+                    {% block slides %}
+                        <div class="swiper-wrapper tw-items-stretch">
+                            {% for item in self.session_items %}
+                            {% image item.value.image fill-420x290 as img %}
+                            <div class="swiper-slide tw-h-auto">
                                 {% include 'fragments/session_card.html' with title=item.value.title author_subheading=item.value.author_subheading url=item.value.link.0.value.link_url image=img.url text=item.value.body animated_thumbnail=item.value.video.url %}
                             </div>
-                        {% endfor %}
-                    </div>
-                {% endblock %}
+                            {% endfor %}
+                        </div>
+                    {% endblock %}
 
-                {% block pagination %}
-                    <div class="swiper-pagination tw--bottom-[5px] large:tw-hidden"></div>
-                {% endblock %}
-
-            </div>
-
-        </div>
-
-        {% if self.button %}
-            <div class="tw-container tw-px-8 tw-pt-2 medium:tw-pt-0">
-                <div class="tw-flex tw-flex-wrap tw-gap-6 tw-px-6">
-                    <a class="tw-btn-primary tw-mt-auto tw-w-full medium:tw-w-auto" href="{{ self.button.0.value.link_url }}">{{ self.button.0.value.label }}</a>
+                    {% block pagination %}
+                        <div class="swiper-pagination tw-relative tw-mt-16"></div>
+                    {% endblock %}
                 </div>
             </div>
-        {% endif %}
+
+            {% if self.button %}
+                <div class="tw-flex tw-justify-center tw-w-full">
+                    <a class="tw-cta-link tw-text-black" href="{{ self.button.0.value.link_url }}">{{ self.button.0.value.label }}</a>
+                </div>
+            {% endif %}
+        </div>
     </div>
 {% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/session_slider_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/session_slider_block.html
@@ -23,10 +23,10 @@
                     {% block slides %}
                         <div class="swiper-wrapper tw-items-stretch">
                             {% for item in self.session_items %}
-                            {% image item.value.image fill-420x290 as img %}
-                            <div class="swiper-slide tw-h-auto">
-                                {% include 'fragments/session_card.html' with title=item.value.title author_subheading=item.value.author_subheading url=item.value.link.0.value.link_url image=img.url text=item.value.body animated_thumbnail=item.value.video.url %}
-                            </div>
+                                {% image item.value.image fill-420x290 as img %}
+                                <div class="swiper-slide tw-h-auto">
+                                    {% include 'fragments/session_card.html' with title=item.value.title author_subheading=item.value.author_subheading url=item.value.link.0.value.link_url image=img.url text=item.value.body animated_thumbnail=item.value.video.url %}
+                                </div>
                             {% endfor %}
                         </div>
                     {% endblock %}

--- a/source/js/components/carousel/carousel.js
+++ b/source/js/components/carousel/carousel.js
@@ -21,7 +21,7 @@ class Carousel {
       watchOverflow: true,
       centeredSlides: false,
       simulateTouch: true,
-      slidesPerView: 1,
+      slidesPerView: this.node.dataset.slidesPerView || 1,
       autoHeight: false,
       keyboard: {
         enabled: true,


### PR DESCRIPTION
# Description

- Updates the existing session slider component to be in line with the new designs. This mainly involved making the image full width on the card, adding pagination and showing a slice of the next slide.
- The session slider is only used for MozFest so there was no BE work to be done for this. 
- The carousel navigation is a shared component so style updates were done using a parent selector.

Desktop/Tablet/Mobile

<details><summary>Details</summary>
<p>

![Screenshot 2023-12-20 at 12 59 55](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/396dbe1b-db1c-44e4-be54-6d09bea92b14)

![Screenshot 2023-12-20 at 13 00 12](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/81c05506-9e54-49f3-b10d-7179f29a8b8a)

![Screenshot 2023-12-20 at 13 00 22](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/02fc618c-32a6-450e-a3de-1c8a42a839bc)

</p>
</details> 

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
