### PR TITLE
Removed 'data-newsletter' attribute from template because it's not doing anything

### DIFF
--- a/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/newsletter_signup_with_background_block.html
@@ -14,7 +14,6 @@
                             data-signup-id="{{ snippet_localized.id }}"
                             data-cta-header="{{ snippet_localized.header | escape }}"
                             data-cta-description="{{ snippet_localized.description | escape }}"
-                            data-newsletter="{{ snippet_localized.newsletter }}"
                             data-ask-name="{{ snippet_localized.ask_name }}">
                         </div>
                     </div>

--- a/network-api/networkapi/mozfest/templates/fragments/blocks/sign_up_block.html
+++ b/network-api/networkapi/mozfest/templates/fragments/blocks/sign_up_block.html
@@ -12,7 +12,6 @@
                         data-signup-id="{{ self.signup.id | unlocalize }}"
                         data-cta-header="{{ self.signup.header | escape }}"
                         data-cta-description="{{ self.signup.description | escape }}"
-                        data-newsletter="{{ self.signup.newsletter }}"
                     >
                     </div>
                 </div>

--- a/network-api/networkapi/mozfest/templates/partials/mozfest_footer.html
+++ b/network-api/networkapi/mozfest/templates/partials/mozfest_footer.html
@@ -17,8 +17,7 @@
                 data-signup-id="{{ localized_footer_signup.id }}"
                 data-button-text="{% trans "Sign up" context "Submit button for newsletter signup form" %}"
                 data-cta-header="{{ localized_footer_signup.header | escape }}"
-                data-cta-description="{{ localized_footer_signup.description | escape }}"
-                data-newsletter="{{ localized_footer_signup.newsletter }}">
+                data-cta-description="{{ localized_footer_signup.description | escape }}">
             </div>
         {% endwith %}
 

--- a/network-api/networkapi/mozfest/templates/partials/signup.html
+++ b/network-api/networkapi/mozfest/templates/partials/signup.html
@@ -14,7 +14,6 @@
                         data-signup-id="{{ localized_signup.id }}"
                         data-cta-header="{{ localized_signup.header | escape }}"
                         data-cta-description="{{ localized_signup.description | escape }}"
-                        data-newsletter="{{ localized_signup.newsletter }}"
                         data-ask-name="{{ localized_signup.ask_name }}">
                     </div>
                 {% endwith %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/bannered_campaign_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/bannered_campaign_page.html
@@ -67,7 +67,6 @@ An extra check has been added so as to not show the fixed "Take action" button o
                                     data-signup-id="{{ localized_signup.id }}"
                                     data-cta-header="{{ localized_signup.header | escape }}"
                                     data-cta-description="{{ localized_signup.description | escape }}"
-                                    data-newsletter="{{ localized_signup.newsletter }}"
                                     data-ask-name="{{ localized_signup.ask_name }}">
                                 </div>
                             {% endwith %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/blog_newsletter_signup_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/blog_newsletter_signup_block.html
@@ -12,6 +12,5 @@
          data-button-text="{% trans "Sign up" context "Submit button for newsletter signup form" %}"
          data-cta-header="{{ self.signup.header | escape }}"
          data-cta-description="{{ self.signup.description | escape }}"
-         data-newsletter="{{ self.signup.newsletter }}"
     ></div>
 {% endblock block_content %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/newsletter_signup_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/newsletter_signup_block.html
@@ -13,7 +13,6 @@
             data-signup-id="{{ self.signup.id | unlocalize }}"
             data-cta-header="{{ self.signup.header | escape }}"
             data-cta-description="{{ self.signup.description | escape }}"
-            data-newsletter="{{ self.signup.newsletter }}"
             data-ask-name="{{ self.signup.ask_name }}">
             >
         </div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/signup.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/signup.html
@@ -3,6 +3,5 @@
     {% if cta.header %}
         data-cta-header="{{ cta.header | escape }}"
     {% endif %}
-    data-cta-description="{{ cta.description | escape }}"
-    data-newsletter="{{ cta.newsletter }}">
+    data-cta-description="{{ cta.description | escape }}">
 </div>


### PR DESCRIPTION
TL;DR 
Removed `data-newsletter` attribute from template code because it's not doing anything. Please see below for detailed explanation.

Related PRs/issues: #11712

---

# Back end

When handling newsletter signup info, [backend](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/network-api/networkapi/campaign/views.py#L78) gets the `newsletters` value from the Signup object directly and not through the payload it receives. This means payload does not need to include such value.

# Front end

In the codebase, there are two ways to render newsletter signup modules:

### 1. Through `join-us.js` (code is being refactored and going away soon)

[`join-us.js`](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/common/inject-react/join-us.js#L24) renders the [newsletter module (join.jsx)](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/components/join/join.jsx) at where the `.join-us` DOM nodes are.

`data-newsletter` is passed as `props` into the React components `<JoinUs>`. However, in `join.jsx` implementation, looking for keywords like `newsletter` and `props`, I don't see the value of `newsletter` being used or manipulated anywhere. The payload in [submitDataToApi method](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/components/join/join.jsx#L133-L180) does not include `newsletter` info either. Hence, I've removed the `data-newsletter` attribute from `.join-us` DOM nodes.

**Link to sample test page**
- Create a BannerPage (BanneredCampaignPage) locally and link it with a Signup snippet.
- template code: https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11724/files#diff-45e83b057173ef31d57fa50a5144e65fe24cb5ec6c3309d603057610aad21599
- when testing, please use `mozilla-foundation`, `mozilla-festival`, or `mozilla-foundation,mozilla-festival` as the "newsletter" value because Basket only accepts these.

### 2. Through `newsletter-signup-module.js`

[newsletter-signup-module.js](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/common/inject-react/newsletter-signup-module.js#L31) renders the [newsletter modules (default-layout-signup.jsx)](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/components/newsletter-signup/organisms/default-layout-signup.jsx) at where the `.newsletter-signup-module` DOM nodes are.

`data-newsletter` is passed as `props` into the React components `<DefaultLayoutSignup>`. However, in `default-layout-signup.jsx` and [its HOC component](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/components/newsletter-signup/organisms/with-submission-logic.jsx)'s implementation, looking for keywords like `newsletter` and `props`, I don't see the value of `newsletter` being used or manipulated anywhere. The payload in [submitDataToApi method](https://github.com/MozillaFoundation/foundation.mozilla.org/blob/main/source/js/components/newsletter-signup/organisms/with-submission-logic.jsx#L169-L176) does not include `newsletter` info either. Hence, I've removed the `data-newsletter` attribute from `.newsletter-signup-module` DOM nodes.

**Link to sample test page**
- http://mozfest.localhost:8000/ (signup form on footer)
- template code: https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11724/files#diff-ae5210abd937cbe7ed10c81b534e646ae8a820a29bc4ebff362a50352e8aa76e
- when testing, please use `mozilla-foundation`, `mozilla-festival`, or `mozilla-foundation,mozilla-festival` as the "newsletter" value because Basket only accepts these.