### PR TITLE
Fix PNI product subnav

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,7 +53,7 @@ module.exports = {
       addVariant("summary-open", ["details[open] > summary > &"]);
       addVariant("details-open", ["details[open] > &"]);
       addVariant("rich-text-links", "& [class~='rich-text'] a");
-      addVariant("2xdpi", "@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)");
+      addVariant("2xdpi", "@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)");  // high density screens (retina)
       addBase(newBase);
     }),
     ...componentPlugins,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,6 +53,7 @@ module.exports = {
       addVariant("summary-open", ["details[open] > summary > &"]);
       addVariant("details-open", ["details[open] > &"]);
       addVariant("rich-text-links", "& [class~='rich-text'] a");
+      addVariant("2xdpi", "@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)");
       addBase(newBase);
     }),
     ...componentPlugins,
@@ -128,8 +129,6 @@ module.exports = {
       large: "992px",
       xlarge: "1200px",
       "2xl": "1400px",
-      // High density screens (retina)
-      "2xdpi": {raw: "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"},
     },
     fontFamily: {
       sans: ["Nunito Sans", "Helvetica", "Arial", "sans-serif"],


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

When the `tailwind.config.js` was changed during the Mozfest work to query retina screens, it introduced a screen size as an object:

```js
screens: {
      ...
      // High density screens (retina)
      "2xdpi": {raw: "(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)"},
    },
```

That's fine but it means that we can't use the `min-` and `max-` variants when the we have that kind of screen config. Tailwind started to alert us:

```sh
backend-1   | 18:22:45 frontend-watch.1 | warn - The `min-*` and `max-*` variants are not supported with a `screens` configuration containing objects.
```

On PNI, the placement of the subnav was now in the wrong place (image show before/after): 

![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/61277874/b6696b12-b962-42ed-9e47-65be207b95a9)


On this component, `min-[400px]` is used to [disable a hidden ](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/cd0b3b6227b40a2727f9d0f866735a148c6fbcf6/network-api/networkapi/templates/fragments/buyersguide/product_tab_header.html#L7-L8) `li` [on screens larger than mobile:](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/cd0b3b6227b40a2727f9d0f866735a148c6fbcf6/network-api/networkapi/templates/fragments/buyersguide/product_tab_header.html#L7-L8)

```html
        <!-- Need this span for x-scrolling on smaller devices so the first tab doesn't get cut off -->
        <li class="tw-py-4 tw-px-24 tw-shrink-0 tw-relative tw-opacity-0 min-[330px]:tw-w-[50px] min-[400px]:tw-hidden">mobile</li>
```

but that doesn't work anymore because of the new Tailwind config. If we comment the `2xdpi` line, the Buyers Guide component goes back to normal.

This PR fixes that by querying the retina as a variant, not as a new screen. This preserves the previous behaviour.

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
