### PR TITLE
#11600 Make generic card more generic

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -5,47 +5,47 @@
     {% endif %}
 {% endif %}
 {% with title=title|default:page.localized.title image=image|default:page.localized.specific.get_meta_image %}
-<div
-    class="
-           tw-flex
-           tw-flex-col
-           tw-gap-6
-           tw-w-full
-           {% if horizontal %}
-               medium:tw-flex-row
-               medium:tw-gap-16
-           {% endif %}
-          "
->
     <div
-        {% if horizontal %}
-            class="medium:tw-max-w-xs large:tw-max-w-sm medium:tw-shrink-0"
-        {% endif %}
+        class="
+               tw-flex
+               tw-flex-col
+               tw-gap-6
+               tw-w-full
+               {% if horizontal %}
+                   medium:tw-flex-row
+                   medium:tw-gap-16
+               {% endif %}
+              "
     >
-        <a href="{{ url }}">
-            {% block image %}
-                {% image image fill-1200x628 %}
-            {% endblock image %}
-        </a>
-    </div>
-
-    <div>
-        <div class="tw-flex tw-flex-wrap">
-            {% block tags %}{% endblock %}
-            {% block published_date %}{% endblock %}
+        <div
+            {% if horizontal %}
+                class="medium:tw-max-w-xs large:tw-max-w-sm medium:tw-shrink-0"
+            {% endif %}
+        >
+            <a href="{{ url }}">
+                {% block image %}
+                    {% image image fill-1200x628 %}
+                {% endblock image %}
+            </a>
         </div>
 
-        <a href="{{ url }}" class="tw-group tw-block hover:tw-no-underline">
-            <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">
-                {% block title %}
-                    {{ title }}
-                {% endblock title %}
-            </p>
-            <div class="tw-body-small my-0">
-                {% block description %}{% endblock %}
+        <div>
+            <div class="tw-flex tw-flex-wrap">
+                {% block tags %}{% endblock %}
+                {% block published_date %}{% endblock %}
             </div>
-        </a>
-        {% block byline %}{% endblock %}
+
+            <a href="{{ url }}" class="tw-group tw-block hover:tw-no-underline">
+                <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">
+                    {% block title %}
+                        {{ title }}
+                    {% endblock title %}
+                </p>
+                <div class="tw-body-small my-0">
+                    {% block description %}{% endblock %}
+                </div>
+            </a>
+            {% block byline %}{% endblock %}
+        </div>
     </div>
-</div>
 {% endwith %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/generic_card.html
@@ -1,5 +1,10 @@
 {% load wagtailcore_tags wagtailimages_tags %}
-
+{% if page %}
+    {% if not url %}
+        {% pageurl page as url %}
+    {% endif %}
+{% endif %}
+{% with title=title|default:page.localized.title image=image|default:page.localized.specific.get_meta_image %}
 <div
     class="
            tw-flex
@@ -17,8 +22,10 @@
             class="medium:tw-max-w-xs large:tw-max-w-sm medium:tw-shrink-0"
         {% endif %}
     >
-        <a href="{% pageurl page %}">
-            {% image page.localized.specific.get_meta_image fill-1200x628 %}
+        <a href="{{ url }}">
+            {% block image %}
+                {% image image fill-1200x628 %}
+            {% endblock image %}
         </a>
     </div>
 
@@ -28,8 +35,12 @@
             {% block published_date %}{% endblock %}
         </div>
 
-        <a href="{% pageurl page %}" class="tw-group tw-block hover:tw-no-underline">
-            <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">{{ page.localized.title }}</p>
+        <a href="{{ url }}" class="tw-group tw-block hover:tw-no-underline">
+            <p class="tw-h4-heading d-inline-block mt-1 mb-2 group-hover:tw-underline">
+                {% block title %}
+                    {{ title }}
+                {% endblock title %}
+            </p>
             <div class="tw-body-small my-0">
                 {% block description %}{% endblock %}
             </div>
@@ -37,3 +48,4 @@
         {% block byline %}{% endblock %}
     </div>
 </div>
+{% endwith %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR updates the generic card template to be more generic. 

Previously it was only possible to pass a page. While this works often it fails in cases where we might want to link to external pages. See #11585. 

This PR adds the option to pass url, image, and title directly to the card template making it more re-usable. It also adds extra blocks for overrides.

Currently, the generic card is used as basis for the blog card (on the blog index) and for the related links in each blog page. 

Link to sample test page: http://localhost:8000/en/blog/, http://localhost:8000/en/blog/initial-test-blog-post-with-fixed-title/
Related PRs/issues: #11600

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [-] Did I update or add new fake data?
- [-] Did I squash my migration?
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [-] Is my code documented?
- [-] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
