### PR TITLE
[Main Nav] Handle routes with no page or menu context

### DIFF
--- a/network-api/networkapi/nav/templatetags/nav_tags.py
+++ b/network-api/networkapi/nav/templatetags/nav_tags.py
@@ -21,15 +21,21 @@ def get_dropdown_id(**kwargs):
         index = int(kwargs["idx"])
     except ValueError:
         return None
-    menu = kwargs["menu"]
+    menu = kwargs.get("menu", None)
+    if not menu:
+        return None
     return menu.dropdowns.get_prep_value()[index]["id"]
 
 
 @register.simple_tag(takes_context=True)
 def check_if_dropdown_is_active(context, dropdown_id):
     # The page that user is currently visiting/requesting:
-    page = context["page"]
-    menu = context["menu"]
+    page = context.get("page", None)
+    if not page:
+        return None
+    menu = context.get("menu", None)
+    if not menu:
+        return None
     dropdowns_page_links = menu.page_references_per_dropdown
 
     # Don't highlight the link if the page is the homepage
@@ -69,7 +75,9 @@ def check_if_link_is_active(context, link):
         return False
 
     # Page that the user is currently visiting/requesting:
-    page = context["page"]
+    page = context.get("page", None)
+    if not page:
+        return None
 
     # Don't highlight the link if the page is the homepage
     if isinstance(page, Homepage):

--- a/network-api/networkapi/nav/tests/test_templatetags.py
+++ b/network-api/networkapi/nav/tests/test_templatetags.py
@@ -32,6 +32,13 @@ class TestGetDropdownId(test_base.WagtailpagesTestCase):
         # Check if the ID is None:
         self.assertIsNone(dropdown_id)
 
+    def test_get_dropdown_id_no_menu(self) -> None:
+        # Get the dropdown IDs without a menu:
+        dropdown_id = nav_tags.get_dropdown_id(menu=None, idx=0)
+
+        # Check if the ID is None:
+        self.assertIsNone(dropdown_id)
+
 
 class TestCheckIfDropdownIsActive(test_base.WagtailpagesTestCase):
     def test_active_dropdown_check(self) -> None:
@@ -148,6 +155,38 @@ class TestCheckIfDropdownIsActive(test_base.WagtailpagesTestCase):
         # Even though the homepage is part of the dropdown, it should not be marked as active:
         self.assertFalse(nav_tags.check_if_dropdown_is_active(context, dropdown_1_id))
 
+    def test_returns_false_if_no_page(self) -> None:
+        """If no page is passed, the function should return False."""
+        # Create a menu with the first dropdown linking to a page:
+        page = wagtail_factories.PageFactory(parent=self.homepage, title="Test Page")
+        menu = nav_factories.NavMenuFactory(
+            dropdowns__0__dropdown__button__link_to="page",
+            dropdowns__0__dropdown__button__page=page,
+        )
+
+        dropdown_1_id = nav_tags.get_dropdown_id(menu=menu, idx=0)
+
+        # No page is passed
+        context = {"menu": menu}
+        # Should return False
+        self.assertFalse(nav_tags.check_if_dropdown_is_active(context, dropdown_1_id))
+
+    def test_returns_false_if_no_menu(self) -> None:
+        """If no page is passed, the function should return False."""
+        # Create a menu with the first dropdown linking to a page:
+        page = wagtail_factories.PageFactory(parent=self.homepage, title="Test Page")
+        menu = nav_factories.NavMenuFactory(
+            dropdowns__0__dropdown__button__link_to="page",
+            dropdowns__0__dropdown__button__page=page,
+        )
+
+        dropdown_1_id = nav_tags.get_dropdown_id(menu=menu, idx=0)
+
+        # No page is passed
+        context = {"page": page}
+        # Should return False
+        self.assertFalse(nav_tags.check_if_dropdown_is_active(context, dropdown_1_id))
+
 
 class TestCheckIfLinkIsActive(test_base.WagtailpagesTestCase):
     def test_active_link_check(self) -> None:
@@ -215,4 +254,20 @@ class TestCheckIfLinkIsActive(test_base.WagtailpagesTestCase):
         # User is now on homepage
         context = {"page": self.homepage, "menu": menu}
         # Even so, the homepage should not be marked as active:
+        self.assertFalse(nav_tags.check_if_link_is_active(context, homepage_link))
+
+    def test_no_page_returns_false(self) -> None:
+        """If no page is passed, the function should return False."""
+        # Create a menu with the first dropdown linking to a page:
+        page = wagtail_factories.PageFactory(parent=self.homepage, title="Test Page")
+        menu = nav_factories.NavMenuFactory(
+            dropdowns__0__dropdown__button__link_to="page",
+            dropdowns__0__dropdown__button__page=page,
+        )
+
+        homepage_link = menu.dropdowns[0].value["button"]
+
+        # No page is passed
+        context = {}
+        # Should return False
         self.assertFalse(nav_tags.check_if_link_is_active(context, homepage_link))

--- a/network-api/networkapi/nav/tests/test_templatetags.py
+++ b/network-api/networkapi/nav/tests/test_templatetags.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import wagtail_factories
 
 from networkapi.nav import factories as nav_factories
@@ -268,6 +270,6 @@ class TestCheckIfLinkIsActive(test_base.WagtailpagesTestCase):
         homepage_link = menu.dropdowns[0].value["button"]
 
         # No page is passed
-        context = {}
+        context: dict[Any, Any] = {}
         # Should return False
         self.assertFalse(nav_tags.check_if_link_is_active(context, homepage_link))


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Gracefully handle cases in nav template tags where the `context` object doesn't have a `page` or `menu` keys. This was causing `KeyError` on some routes.

Link to sample test page: https://foundation-s-bugfix-han-8dbki3.herokuapp.com/
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~[ ] Did I update or add new fake data?~~
- ~~[ ] Did I squash my migration?~~
- ~~[ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~[ ] Is my code documented?~~
- ~~[ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-598)
