### PR TITLE
Add A/B testing worker token setting

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -88,6 +88,7 @@ env = environ.Env(
     SCOUT_KEY=(str, ""),
     WAGTAILADMIN_BASE_URL=(str, ""),
     PATTERN_LIBRARY_ENABLED=(bool, False),
+    WAGTAIL_AB_TESTING_WORKER_TOKEN=(str, ""),
 )
 
 # Read in the environment
@@ -186,6 +187,12 @@ TESTING = "test" in sys.argv or "pytest" in sys.argv
 # Django Pattern Library
 # Do not enable for production!
 PATTERN_LIBRARY_ENABLED = env("PATTERN_LIBRARY_ENABLED")
+
+# Wagtail AB Testing Cloudflare worker token
+# This is used to authenticate the worker that handles the caching for A/B testing
+# Not enabled on local development
+if not DEBUG:
+    WAGTAIL_AB_TESTING_WORKER_TOKEN = env("WAGTAIL_AB_TESTING_WORKER_TOKEN")
 
 INSTALLED_APPS = list(
     filter(


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

In order to run A/B tests on staging/production, we need to setup a custom CloudFlare worker to handle the caching/cookies for the control/variant serving of testing pages.

This in turn needs a `WAGTAIL_AB_TESTING_WORKER_TOKEN` Django setting to confirm that the requests are actually coming from our Django server.

This PR implements this setting. See https://github.com/wagtail-nest/wagtail-ab-testing?tab=readme-ov-file#running-ab-tests-on-a-site-that-uses-cloudflare-caching

~~Link to sample test page:~~
Related PRs/issues: #11826 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- ~~[ ] Is the code I'm adding covered by tests?~~

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- [X] Is my code documented?
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
