### PR TITLE
11632 fix html validation errors campaign page

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/callpower.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/callpower.html
@@ -2,7 +2,9 @@
 
 <div class="callpower-cta">
     <form class="cta-form">
-        <h5 class="tw-h5-heading">{{ cta.header }}</h5>
+        {% if cta.header %}
+            <h5 class="tw-h5-heading">{{ cta.header }}</h5>
+        {% endif %}
         <p>{{ cta.description | safe }}</p>
         <div>
             <input type="hidden" name="campaignId" value="{{ cta.campaign_id }}">

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/petition.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/petition.html
@@ -19,7 +19,9 @@
     {% endif %}
 
     {% if not show_formassembly_thank_you %}
-        <h5 class="tw-h5-heading">{{ cta.header | escape }}</h5>
+        {% if cta.header %}
+            <h5 class="tw-h5-heading">{{ cta.header | escape }}</h5>
+        {% endif %}
         {{ cta.description | richtext }}
         <p class="label tw-body-small tw-italic tw-my-4">{% blocktrans %} * indicates a required field {% endblocktrans %}</p>
         {% comment %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/signup.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/signup.html
@@ -1,6 +1,8 @@
 <div
     class="join-us mb-5"
-    data-cta-header="{{ cta.header | escape }}"
+    {% if cta.header %}
+        data-cta-header="{{ cta.header | escape }}"
+    {% endif %}
     data-cta-description="{{ cta.description | escape }}"
     data-newsletter="{{ cta.newsletter }}">
 </div>


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR fixes 1 validation error on the campaign page when the displayed CTA does not have a header defined. 

There are a bunch of other validation errors on the [reference page](https://foundation.mozilla.org/fr/campaigns/sign-our-petition-to-stop-france-from-forcing-browsers-like-mozillas-firefox-to-censor-websites/). However, all those are related to the FormAssembly code in `formassembly_header.html` and `formassembly_body.html`, which seems to be coming from FormAssembly and I don't want to touch that without more knowledge of it.

Link to sample test page: https://foundation.mozilla.org/fr/campaigns/sign-our-petition-to-stop-france-from-forcing-browsers-like-mozillas-firefox-to-censor-websites/
Related PRs/issues: #11632 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [-] Is the code I'm adding covered by tests?

**Changes in Models:**
- [-] Did I update or add new fake data?
- [-] Did I squash my migration?
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [-] Is my code documented?
- [-] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
