### PR TITLE
[Main Nav] Fix blog topics url

### DIFF
--- a/network-api/networkapi/nav/models.py
+++ b/network-api/networkapi/nav/models.py
@@ -170,7 +170,7 @@ class NavMenu(
         blog_index_page = self.blog_index_page
         for relationship in featured_topics_relationships:
             if relationship.topic:
-                relationship.topic.url = blog_index_page.reverse_subpage(
+                relationship.topic.url = blog_index_page.url + blog_index_page.reverse_subpage(
                     "entries_by_topic", args=[relationship.topic.slug]
                 )
 

--- a/network-api/networkapi/nav/tests/test_models.py
+++ b/network-api/networkapi/nav/tests/test_models.py
@@ -47,6 +47,8 @@ class TestNavMenuFeaturedTopics(test_base.WagtailpagesTestCase):
         self.synchronize_tree()
 
     def test_localized_featured_topics(self) -> None:
+        self.blog_index_page.slug = "blog"
+        self.blog_index_page.save_revision().publish()
         # Create some topics:
         topic_a = blog_factories.BlogPageTopicFactory(locale=self.default_locale, name="Topic A")
         topic_b = blog_factories.BlogPageTopicFactory(locale=self.default_locale, name="Topic B")
@@ -80,6 +82,9 @@ class TestNavMenuFeaturedTopics(test_base.WagtailpagesTestCase):
         # It keeps the order:
         self.assertEqual(topics[0], topic_b)
         self.assertEqual(topics[1], topic_a)
+        # It adds the proper URL to the topics:
+        self.assertEqual(topics[0].url, "/en/blog/topic/topic-b/")
+        self.assertEqual(topics[1].url, "/en/blog/topic/topic-a/")
 
     def test_number_of_queries_for_localized_featured_topics(self) -> None:
         # Create some topics:


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Fix issue where URLs on featured topics for Blog dropdown were broken.

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [X] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-602)
