### PR TITLE
removed logging updates

### DIFF
--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -679,8 +679,8 @@ LOGGING = {
         "django.db.backends": {"handlers": ["debug-error"], "level": "ERROR"},
         "django.utils.autoreload": {"handlers": ["debug-error"], "level": "ERROR"},
         "networkapi": {
-            "handlers": ["debug"],
-            "level": "DEBUG",
+            "handlers": ["info"],
+            "level": "INFO",
         },
     },
 }

--- a/network-api/networkapi/wagtailpages/templatetags/mini_site_tags.py
+++ b/network-api/networkapi/wagtailpages/templatetags/mini_site_tags.py
@@ -1,4 +1,3 @@
-import logging
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from django import template
@@ -9,8 +8,6 @@ from networkapi.wagtailpages.models import CTA
 from ..utils import get_mini_side_nav_data
 
 register = template.Library()
-
-logger = logging.getLogger(__name__)
 
 
 # Instantiate a mini-site sidebar menu based on the current page's relation to other pages
@@ -30,18 +27,11 @@ def _generate_thank_you_url(url):
     Generate a thank you page URL by grabbing the current url and appending thank_you=true
     """
 
-    logger.debug(f'Generating "thank you URL" for {url}')
-
     parsed_url = urlparse(url)
-    logger.debug(f"parsed_url: {parsed_url}")
     query_params = parse_qsl(parsed_url.query)
-    logger.debug(f"query_params: {query_params}")
     query_params.append(("thank_you", "true"))
     query_string = urlencode(query_params)
-    logger.debug(f"query_string: {query_string}")
     thank_you_url = urlunparse(parsed_url._replace(query=query_string))
-
-    logger.debug(f'Generated "thank you URL": {thank_you_url}')
 
     return thank_you_url
 


### PR DESCRIPTION
# Description

This PR reverts the logging update/statements that were added in #12037 and #12034 while troubleshooting #12018 , but does not remove the new tests for the function `_generate_thank_you_url` that were introduced in #12034.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP-329)
