### PR TITLE
updated ordering of related products

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -998,7 +998,9 @@ class ProductPage(BasePage):
 
     @property
     def localized_related_products(self):
-        related_products = ProductPage.objects.filter(related_product_relationships__page=self).order_by("related_product_relationships__sort_order")
+        related_products = ProductPage.objects.filter(related_product_relationships__page=self).order_by(
+            "related_product_relationships__sort_order"
+        )
         related_products = localize_queryset(related_products, preserve_order=True)
         return related_products.specific()
 

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/products.py
@@ -998,8 +998,9 @@ class ProductPage(BasePage):
 
     @property
     def localized_related_products(self):
-        related_products = ProductPage.objects.filter(related_product_relationships__page=self)
-        return localize_queryset(related_products).order_by("title")
+        related_products = ProductPage.objects.filter(related_product_relationships__page=self).order_by("related_product_relationships__sort_order")
+        related_products = localize_queryset(related_products, preserve_order=True)
+        return related_products.specific()
 
     @property
     def local_categories(self):

--- a/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
+++ b/network-api/networkapi/wagtailpages/tests/buyersguide/test_products.py
@@ -81,7 +81,7 @@ class TestProductPage(BuyersGuideTestCase):
             )
             related_products.append(related_product)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             result = product_page.localized_related_products
             for related_product in related_products:
                 self.assertIn(related_product, result)


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Related PRs/issues: #11799

Using https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11514/ for reference, this PR updates the `ProductPage`'s `localized_related_products` method to return the product page's related products in the order in which they are set through the CMS.



# Screenshots:

**CMS:**

![Screenshot 2024-01-31 at 22-59-23 Editing General Product Page Dodge - Wagtail](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/b44841b4-85c7-4670-ba93-7c4653fd738e)


**Ordering Before (Alphabetically by title) :**
![Screenshot 2024-01-31 at 23-02-39 Privacy Not Included review Dodge](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/4b3dae03-1b6a-4432-b3a5-08239449219f)



**Ordering After (sorted by CMS sort order):**

![Screenshot 2024-01-31 at 23-00-14 Privacy Not Included review Dodge](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/696aa9c0-7b91-4256-a815-19a5de82c77c)


