### PR TITLE
Remove extra spaces in env.default

### DIFF
--- a/env.default
+++ b/env.default
@@ -61,7 +61,7 @@ CSP_STYLE_SRC=" 'self' 'unsafe-inline' https://code.cdn.mozilla.net https://font
 CSP_INCLUDE_NONCE_IN=script-src
 
 # Security config
-SECURE_CROSS_ORIGIN_OPENER_POLICY = " 'same-origin-allow-popups' "
+SECURE_CROSS_ORIGIN_OPENER_POLICY=" 'same-origin-allow-popups' "
 
 # Petition test campaign id for Salesforce Sandbox
 PETITION_TEST_CAMPAIGN_ID=7017i000000bIgTAAU


### PR DESCRIPTION
Just realized in my previous PR I added two spaces around the `=` which creates parsing issue. I'm filing this PR to remove them.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/TP1-324)
