### PR TITLE
11631  Fix HTML validation errors on PNI article page

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/share-buttons.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/share-buttons.html
@@ -12,7 +12,7 @@
                         <span>{% trans "Facebook" %}</span>
                     {% endif %}
                 </a>
-                <a class="tw-btn tw-btn-secondary btn-share after:tw-hidden twitter-share" href="https://twitter.com/intent/tweet?text={{ share_text|urlencode }} {{ current_url|urlencode }} ">
+                <a class="tw-btn tw-btn-secondary btn-share after:tw-hidden twitter-share" href="https://twitter.com/intent/tweet?text={{ share_text|urlencode }}%20{{ current_url|urlencode }}">
                     {% if version == "mini" %}
                         <span class="sr-only">{% trans "Share on Twitter" %}</span>
                     {% else %}
@@ -21,7 +21,7 @@
                 </a>
             </div>
             <div class="subgroup">
-                <a class="tw-btn tw-btn-secondary btn-share after:tw-hidden email-share" href="mailto:?&body={{ share_text|urlencode }} {{ current_url|urlencode }}">
+                <a class="tw-btn tw-btn-secondary btn-share after:tw-hidden email-share" href="mailto:?&body={{ share_text|urlencode }}%20{{ current_url|urlencode }}">
                     {% if version == "mini" %}
                         <span class="sr-only">{% trans "Share by Email" %}</span>
                     {% else %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR fixes 2 validation errors on the PNI article page type (the page type with the most traffic). 

https://validator.w3.org/nu/?doc=https%3A%2F%2Ffoundation.mozilla.org%2Fen%2Fprivacynotincluded%2Farticles%2Fits-official-cars-are-the-worst-product-category-we-have-ever-reviewed-for-privacy%2F

Some errors reported in production have been fixed already with other PRs. 

Some errors are not resolved because fixing them will require larger refactorings and should be done in dedicated PRs. (#11606, #11605)

Then there are 3 errors (particularly on the [highest traffic page](https://foundation.mozilla.org/en/privacynotincluded/articles/its-official-cars-are-the-worst-product-category-we-have-ever-reviewed-for-privacy/)) that can not be fixed as they are injected from the Datawrapper embed markup which is coming from Datawrapper and we don't have control over. 

Link to sample test page: https://foundation.mozilla.org/en/privacynotincluded/articles/its-official-cars-are-the-worst-product-category-we-have-ever-reviewed-for-privacy/
Related PRs/issues: #11631 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [-] Did I update or add new fake data?
- [-] Did I squash my migration?
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [-] Is my code documented?
- [-] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
