### PR TITLE
Fix a bug in signup form on PNI Consumer Page's quiz section

### DIFF
--- a/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
+++ b/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { POINTS, PRODUCTS, RESULTS } from "./data";
-import JoinUs from "../../../components/join/join.jsx";
 import DefaultLayoutSignup from "../../../components/newsletter-signup/organisms/default-layout-signup.jsx";
 import ProductQuizShareButtons from "../social-share/product-quiz-share-buttons.jsx";
 

--- a/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
+++ b/source/js/buyers-guide/components/product-quiz/product-quiz.jsx
@@ -206,8 +206,8 @@ class ProductQuiz extends Component {
     );
   }
 
-  handleSignUp(successState) {
-    this.setState({ showThankYou: successState }, () => {
+  handleSubmissionSuccess(isSuccess) {
+    this.setState({ showThankYou: isSuccess }, () => {
       setTimeout(() => {
         this.moveToNextStep();
       }, this.finalScreenDelay);
@@ -268,7 +268,9 @@ class ProductQuiz extends Component {
             ctaDescription=""
             apiUrl={this.props.joinUsApiUrl}
             disableSubmitButtonByDefault={true}
-            handleSignUp={(successState) => this.handleSignUp(successState)}
+            handleSubmissionSuccess={(isSuccess) =>
+              this.handleSubmissionSuccess(isSuccess)
+            }
           />
         </div>
         <div className="tw-text-center">

--- a/source/js/components/join/join.jsx
+++ b/source/js/components/join/join.jsx
@@ -34,9 +34,7 @@ class JoinUs extends Component {
       apiFailed: false,
       userTriedSubmitting: false,
       lang: getCurrentLanguage(),
-      hideLocaleFields: [`body`, `callout-box`, `pni-product-quiz`].includes(
-        props.formPosition
-      ),
+      hideLocaleFields: [`body`, `callout-box`].includes(props.formPosition),
       submitButtonDisabled: props.disableSubmitButton,
     };
   }
@@ -69,16 +67,9 @@ class JoinUs extends Component {
 
   // state update function
   apiSubmissionSuccessful() {
-    this.setState(
-      {
-        apiSuccess: true,
-      },
-      () => {
-        if (this.props.formPosition === "pni-product-quiz") {
-          this.props.handleSignUp(true);
-        }
-      }
-    );
+    this.setState({
+      apiSuccess: true,
+    });
   }
 
   // state update function

--- a/source/js/components/newsletter-signup/organisms/with-submission-logic.jsx
+++ b/source/js/components/newsletter-signup/organisms/with-submission-logic.jsx
@@ -143,6 +143,7 @@ function withSubmissionLogic(WrappedComponent) {
               this.setState({
                 apiSubmissionStatus: this.API_SUBMISSION_STATUS.SUCCESS,
               });
+              this.props.handleSubmissionSuccess?.(true);
             })
             .catch(() => {
               // [TODO][FIXME] We need to let the user know that something went wrong


### PR DESCRIPTION
# Description

My previous PR #11729  failed to include functionality to trigger the `handleSignUp` function . This PR includes the fix to that. Note that I've renamed the function name to `handleSubmissionSuccess`.

Related PRs/issues: #11671 

## Review App
https://foundation-s-11671-foll-ltrnii.herokuapp.com/en/privacynotincluded/articles/annual-consumer-creep-o-meter/

## Expected Behaviour (Thank You screen disappears after a few seconds.)
Prod: https://foundation.mozilla.org/en/privacynotincluded/articles/annual-creep-o-meter/

https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/ff1f0804-9dc3-48b9-a99f-c970225fec3f

## Staging (Has bug. Thank You screen shows too many things.)
Staging: https://foundation.mofostaging.net/en/privacynotincluded/articles/annual-creep-o-meter/

<img width="1167" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/8bb5d7d2-ddff-49f7-b900-c2bf144ff9de">

