### PR TITLE
updated networkapi log levels to debug

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -679,8 +679,8 @@ LOGGING = {
         "django.db.backends": {"handlers": ["debug-error"], "level": "ERROR"},
         "django.utils.autoreload": {"handlers": ["debug-error"], "level": "ERROR"},
         "networkapi": {
-            "handlers": ["info"],
-            "level": "INFO",
+            "handlers": ["debug"],
+            "level": "DEBUG",
         },
     },
 }


### PR DESCRIPTION
In pull request #12034, we included logger statements within the generate_thank_you_url function. However, the visibility of these logs was restricted to the INFO level as per settings.py.

This update modifies settings.py to extend the visibility of logs to the DEBUG level specifically for the app networkapi (the foundation site). This adjustment enables us to effectively utilize and observe our debug statements for debugging purposes.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP-323)
