### PR TITLE
Add 'self' to CSP_FRAME_ANCESTORS

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -31,7 +31,7 @@ jobs:
       CSP_CONNECT_SRC: " * "
       CSP_DEFAULT_SRC: " 'none' "
       CSP_FONT_SRC: " 'self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/fonts/ data: https://static.fundraiseup.com/common-fonts/ https://*.fundraiseup.com https://*.stripe.com "
-      CSP_FRAME_ANCESTORS: " 'none' "
+      CSP_FRAME_ANCESTORS: " 'self' "
       CSP_FRAME_SRC: " 'self' https://www.youtube.com https://comments.mozillafoundation.org/ https://airtable.com https://docs.google.com/ https://platform.twitter.com https://public.zenkit.com https://calendar.google.com https://www.youtube-nocookie.com https://form.typeform.com https://js.tito.io https://datawrapper.dwcdn.net https://www.google.com/recaptcha/ https://*.stripe.com https://pay.google.com https://*.paypal.com https://*.fundraiseup.com "
       CSP_IMG_SRC: " * data: blob: https://*.fundraiseup.com https://ucarecdn.com https://pay.google.com https://*.paypalobjects.com "
       CSP_MEDIA_SRC: " 'self' data: https://s3.amazonaws.com/mofo-assets/foundation/video/ "

--- a/app.json
+++ b/app.json
@@ -27,7 +27,7 @@
     "CSP_CHILD_SRC": "'self' https://www.youtube.com https://www.youtube-nocookie.com",
     "CSP_CONNECT_SRC": "*",
     "CSP_DEFAULT_SRC": "'none'",
-    "CSP_FRAME_ANCESTORS": "'none'",
+    "CSP_FRAME_ANCESTORS": "'self'",
     "CSP_FRAME_SRC": "'self' https://js.tito.io https://www.google.com/recaptcha/ https://*.stripe.com https://pay.google.com https://*.paypal.com https://*.fundraiseup.com",
     "CSP_FONT_SRC": "'self' https://fonts.gstatic.com https://fonts.googleapis.com https://code.cdn.mozilla.net https://*.fundraiseup.com https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/fonts/",
     "CSP_IMG_SRC": "* data: blob: https://*.fundraiseup.com https://ucarecdn.com https://pay.google.com https://*.paypalobjects.com",


### PR DESCRIPTION
# Description

This PR updates our CSP directives to include 'self' on review apps, which is how our production site is configured. This directive is needed for things like the preview panel to work correctly.

Link to sample test page:
Related PRs/issues: TP1-534 #12221

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-535)
