### PR TITLE
removed class that was causing visual regression on campaign page navs

### DIFF
--- a/network-api/networkapi/templates/fragments/primary_nav.html
+++ b/network-api/networkapi/templates/fragments/primary_nav.html
@@ -33,7 +33,7 @@
                 <div class="col">
                     <div class="tw-flex tw-flex-row tw-justify-between large:tw-items-center">
                         <div id="primary-nav-links" class="tw-w-full large:tw-w-auto large:tw-py-0 large:tw-items-center">
-                            <div class="tw-flex tw-items-center tw-flex-wrap large:tw-h-24">
+                            <div class="tw-flex tw-items-center tw-flex-wrap ">
 
                                 <button class="burger tw-z-50 tw-bg-white {% if page.zen_nav is not True %} large:tw-hidden small:tw-ml-0 {% endif %}" aria-label="{% trans 'Open menu' %}">
                                     <span class="burger-bar burger-bar-top"></span>


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues: #12290

This PR removes a tailwind class that seemed to be causing a visual regression on the campaign page navigation bar


# Screenshots:


**Homepage (unnaffected):**
![Screenshot 2024-04-30 at 14-30-57 Mozilla Foundation](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/03b062d2-579b-436d-bc06-9986edb17f15)

**Campaign Page with Zen Mode:**
![Screenshot 2024-04-30 at 14-29-50 Demand Privacy for All Support a U S  Data Privacy Law](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/8e8011ae-bd9b-41d0-b5d9-199415ec94e7)

**Campaign Page without Zen Mode:**
![Screenshot 2024-04-30 at 14-30-09 Demand Privacy for All Support a U S  Data Privacy Law](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/18314510/15e40827-7682-4a06-8d9e-6e4c8a420b2b)

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-608)
