### PR TITLE
Bump postgres images from 13 to 15

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres:13.2
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       postgres:
-        image: postgres:13.2
+        image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Mozilla Foundation site",
   "description": "Mozilla Foundation site",
   "addons": [
-    "heroku-postgresql:mini --version=15"
+    "heroku-postgresql:basic --version=15"
   ],
   "formation": {
     "web": {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Mozilla Foundation site",
   "description": "Mozilla Foundation site",
   "addons": [
-    "heroku-postgresql:mini"
+    "heroku-postgresql:mini --version=15"
   ],
   "formation": {
     "web": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:13.2
+    image: postgres:15
     ports:
       - "5678:5432"
     environment:


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Upgrades postgres images used locally, on CI and on Review Apps to use version 15 instead of 13.

Pins the version used on Review Apps. Before, it was always using the latest version.

Fixes an issue where Heroku warns of a "Database disruption imminent" on Review Apps. This was caused by using the "mini" plan, which only allows up to 10,000 rows in it. This PR fixes it by bumping it to a "basic" plan, which allows for up to a million rows in a DB. See [Essential Tier in Heroku](https://devcenter.heroku.com/articles/heroku-postgres-plans#essential-tier):

| Plan Name |    Provisioning Name    |  Row Limit | Disk Size | Connection Limit |
|:---------:|:-----------------------:|:----------:|:---------:|:----------------:|
| Mini      | heroku-postgresql:mini  | 10,000     | 1 GB      | 20               |
| Basic     | heroku-postgresql:basic | 10,000,000 | 10 GB     | 20               |

Link to sample test page:
Related PRs/issues: #11691 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
