### PR TITLE
Updated newsletter module on PNI consumer page's quiz section

### DIFF
--- a/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
+++ b/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { POINTS, PRODUCTS, RESULTS } from "./data";
 import JoinUs from "../../../components/join/join.jsx";
+import DefaultLayoutSignup from "../../../components/newsletter-signup/organisms/default-layout-signup.jsx";
 import ProductQuizShareButtons from "../social-share/product-quiz-share-buttons.jsx";
 
 class ProductQuiz extends Component {
@@ -259,14 +260,14 @@ class ProductQuiz extends Component {
             more people like you.
           </p>
         </div>
-        <div className="join-us react-rendered">
-          <JoinUs
+        <div className="newsletter-signup-module react-rendered">
+          <DefaultLayoutSignup
             formPosition="pni-product-quiz"
-            formStyle="pni"
+            formStyle="pni-product-quiz"
             ctaHeader=""
             ctaDescription=""
             apiUrl={this.props.joinUsApiUrl}
-            disableSubmitButton={true}
+            disableSubmitButtonByDefault={true}
             handleSignUp={(successState) => this.handleSignUp(successState)}
           />
         </div>

--- a/source/js/common/inject-react/newsletter-signup-module.js
+++ b/source/js/common/inject-react/newsletter-signup-module.js
@@ -10,7 +10,9 @@ import DefaultSignupForm from "../../components/newsletter-signup/organisms/defa
 export default (apps, siteUrl) => {
   // excluding `.newsletter-signup-module.on-nav` because it's taken care of by nav-newsletter.js
   document
-    .querySelectorAll(`.newsletter-signup-module:not(.on-nav)`)
+    .querySelectorAll(
+      `.newsletter-signup-module:not(.on-nav):not(.react-rendered)`
+    )
     .forEach((element) => {
       const props = element.dataset;
       const sid = props.signupId || 0;

--- a/source/js/components/newsletter-signup/atoms/button-submit.jsx
+++ b/source/js/components/newsletter-signup/atoms/button-submit.jsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import PropTypes from "prop-types";
 
 const ButtonSubmit = ({
+  disabled = false,
   children,
   buttonStyle = "primary",
   widthClasses = `tw-w-full`,
@@ -14,7 +15,7 @@ const ButtonSubmit = ({
   let classes = classNames(`tw-btn tw-btn-${buttonStyle}`, widthClasses);
 
   return (
-    <button type="submit" className={classes}>
+    <button type="submit" className={classes} disabled={disabled}>
       {children}
     </button>
   );

--- a/source/js/components/newsletter-signup/organisms/default-layout-signup.jsx
+++ b/source/js/components/newsletter-signup/organisms/default-layout-signup.jsx
@@ -41,6 +41,7 @@ class DefaultSignupForm extends Component {
         privacy: "",
       },
       showAllFields: false,
+      submitButtonDisabled: this.props.disableSubmitButtonByDefault,
     };
   }
 
@@ -80,8 +81,18 @@ class DefaultSignupForm extends Component {
     return this.state.formData[name];
   }
 
+  // Toggle the submit button disabled state if the button is disabled by default
+  toggleSubmitButton(setToDisabled) {
+    if (this.props.disableSubmitButtonByDefault) {
+      this.setState({
+        submitButtonDisabled: setToDisabled,
+      });
+    }
+  }
+
   handleEmailChange(event) {
     this.updateFormFieldValue("email", event.target.value);
+    this.toggleSubmitButton(event.target.value === "");
   }
 
   handleCountryChange(event) {
@@ -222,6 +233,7 @@ class DefaultSignupForm extends Component {
             <ButtonSubmit
               buttonStyle={this.style.buttonStyle}
               widthClasses={this.style.buttonWidthClasses}
+              disabled={this.state.submitButtonDisabled}
             >
               {this.buttonText}
             </ButtonSubmit>

--- a/source/js/components/newsletter-signup/organisms/form-specific-style.js
+++ b/source/js/components/newsletter-signup/organisms/form-specific-style.js
@@ -80,6 +80,7 @@ export const FORM_STYLE = {
     fieldStyle: "filled",
     headingLevel: 4,
     headingClass: `tw-h5-heading`,
+  },
   "youtube-regrets-reporter:2-col": {
     buttonStyle: "primary",
     buttonWidthClasses: "tw-w-full",

--- a/source/js/components/newsletter-signup/organisms/form-specific-style.js
+++ b/source/js/components/newsletter-signup/organisms/form-specific-style.js
@@ -76,4 +76,9 @@ export const FORM_STYLE = {
     headingLevel: 3,
     headingClass: "tw-h5-heading",
   },
+  "pni-product-quiz": {
+    fieldStyle: "filled",
+    headingLevel: 4,
+    headingClass: `tw-h5-heading`,
+  },
 };


### PR DESCRIPTION
Updated newsletter module on PNI consumer page's quiz section with the new implementation approach.

Related PRs/issues: #11671 


---

- Review app: https://foundation-s-11671-news-tsuohl.herokuapp.com/en/privacynotincluded/articles/annual-consumer-creep-o-meter/
- Prod: https://foundation.mozilla.org/en/privacynotincluded/articles/annual-creep-o-meter/

# To QA

1. Go to the page
2. Scroll to the quiz section and select "See Results"
3. Sign up button should be disabled by default and whenever "email" field is empty

Note that on prod, there's no gap in between the email field and "Sign up" button but on review app there is. This is expected behaviour and not a regression.

<img width="1049" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/7c307bd8-fc8e-4dd1-8fac-20dfcc8411d1">

<img width="1055" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/623906ac-823e-40ec-b7a0-55ef0c716e01">


