### PR TITLE
Replace react-axe with @axe-core/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "postcss-scss": "^4.0.9",
         "prop-types": "^15.7.2",
         "react": "^18.2.0",
-        "react-axe": "^3.5.4",
         "react-dom": "^18.2.0",
         "react-ga": "3.3.1",
         "sass": "^1.59.3",
@@ -40,6 +39,7 @@
         "whatwg-fetch": "^3.6.2"
       },
       "devDependencies": {
+        "@axe-core/react": "^4.8.5",
         "@percy/cli": "^1.27.1",
         "@percy/playwright": "^1.0.4",
         "@playwright/test": "^1.42.1",
@@ -80,6 +80,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/react": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.8.5.tgz",
+      "integrity": "sha512-GKXFAc/VPa3sDPv8lqPZlDvBt0UNwOwN0B/EnUOaHTRe5IcLl+RfcD+LHVEE75Quc1LOgSyw4T0O9kvJuPzIxg==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "~4.8.4",
+        "requestidlecallback": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1587,9 +1597,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.4.tgz",
+      "integrity": "sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg==",
       "engines": {
         "node": ">=4"
       }
@@ -8392,24 +8402,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-axe": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/react-axe/-/react-axe-3.5.4.tgz",
-      "integrity": "sha512-5xNO0QVCCEZnJiyhAGox0MGFyclgU3XL8se+5H+whdxV1VTtA9/uux9BSCF5mGNSgtSZkb+tQtrOaF+zGf/oWw==",
-      "deprecated": "deprecated",
-      "dependencies": {
-        "axe-core": "^3.5.0",
-        "requestidlecallback": "^0.3.0"
-      }
-    },
-    "node_modules/react-axe/node_modules/axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -8741,7 +8733,8 @@
     "node_modules/requestidlecallback": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU="
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -11006,6 +10999,16 @@
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="
     },
+    "@axe-core/react": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.8.5.tgz",
+      "integrity": "sha512-GKXFAc/VPa3sDPv8lqPZlDvBt0UNwOwN0B/EnUOaHTRe5IcLl+RfcD+LHVEE75Quc1LOgSyw4T0O9kvJuPzIxg==",
+      "dev": true,
+      "requires": {
+        "axe-core": "~4.8.4",
+        "requestidlecallback": "^0.3.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
@@ -11988,9 +11991,9 @@
       }
     },
     "axe-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
-      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.4.tgz",
+      "integrity": "sha512-CZLSKisu/bhJ2awW4kJndluz2HLZYIHh5Uy1+ZwDRkJi69811xgIXXfdU9HSLX0Th+ILrHj8qfL/5wzamsFtQg=="
     },
     "axobject-query": {
       "version": "3.1.1",
@@ -16934,22 +16937,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "react-axe": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/react-axe/-/react-axe-3.5.4.tgz",
-      "integrity": "sha512-5xNO0QVCCEZnJiyhAGox0MGFyclgU3XL8se+5H+whdxV1VTtA9/uux9BSCF5mGNSgtSZkb+tQtrOaF+zGf/oWw==",
-      "requires": {
-        "axe-core": "^3.5.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "dependencies": {
-        "axe-core": {
-          "version": "3.5.5",
-          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-          "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q=="
-        }
-      }
-    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -17188,7 +17175,8 @@
     "requestidlecallback": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-      "integrity": "sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU="
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "postcss-scss": "^4.0.9",
     "prop-types": "^15.7.2",
     "react": "^18.2.0",
-    "react-axe": "^3.5.4",
     "react-dom": "^18.2.0",
     "react-ga": "3.3.1",
     "sass": "^1.59.3",
@@ -103,6 +102,7 @@
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
+    "@axe-core/react": "^4.8.5",
     "@percy/cli": "^1.27.1",
     "@percy/playwright": "^1.0.4",
     "@playwright/test": "^1.42.1",

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -1,3 +1,4 @@
+import React from "react";
 import ReactDOM from "react-dom";
 import Storage from "../storage.js";
 import {
@@ -19,14 +20,8 @@ import initializeSentry from "../common/sentry-config.js";
 import PNIMobileNav from "./pni-mobile-nav.js";
 
 // Initializing component a11y browser console logging
-// TODO React-axe is currently deprecated, we should replace it with @axe-core/react
-// https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10306
-if (
-  typeof process !== "undefined" &&
-  process.env &&
-  process.env.NODE_ENV === "development"
-) {
-  axe = require("react-axe");
+if (process.env.NODE_ENV === "development") {
+  const axe = require("@axe-core/react");
   axe(React, ReactDOM, 1000);
 }
 

--- a/source/js/main.js
+++ b/source/js/main.js
@@ -1,4 +1,5 @@
 /* eslint no-unused-vars: ["error", { "varsIgnorePattern": "React" }] */
+import React from "react";
 import ReactDOM from "react-dom";
 import {
   bindCommonEventHandlers,
@@ -39,14 +40,8 @@ import { initYoutubeRegretsCarousel } from "./foundation/pages/youtube-regrets/c
 import { initYoutubeRegretsLocomotiveScroll } from "./foundation/pages/youtube-regrets/locomotive-scroll";
 
 // Initializing component a11y browser console logging
-// TODO React-axe is currently deprecated, we should replace it with @axe-core/react
-// https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10306
-if (
-  typeof process !== "undefined" &&
-  process.env &&
-  process.env.NODE_ENV === "development"
-) {
-  axe = require("react-axe");
+if (process.env.NODE_ENV === "development") {
+  const axe = require("@axe-core/react");
   axe(React, ReactDOM, 1000);
 }
 


### PR DESCRIPTION
# Description

The `axe-core` library is a dev tool that provides accessibility notifications in the browser's js console. `react-axe` is an npm package that lets you use the `axe-core` library to test a React app for accessibility issues. But `react-axe` deprecated and does not appear to work when viewing the JS console locally.

This pull request uninstalls the deprecated `react-axe` package and installs the new `@axe-core/react` package. It also updates the `main.js` and `bg-main.js` files to utilize the new package.

Link to sample test page:
Related PRs/issues: #11985 #10306 #10260

# To test

1. Pull branch locally.
2. You may need to `docker-compose down`, `inv catchup`, and `docker-compose up` to get new dependencies
3. Navigate to homepage
4. Open brower's dev tools
5. Confirm you are now receiving accessibility notifications from axe
6. Navigate to the buyers' guide at /en/privacynotincluded
7. Repeat steps 4 and 5 to confirm you are now receiving accessibility notifications from axe.

![axe-core](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/3083419/d7fef2b5-b406-483a-92e8-d0e203c4e182)
