### PR TITLE
Remove dupe in mobile-dropdown.js

### DIFF
--- a/source/js/components/nav/mobile-dropdown.js
+++ b/source/js/components/nav/mobile-dropdown.js
@@ -13,11 +13,6 @@ class NavMobileDropdown extends Accordion {
     }
   }
 
-  getSiblings() {
-    let siblings = document.querySelectorAll(NavMobileDropdown.selector());
-    return Array.from(siblings).filter((sibling) => sibling !== this.accordion);
-  }
-
   addBaseWayfindingStyles() {
     this.title.classList.add("tw-border-s-4", "tw-border-gray-60");
   }


### PR DESCRIPTION
There are two exact copies of `getSiblings()` implementation. This PR removes one copy.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-575)
