### PR TITLE
Center the nav div to address backup nav regression

### DIFF
--- a/network-api/networkapi/templates/fragments/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/primary_nav.html
@@ -48,7 +48,7 @@
                                 {% if page.zen_nav == True %}
                                     <div class="wide-screen-menu hidden">
                                 {% else %}
-                                    <div class="wide-screen-menu large:tw-h-full">
+                                    <div class="wide-screen-menu large:tw-h-full large:tw-flex large:tw-items-center">
                                 {% endif %}
 
                                 {% block wide_screen_menu %}


### PR DESCRIPTION
# Description

This PR centers the nav div for the backup navbar while leaving the new navbar unchanged visually.

Link to sample test page:
Related PRs/issues: TP1-544 / #12230

Old navbar regression
![Screenshot 2024-04-25 at 4 25 59 PM](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/3083419/d32deab5-3aed-4658-8ec3-74a687817e8b)

Old navbar fixed
![Screenshot 2024-04-25 at 4 25 12 PM](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/3083419/9df30dab-b939-4c43-809e-10bfb290dcf2)

New navbar unchanged
![Screenshot 2024-04-25 at 4 25 20 PM](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/3083419/04949768-3b96-4628-a906-a162606719e0)

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-567)
