### PR TITLE
Fix - Validation errors on default page

### DIFF
--- a/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
+++ b/network-api/networkapi/templates/fragments/buyersguide/pni_mobile_nav.html
@@ -8,7 +8,7 @@
                 <div class="dropdown-nav">
                     <div>
                         <button class="expander d-flex justify-content-between">
-                            <span class="active-link-label d-inline-block multipage-link active">
+                            <span class="active-link-label multipage-link active">
                                 {% if current_category.parent %}
                                     {{ current_category.parent.name }}
                                 {% elif current_category %}
@@ -17,7 +17,7 @@
                                     {% trans "All Categories" %}
                                 {% endif %}
                             </span>
-                            <span class="d-inline-block align-self-center control"></span>
+                            <span class="align-self-center control"></span>
                         </button>
                     </div>
                     <div>

--- a/network-api/networkapi/templates/fragments/footer.html
+++ b/network-api/networkapi/templates/fragments/footer.html
@@ -89,7 +89,7 @@
                             {% endif %}
                             <div class="tw-row">
                                 <div class="tw-w-full tw-px-8">
-                                    <hr class="tw-mt-24 tw-mb-8" />
+                                    <hr class="tw-mt-24 tw-mb-8">
                                     <p class="tw-dark tw-body-small tw-mb-0">
                                         {% blocktrans with foundation_website_url='https://foundation.mozilla.org' foundation_website='foundation.mozilla.org' cc_website_url='https://foundation.mozilla.org/about/website-licensing/' %}Mozilla is a global non-profit dedicated to putting you in control of your online experience and shaping the future of the web for the public good. Visit us at <a href="{{ foundation_website_url }}">{{ foundation_website }}</a>. Most content available under a <a href="{{ cc_website_url }}">Creative Commons license</a>.{% endblocktrans %}
                                     </p>

--- a/network-api/networkapi/templates/fragments/language_switcher.html
+++ b/network-api/networkapi/templates/fragments/language_switcher.html
@@ -4,7 +4,7 @@
 {% get_local_language_names as languages %}
 
 <form id="language-switcher-form" action="{% url 'set_language' %}" method="post">
-    <input name="next" type="hidden" value="{% get_unlocalized_url page current_language %}" />
+    <input name="next" type="hidden" value="{% get_unlocalized_url page current_language %}">
     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-center mb-md-0">
         <label class="tw-h5-heading mb-0 d-flex align-items-center tw-globe-glyph" for="language-switcher">{% trans "Language" %}</label>
         <select name="language" id="language-switcher" class="mt-3 mt-md-0 ml-md-3 w-100 tw-form-control">

--- a/source/js/components/newsletter-signup/organisms/default-layout-signup.jsx
+++ b/source/js/components/newsletter-signup/organisms/default-layout-signup.jsx
@@ -162,7 +162,7 @@ class DefaultSignupForm extends Component {
       <InputText
         id={this.ids[name]}
         name={name}
-        label={getText(`First name`)}
+        ariaLabel={getText(`First name`)}
         value={this.getFormFieldValue(name)}
         placeholder={getText(`First name`)}
         onFocus={() => this.handleInputFocus()}
@@ -182,7 +182,7 @@ class DefaultSignupForm extends Component {
       <InputText
         id={this.ids[name]}
         name={name}
-        label={getText(`Last name`)}
+        ariaLabel={getText(`Last name`)}
         value={this.getFormFieldValue(name)}
         placeholder={getText(`Last name`)}
         onFocus={() => this.handleInputFocus()}
@@ -203,7 +203,7 @@ class DefaultSignupForm extends Component {
         id={this.ids[name]}
         type="email"
         name={name}
-        label={getText(`Email address`)}
+        ariaLabel={getText(`Email address`)}
         value={this.getFormFieldValue(name)}
         placeholder={getText(`Please enter your email`)}
         onFocus={() => this.handleEmailFocusAndInput()}

--- a/source/js/multipage-nav.js
+++ b/source/js/multipage-nav.js
@@ -40,9 +40,9 @@ export default () => {
     let className = `multipage-link${isActive ? ` active` : ``}`;
 
     if (isActive) {
-      activeLinkLabel = `<div class="active-link-label d-inline-block ${className}">
+      activeLinkLabel = `<span class="active-link-label d-inline-block ${className}">
             ${label}
-          </div>`;
+          </span>`;
     }
 
     return `<div><a href="${href}" class="${className}">${label}</a></div>`;
@@ -51,10 +51,10 @@ export default () => {
   links.unshift(
     `<div>
         <button class="expander">
-          <div class="d-flex justify-content-between">
-            <div>${activeLinkLabel}</div>
-            <div class="d-inline-block align-self-center control" />
-          </div>
+          <span class="d-flex justify-content-between">
+            <span>${activeLinkLabel}</span>
+            <span class="align-self-center control" />
+          </span>
         </button>
       </div>`
   );


### PR DESCRIPTION
# Description

Link to sample test page: `/en/artifacts/x-ray-goggles/`
Related PRs/issues: #11646 



<details>
  <summary>The changes in this PR aim to solve the following HTML validation errors</summary>


![Screenshot 2024-02-14 at 06-12-22 Showing results for contents of text-input area - Nu Html Checker](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/35934884/c9e6e196-a441-4733-bd02-f4d6b6b0008e)

</details>

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
