### PR TITLE
[TP-265] [Main Nav] Navigation item

### DIFF
--- a/network-api/networkapi/nav/blocks.py
+++ b/network-api/networkapi/nav/blocks.py
@@ -18,7 +18,7 @@ class NavLinkValue(BaseLinkValue):
 
 
 class NavLinkBlock(BaseLinkBlock):
-    description = blocks.CharBlock(required=False)
+    description = blocks.CharBlock(required=False, max_length=100)
 
     class Meta:
         value_class = NavLinkValue

--- a/network-api/networkapi/nav/blocks.py
+++ b/network-api/networkapi/nav/blocks.py
@@ -1,3 +1,4 @@
+from wagtail import blocks
 from wagtail.telepath import register
 
 from networkapi.wagtailpages.pagemodels.customblocks.common.base_link_block import (
@@ -17,6 +18,8 @@ class NavLinkValue(BaseLinkValue):
 
 
 class NavLinkBlock(BaseLinkBlock):
+    description = blocks.CharBlock(required=False)
+
     class Meta:
         value_class = NavLinkValue
         label = "Navigation Link"

--- a/network-api/networkapi/nav/factories.py
+++ b/network-api/networkapi/nav/factories.py
@@ -41,6 +41,7 @@ class NavLinkBlockFactory(wagtail_factories.StructBlockFactory):
         relative_url_link = factory.Trait(link_to="relative_url", relative_url=f'/{factory.Faker("uri_path")}')
 
     label = factory.Faker("sentence", nb_words=3)
+    description = factory.Faker("sentence", nb_words=6)
 
     # Setup default link as external URL (it won't pass validation without a link type defined though
     # so it's still necessary to use the factory with traits)


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Implements the backend functionality for navigation item.

The `navigation item` will be an instance of `NavLinkBlock`, which was mainly implemented in #12033, so this PR only adds the "missing" `description` field.

Link to sample test page:
Related PRs/issues:
- #11979 
- https://mozilla-hub.atlassian.net/browse/TP-265

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- [X] Did I update or add new fake data?
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP-325)
