### PR TITLE
Remove 'moment' from npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "gsap": "^3.12.2",
         "htmx.org": "^1.8.6",
         "locomotive-scroll": "^4.1.4",
-        "moment": "^2.29.4",
         "npm-run-all": "^4.1.3",
         "postcss": "^8.4.35",
         "postcss-cli": "^10.1.0",
@@ -6743,14 +6742,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
       "dev": true
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -15953,11 +15944,6 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.2.0.tgz",
       "integrity": "sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==",
       "dev": true
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "gsap": "^3.12.2",
     "htmx.org": "^1.8.6",
     "locomotive-scroll": "^4.1.4",
-    "moment": "^2.29.4",
     "npm-run-all": "^4.1.3",
     "postcss": "^8.4.35",
     "postcss-cli": "^10.1.0",


### PR DESCRIPTION
Dependabot filed a PR(https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11626) to update version for `moment`. However, it doesn't seem like we are using this module at all. I've removed it from `package.json` in this PR.



┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/TP1-26)
