### PR TITLE
[Main Nav] Add menu to PrimaryPage

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/primary_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/primary_page.html
@@ -4,7 +4,13 @@
 {% block body_id %}{% if root.slug %}{{ root.slug }}{% else %}primary{% endif %}{% endblock %}
 
 {% block primary_nav %}
-    {% include "fragments/primary_nav.html" %}
+    {% with nav_menu=settings.nav.SiteNavMenu.active_nav_menu %}
+        {% if nav_menu %}
+            {% include "fragments/nav/menu.html" with menu=nav_menu.localized %}
+        {% else %}
+            {% include "fragments/primary_nav.html" with background="simple-background" %}
+        {% endif %}
+    {% endwith %}
 {% endblock %}
 
 {% block hero_guts %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

The main nav menu is not showing up to the "who we are" page because the `PrimaryPage` template was overriding the `primary_nav` block on `base_page.html`.

This fixes the issue by rendering the menu on that block.

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-571)
