### PR TITLE
Fix banner name on mozfest landing page

### DIFF
--- a/network-api/networkapi/mozfest/models.py
+++ b/network-api/networkapi/mozfest/models.py
@@ -433,7 +433,7 @@ class MozfestLandingPage(MozfestPrimaryPage):
         # Content tab fields
         TranslatableField("title"),
         TranslatableField("banner_heading"),
-        SynchronizedField("banner_image"),
+        SynchronizedField("banner"),
         TranslatableField("banner_meta"),
         TranslatableField("banner_text"),
         SynchronizedField("banner_link_url"),


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

`translatable_fields` on `MozfestLandingPage` is referencing a `banner_image` field that doesn't exist. This field should be called `banner`.

Link to sample test page:
Related PRs/issues: 
- #12109
- https://mozilla-hub.atlassian.net/browse/TP-402

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP-403)
