### PR TITLE
7028 sign up block image resolution

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -18,7 +18,7 @@
                             data-ask-name="{{ snippet_localized.ask_name }}">
                         </div>
                     </div>
-                    {% image snippet_localized.background_image fill-442x256 as background_image %}
+                    {% image snippet_localized.background_image fill-475x475 as background_image %}
                     <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat large:tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
                 </div>
             {% endwith %}

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -19,7 +19,7 @@
                         </div>
                     </div>
                     {% image snippet_localized.background_image fill-442x256 as background_image %}
-                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
+                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat large:tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
                 </div>
             {% endwith %}
         </div>

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -19,7 +19,27 @@
                         </div>
                     </div>
                     {% image snippet_localized.background_image fill-475x475 as background_image %}
-                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-center tw-bg-no-repeat large:[background-image:_var(--background-image)]" style="--background-image: url({{ background_image.url }})"></div>
+                    {% image snippet_localized.background_image fill-950x950 as background_image_2x %}
+                    <div
+                        class="
+                            tw-hidden large:tw-block
+                            after:tw-h-full
+                            after:tw-block
+                            after:tw-w-full
+                            after:tw-bg-gradient-to-tl
+                            after:tw-from-black
+                            after:tw-via-10%
+                            after:tw-via-transparent
+                            after:tw-to-black
+                            after:tw-content-['']
+                            large:tw-w-5/12
+                            tw-bg-cover
+                            tw-bg-center
+                            tw-bg-no-repeat
+                            large:[background-image:_var(--background-image)]
+                            large:2xdpi:[background-image:_var(--background-image-2x)]
+                        "
+                        style="--background-image: url({{ background_image.url }}); --background-image-2x: url({{ background_image_2x.url }})"></div>
                 </div>
             {% endwith %}
         </div>

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -22,23 +22,23 @@
                     {% image snippet_localized.background_image fill-950x950 as background_image_2x %}
                     <div
                         class="
-                            tw-hidden large:tw-block
-                            after:tw-h-full
-                            after:tw-block
-                            after:tw-w-full
-                            after:tw-bg-gradient-to-tl
-                            after:tw-from-black
-                            after:tw-via-10%
-                            after:tw-via-transparent
-                            after:tw-to-black
-                            after:tw-content-['']
-                            large:tw-w-5/12
-                            tw-bg-cover
-                            tw-bg-center
-                            tw-bg-no-repeat
-                            large:[background-image:_var(--background-image)]
-                            large:2xdpi:[background-image:_var(--background-image-2x)]
-                        "
+                               tw-hidden large:tw-block
+                               after:tw-h-full
+                               after:tw-block
+                               after:tw-w-full
+                               after:tw-bg-gradient-to-tl
+                               after:tw-from-black
+                               after:tw-via-10%
+                               after:tw-via-transparent
+                               after:tw-to-black
+                               after:tw-content-['']
+                               large:tw-w-5/12
+                               tw-bg-cover
+                               tw-bg-center
+                               tw-bg-no-repeat
+                               large:[background-image:_var(--background-image)]
+                               large:2xdpi:[background-image:_var(--background-image-2x)]
+                              "
                         style="--background-image: url({{ background_image.url }}); --background-image-2x: url({{ background_image_2x.url }})"></div>
                 </div>
             {% endwith %}

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -19,7 +19,7 @@
                         </div>
                     </div>
                     {% image snippet_localized.background_image fill-442x256 as background_image %}
-                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat" style="background-image: url('{{ background_image.url }}')"></div>
+                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
                 </div>
             {% endwith %}
         </div>

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -19,7 +19,7 @@
                         </div>
                     </div>
                     {% image snippet_localized.background_image fill-475x475 as background_image %}
-                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-no-repeat large:tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
+                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-center tw-bg-no-repeat large:tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
                 </div>
             {% endwith %}
         </div>

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -19,7 +19,7 @@
                         </div>
                     </div>
                     {% image snippet_localized.background_image fill-475x475 as background_image %}
-                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-center tw-bg-no-repeat large:tw-bg-custom-property" style="--background-image: url({{ background_image.url }})"></div>
+                    <div class="tw-hidden large:tw-block after:tw-h-full after:tw-block after:tw-w-full after:tw-bg-gradient-to-tl after:tw-from-black after:tw-via-10% after:tw-via-transparent after:tw-to-black after:tw-content-[''] large:tw-w-5/12 tw-bg-cover tw-bg-center tw-bg-no-repeat large:[background-image:_var(--background-image)]" style="--background-image: url({{ background_image.url }})"></div>
                 </div>
             {% endwith %}
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,9 @@ module.exports = {
         contain: "contain",
         ...theme("spacing"),
       }),
+      backgroundImage: {
+        "custom-property": "var(--background-image)",
+      },
       gridAutoRows: {
         "1fr": "1fr",
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,9 +76,6 @@ module.exports = {
         contain: "contain",
         ...theme("spacing"),
       }),
-      backgroundImage: {
-        "custom-property": "var(--background-image)",
-      },
       gridAutoRows: {
         "1fr": "1fr",
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -128,6 +128,8 @@ module.exports = {
       large: "992px",
       xlarge: "1200px",
       "2xl": "1400px",
+      // High density screens (retina)
+      "2xdpi": {raw: "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"},
     },
     fontFamily: {
       sans: ["Nunito Sans", "Helvetica", "Arial", "sans-serif"],


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
Increase the image resolution used for the sign-up snippet with background block. Bumping both axes to make a square image because large tablets will show the image in square dimensions. 

Also, limiting the loading of the background image to large screen devices that actually display the image. 

Link to sample test page: http://mozfest.localhost:8000/en/
Related PRs/issues: https://torchbox.monday.com/boards/1334760528/pulses/1336237028

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- [-] Did I update or add new fake data?
- [-] Did I squash my migration?
- [x] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [-] Is my code documented?
- [-] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
