### PR TITLE
updated press page copy per request of stakeholders

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/about/press.html
+++ b/network-api/networkapi/templates/pages/buyersguide/about/press.html
@@ -23,10 +23,9 @@
             <img src="{% static "_images/minus-circle.svg" %}" alt="" data-state="close" class="tw-hidden summary-open:tw-block" />
         </summary>
         <p class="tw-body">
-            {% blocktrans with pni_url="https://foundation.mozilla.org/privacynotincluded/" typeform_url="https://mozillafoundation.typeform.com/to/oWfci8Ee" trimmed %}
-                <em>*Privacy Not Included</em> can help inform your research. Let the <a href="{{ pni_url }}">product guide</a> assist you
-                in incorporating privacy—and not just price and performance—into your consumer technology coverage. If you don’t find
-                the product you’re looking for, you can submit your suggestion <a href="{{ typeform_url }}">here</a>.
+            {% blocktrans with pni_url="https://foundation.mozilla.org/privacynotincluded/" trimmed %}
+                <em>*Privacy Not Included</em> can help inform your research. Let the <a href="{{ pni_url }}">product guide</a> assist
+                you in incorporating privacy—and not just price and performance—into your consumer technology coverage.
             {% endblocktrans %}
         </p>
         <p class="tw-body">


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: https://foundation-s-pni-press--ji5axn.herokuapp.com/en/privacynotincluded/about/press/
Related PRs/issues: #11138


Per request of stakeholders, this PR removes the line `If you don’t find the product you’re looking for, you can submit your suggestion here` from the PNI press page.


# Screenshots

**Before:**
![Screenshot 2024-02-01 at 13-11-29 Privacy Not Included A Buyer’s Guide for Connected Products](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/186cde61-cee9-47b4-844b-c916fd6208c0)


**After:**
![Screenshot 2024-02-01 at 13-12-25 Privacy Not Included A Buyer’s Guide for Connected Products](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/a0d29e8d-8539-4b5f-8e6d-be31ebf8791e)
