### PR TITLE
Bold font-weight styling on articles

### DIFF
--- a/source/sass/views/article.scss
+++ b/source/sass/views/article.scss
@@ -7,6 +7,9 @@
     ul,
     ol {
       font-weight: 300;
+      b {
+        font-weight: 700;
+      }
     }
   }
 }


### PR DESCRIPTION
# Description

This PR will assign a `700` font-weight to `<b>` tags instead of using the relative `bolder` value when the `<b>` tag is nested in lighter parent tags on article pages. Since `bolder` is relative to the parent element, it is resulting in less than desired font-weights on certain light font-weight elements in the article page.

[Link to sample test page](https://foundation-s-11898-bold-smrahc.mofostaging.net/en/publication-page-with-chapter-pages/may-scene-or-quickly-throughout-could-try-cell-great-reach-add-director-common-article-standard-ready/fixed-title-article-page/)
Related PRs/issues: #11898

# To test
View the test page and verify bold is carrying over appropriately.

┆Issue is synchronized with this [Jira Task](https://mozilla-hub.atlassian.net/browse/TP1-327)
