### PR TITLE
Remove `LANGUAGE_SESSION_KEY` from `localized_redirect`

### DIFF
--- a/network-api/networkapi/wagtailpages/tests/test_views.py
+++ b/network-api/networkapi/wagtailpages/tests/test_views.py
@@ -1,0 +1,44 @@
+from django.test import RequestFactory, SimpleTestCase
+
+from networkapi.wagtailpages.views import localized_redirect
+
+
+class LocalizedRedirectTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_redirect_with_subpath_and_query_string(self):
+        # Create a mock request object
+        request = self.factory.get("/destination/")
+        request.LANGUAGE_CODE = "en"
+        request.META = {"QUERY_STRING": "param=value"}
+
+        # Call the localized_redirect function
+        result = localized_redirect(request, "subpath", "destination")
+
+        # Assert that the redirect URL is correct
+        self.assertEqual(result.url, "/en/destination/subpath?param=value")
+
+    def test_redirect_with_empty_subpath_and_query_string(self):
+        # Create a mock request object
+        request = self.factory.get("/destination/")
+        request.LANGUAGE_CODE = "en"
+        request.META = {"QUERY_STRING": ""}
+
+        # Call the localized_redirect function
+        result = localized_redirect(request, "", "destination")
+
+        # Assert that the redirect URL is correct
+        self.assertEqual(result.url, "/en/destination/")
+
+    def test_redirect_with_active_language(self):
+        # Create a mock request object
+        request = self.factory.get("/en/destination/")
+        request.LANGUAGE_CODE = "fr"
+        request.META = {"QUERY_STRING": ""}
+
+        # Call the localized_redirect function
+        result = localized_redirect(request, "", "destination")
+
+        # Assert that the redirect URL is correct
+        self.assertEqual(result.url, "/fr/destination/")

--- a/network-api/networkapi/wagtailpages/views.py
+++ b/network-api/networkapi/wagtailpages/views.py
@@ -29,7 +29,6 @@ def custom404_view(request, exception):
 def localized_redirect(request, subpath, destination_path):
     lang = request.LANGUAGE_CODE
     translation.activate(lang)
-    request.session[translation.LANGUAGE_SESSION_KEY] = lang
     query_string = ""
 
     if request.META["QUERY_STRING"]:


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

`LANGUAGE_SESSION_KEY` is not being set in a `request.session` by Django [since version 4.0](https://github.com/django/django/blob/86d8034972db5014769cdd4832125067f31b3e8b/docs/internals/deprecation.txt#L203-L204).

Link to sample test page:
Related PRs/issues: #11888

# Testing
* Covered in unit testing

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
