### PR TITLE
Created factory for donate's "Ways to give" page and added it to Percy tests

### DIFF
--- a/network-api/networkapi/donate/factory/__init__.py
+++ b/network-api/networkapi/donate/factory/__init__.py
@@ -1,10 +1,11 @@
-from . import help_page, landing_page
+from . import help_page, landing_page, ways_to_give_page
 
 
 def generate(seed):
     # these are not, and should not be, alphabetically ordered.
     landing_page.generate(seed)
     help_page.generate(seed)
+    ways_to_give_page.generate(seed)
 
 
 __all__ = [

--- a/network-api/networkapi/donate/factory/ways_to_give_page.py
+++ b/network-api/networkapi/donate/factory/ways_to_give_page.py
@@ -13,7 +13,7 @@ streamfield_fields = ["paragraph", "linkbutton", "spacer", "quote"]
 
 class DonateWaysToGivePageFactory(PageFactory):
     class Meta:
-        # Using OppurtunityPage AKA "Default Page" model
+        # Using OpportunityPage AKA "Default Page" model
         model = OpportunityPage
 
     title = Faker("sentence", nb_words=2)

--- a/network-api/networkapi/donate/factory/ways_to_give_page.py
+++ b/network-api/networkapi/donate/factory/ways_to_give_page.py
@@ -1,0 +1,29 @@
+import wagtail_factories
+from factory import Faker, SubFactory
+from wagtail_factories import PageFactory
+
+from networkapi.donate.models import  DonateLandingPage
+from networkapi.wagtailpages.models import OpportunityPage
+from networkapi.utility.faker import StreamfieldProvider
+from networkapi.utility.faker.helpers import reseed
+
+Faker.add_provider(StreamfieldProvider)
+
+streamfield_fields = ["paragraph", "linkbutton", "spacer", "quote"]
+
+
+class DonateWaysToGivePageFactory(PageFactory):
+    class Meta:
+        # Using OppurtunityPage AKA "Default Page" model
+        model = OpportunityPage
+
+    title = Faker("sentence", nb_words=2)
+    body = Faker("streamfield", fields=streamfield_fields)
+
+
+def generate(seed):
+    reseed(seed)
+
+    print('Generating a Donate "Ways to give" page')
+    donate_home_page = DonateLandingPage.objects.get(title="Donate Now")
+    DonateWaysToGivePageFactory(parent=donate_home_page, title="Ways to Give", header="", slug="ways-to-give")

--- a/network-api/networkapi/donate/factory/ways_to_give_page.py
+++ b/network-api/networkapi/donate/factory/ways_to_give_page.py
@@ -1,11 +1,10 @@
-import wagtail_factories
-from factory import Faker, SubFactory
+from factory import Faker
 from wagtail_factories import PageFactory
 
-from networkapi.donate.models import  DonateLandingPage
-from networkapi.wagtailpages.models import OpportunityPage
+from networkapi.donate.models import DonateLandingPage
 from networkapi.utility.faker import StreamfieldProvider
 from networkapi.utility.faker.helpers import reseed
+from networkapi.wagtailpages.models import OpportunityPage
 
 Faker.add_provider(StreamfieldProvider)
 

--- a/tests/foundation-urls.js
+++ b/tests/foundation-urls.js
@@ -23,6 +23,7 @@ module.exports = {
     "/publication-page-with-chapter-pages/fixed-title-chapter-page/fixed-title-article-page",
   Donate: "/donate",
   "Donate Help": "/donate/help",
+  "Donate Ways To Give": "/donate/ways-to-give",
   PNI: "/privacynotincluded",
   "PNI (filtered for category)": "/privacynotincluded/categories/toys-games",
   "PNI general product page": "/privacynotincluded/general-percy-product",


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: https://foundation-s-tp1-216-wa-gxvu6s.herokuapp.com/en/donate/ways-to-give/
Related PRs/issues: #11497, https://mozilla-hub.atlassian.net/browse/TP1-216


This PR creates a new factory for the Donate subsite's "ways to give" page. It also adds the route `donate/ways-to-give/` to the list of pages tested by Percy, so we can test for any visual regressions in the future. 


┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-614)
