### PR TITLE
Add scroll margin to footnotes

### DIFF
--- a/network-api/networkapi/templates/fragments/footnotes.html
+++ b/network-api/networkapi/templates/fragments/footnotes.html
@@ -9,7 +9,7 @@
             <h3 class="footnotes-title">{% trans "Footnotes" %}</h3>
             <ol class="footnotes-list pl-0">
                 {% for footnote in page.footnotes_list %}
-                    <li class="footnote-row d-flex" id="footnote-{{ forloop.counter|unlocalize }}">
+                    <li class="footnote-row d-flex tw-scroll-mt-20 large:tw-scroll-mt-32 xlarge:tw-scroll-mt-20" id="footnote-{{ forloop.counter|unlocalize }}">
                         <a href="#footnote-source-{{ forloop.counter|unlocalize }}" class="footnote-number mr-3" aria-label="{% trans 'Back to content' %}">
                             [{{ forloop.counter }}]
                         </a>


### PR DESCRIPTION
# Description

This pull request adds a scroll margin to footnotes, which corrects the footnote anchor scroll location.

Link to sample test page:
Related PRs/issues: TP1-140 / #10310

# To Test

Click back and forth on a publication's footnote at various viewports. The footnote should navigate to the correct location.