### PR TITLE
Revert "[PNI] Improved <title> tags for SEO (#12046)"

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -6,16 +6,8 @@
 
 {% block page_title %}
     {% environment_prefix %}
-    {# if routable page #}
-    {% if pageTitle %}
-        {{ pageTitle }}
-    {# if custom seo_title for a wagtail page #}
-    {% elif page.seo_title %}
-        {{ page.seo_title }}
-    {# default to page.title #}
-    {% else %}
-        {{ page.title }} | {% blocktrans context "“*Privacy Not Included can be localized. This is a reference to the “*batteries not included” mention on toys." %}*Privacy Not Included{% endblocktrans %}
-    {% endif %}
+    {% if pageTitle %}{{ pageTitle }}
+    {% else %}{% blocktrans context "“*Privacy Not Included” can be localized. This is a reference to the “*batteries not included” mention on toys." %}*Privacy Not Included | Shop smart and safe{% endblocktrans %} | Mozilla Foundation{% endif %}
 {% endblock %}
 
 {# TODO: consider using a different ga_identifier? #}

--- a/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/buyersguide/homepage.py
@@ -185,7 +185,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
         context["pagetype"] = "about"
         context["pageTitle"] = pgettext(
             "*Privacy Not Included can be localized.",
-            "How to use *Privacy Not Included | Mozilla Foundation",
+            "How to use *Privacy Not Included",
         )
         return render(request, "pages/buyersguide/about/how_to_use.html", context)
 
@@ -195,7 +195,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
         context["pagetype"] = "about"
         context["pageTitle"] = pgettext(
             "*Privacy Not Included can be localized.",
-            "Why we made *Privacy Not Included | Mozilla Foundation",
+            "Why we made *Privacy Not Included",
         )
         return render(request, "pages/buyersguide/about/why_we_made.html", context)
 
@@ -208,7 +208,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
             + " | "
             + pgettext(
                 "This can be localized. This is a reference to the “*batteries not included” mention on toys.",
-                "*Privacy Not Included | Mozilla Foundation",
+                "*Privacy Not Included",
             )
         )
         return render(request, "pages/buyersguide/about/press.html", context)
@@ -222,7 +222,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
             + " | "
             + pgettext(
                 "This can be localized. This is a reference to the “*batteries not included” mention on toys.",
-                "*Privacy Not Included | Mozilla Foundation",
+                "*Privacy Not Included",
             )
         )
         return render(request, "pages/buyersguide/about/contact.html", context)
@@ -236,7 +236,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
             + " | "
             + pgettext(
                 "This can be localized. This is a reference to the “*batteries not included” mention on toys.",
-                "*Privacy Not Included | Mozilla Foundation",
+                "*Privacy Not Included",
             )
         )
         return render(request, "pages/buyersguide/about/methodology.html", context)
@@ -250,7 +250,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
             + " | "
             + pgettext(
                 "This can be localized. This is a reference to the “*batteries not included” mention on toys.",
-                "*Privacy Not Included | Mozilla Foundation",
+                "*Privacy Not Included",
             )
         )
         return render(request, "pages/buyersguide/contest.html", context)
@@ -309,7 +309,7 @@ class BuyersGuidePage(RoutablePageMixin, BasePage):
         context["category"] = slug
         context["current_category"] = category
         context["products"] = products
-        context["pageTitle"] = f'{category.name} | {gettext("Privacy & Security Guide")}' f" | Mozilla Foundation"
+        context["pageTitle"] = f'{category.name} | {gettext("Privacy & security guide")}' f" | Mozilla Foundation"
         context["template_cache_key_fragment"] = f"{category.slug}_{request.LANGUAGE_CODE}"
 
         # Checking if category has custom metadata, if so, update the share image and description.


### PR DESCRIPTION
This reverts commit 95c8f886382725ef0564b93630699f1e4b9c7d61.

# Description
Revert the PNI title improvements, site identifier missing on article detail pages.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP-369)
