### PR TITLE
Update referrer policy to use strict-origin-when-cross-origin

### DIFF
--- a/env.default
+++ b/env.default
@@ -63,6 +63,9 @@ CSP_INCLUDE_NONCE_IN=script-src
 # Security config
 SECURE_CROSS_ORIGIN_OPENER_POLICY=" 'same-origin-allow-popups' "
 
+# Referral policy
+REFERRER_HEADER_VALUE =" 'strict-origin-when-cross-origin "
+
 # Petition test campaign id for Salesforce Sandbox
 PETITION_TEST_CAMPAIGN_ID=7017i000000bIgTAAU
 

--- a/network-api/networkapi/settings.py
+++ b/network-api/networkapi/settings.py
@@ -638,7 +638,7 @@ if env("SSL_REDIRECT") is True:
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 X_FRAME_OPTIONS = env("X_FRAME_OPTIONS")
-REFERRER_HEADER_VALUE = env("REFERRER_HEADER_VALUE")
+REFERRER_HEADER_VALUE = env("REFERRER_HEADER_VALUE", default="'strict-origin-when-cross-origin'")
 
 
 # Remove the default Django loggers and configure new ones

--- a/network-api/networkapi/utility/middleware.py
+++ b/network-api/networkapi/utility/middleware.py
@@ -6,7 +6,7 @@ hostnames = settings.TARGET_DOMAINS
 if len(hostnames) == 0:
     print("Error: no TARGET_DOMAINS set, please ensure your environment variables are in order.")
 
-referrer_value = "same-origin"
+referrer_value = "strict-origin-when-cross-origin"
 
 if settings.REFERRER_HEADER_VALUE:
     referrer_value = settings.REFERRER_HEADER_VALUE

--- a/network-api/networkapi/utility/middleware.py
+++ b/network-api/networkapi/utility/middleware.py
@@ -6,8 +6,6 @@ hostnames = settings.TARGET_DOMAINS
 if len(hostnames) == 0:
     print("Error: no TARGET_DOMAINS set, please ensure your environment variables are in order.")
 
-referrer_value = "strict-origin-when-cross-origin"
-
 if settings.REFERRER_HEADER_VALUE:
     referrer_value = settings.REFERRER_HEADER_VALUE
 

--- a/network-api/networkapi/utility/middleware.py
+++ b/network-api/networkapi/utility/middleware.py
@@ -6,9 +6,6 @@ hostnames = settings.TARGET_DOMAINS
 if len(hostnames) == 0:
     print("Error: no TARGET_DOMAINS set, please ensure your environment variables are in order.")
 
-if settings.REFERRER_HEADER_VALUE:
-    referrer_value = settings.REFERRER_HEADER_VALUE
-
 
 class HttpResponseTemporaryRedirect(HttpResponseRedirectBase):
     status_code = 307
@@ -20,7 +17,7 @@ class ReferrerMiddleware:
 
     def __call__(self, request):
         response = self.get_response(request)
-        response["Referrer-Policy"] = referrer_value
+        response["Referrer-Policy"] = settings.REFERRER_HEADER_VALUE
         return response
 
 

--- a/network-api/networkapi/utility/tests/test_middleware.py
+++ b/network-api/networkapi/utility/tests/test_middleware.py
@@ -17,7 +17,7 @@ class ReferrerMiddlewareTests(TestCase):
 
         referrer_middleware = ReferrerMiddleware(MagicMock())
         response = referrer_middleware(MagicMock())
-        response.__setitem__.assert_called_with("Referrer-Policy", "same-origin")
+        response.__setitem__.assert_called_with("Referrer-Policy", "strict-origin-when-cross-origin")
 
 
 class XRobotsTagMiddlewareTest(TestCase):


### PR DESCRIPTION
# Description

This PR updates the referrer policy to use `strict-origin-when-cross-origin` instead of `same-origin`. While `same-origin` is a Django default, it can be too restrictive when integrating 3rd party tools like the donation platform as extensively documented in [TP1-364](https://mozilla-hub.atlassian.net/jira/software/c/projects/TP1/boards/1918?selectedIssue=TP1-364) / #12141.

`strict-origin-when-cross-origin` is a modern, [balanced approach](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) that still respects security & privacy and **only** includes the origin (i.e. https://foundation.mozilla.org) in cross-origin requests like 3rd party tools. It is the default of modern browsers and the current setting for mozilla.org and thunderbird.net (who uses the donation modal without issue).

Note: this is just the default .env variable / Django setting, and we will still need to change the config var in heroku.

Related PRs/issues: #12141 / [TP1-364](https://mozilla-hub.atlassian.net/jira/software/c/projects/TP1/boards/1918?selectedIssue=TP1-364)

# To Test
Open Browser console go to "Network" and view request headers to confirm ReferrerPolicy is set to `strict-origin-when-cross-origin`.