### PR TITLE
Replaced Campaign Page's newsletter signup form with the new implementation approach

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/signup.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/tags/cta/signup.html
@@ -1,5 +1,12 @@
+{% load i18n %}
+
 <div
-    class="join-us mb-5"
+    class="newsletter-signup-module mb-5"
+    data-module-type="default"
+    data-form-style="bannered-campaign-body"
+    data-show-country-field-by-default="true"
+    data-show-language-field-by-default="true"
+    data-button-text="{% trans "Sign up" context "Submit button for newsletter signup form" %}"
     {% if cta.header %}
         data-cta-header="{{ cta.header | escape }}"
     {% endif %}

--- a/source/js/components/newsletter-signup/organisms/form-specific-style.js
+++ b/source/js/components/newsletter-signup/organisms/form-specific-style.js
@@ -61,6 +61,14 @@ export const FORM_STYLE = {
     innerWrapperClass: "tw-flex tw-gap-8",
     introContainerClass: "tw-w-1/2 large:tw-pr-24",
   },
+  "campaign-body": {
+    buttonPosition: "bottom",
+    buttonStyle: "primary",
+    buttonWidthClasses: "tw-w-full",
+    fieldStyle: "filled",
+    headingLevel: 3,
+    headingClass: "tw-h5-heading",
+  },
   footer: {
     fieldStyle: "outlined",
     headingLevel: 4,


### PR DESCRIPTION
# Description

Replaced Campaign Page's newsletter signup form with the new implementation approach

Related PRs/issues: #11670 

---

- Link to review app: https://foundation-s-11670-cta--k3bh94.herokuapp.com/en/campaigns/test-page/ (creds: `admin2/admin2password`)
- Staging for comparison: https://foundation.mofostaging.net/en/campaigns/test-page/