### PR TITLE
9300 - MozFest Listing block width

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/listing_block.html
@@ -1,7 +1,7 @@
 {% extends "./base_streamfield_block.html" %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% block streamfield_content_classes %}[body.mozfest_&]:tw-pt-14 [body.mozfest_&]:medium:tw-pt-24 [body.mozfest_&]:large:tw-w-full{% endblock %}
+{% block streamfield_content_classes %}[body.mozfest_&]:tw-pt-14 [body.mozfest_&]:medium:tw-pt-24{% endblock %}
 
 {% block block_content %}
     {% if self.heading %}

--- a/source/sass/mozfest.scss
+++ b/source/sass/mozfest.scss
@@ -365,4 +365,11 @@ body.mozfest {
       @apply tw-opacity-50;
     }
   }
+
+  // Make the listing block full width
+  .listing-block {
+    .streamfield-content {
+      @extend .col-lg-12;
+    }
+  }
 }


### PR DESCRIPTION
# Description

- The override added here https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11545/commits/1caf296998fd078af7ef2614c037895458347fc3 didn't work as expected as the `.col-` class also sets `flex` and `max-width` values with the tailwind class does not overwrite (we could overwrite them but it doesn't feel right and we may need to add more rules in for different breakpoints) so i've reverted that change here.

Screen showing the rules set in Tailwind and the rules set by the grid system.

![Screenshot 2023-12-20 at 14 36 34](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/31627284/4ffcae61-e8e5-48d2-ae8b-9757bdc1aa9e)

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
