### PR TITLE
Use en slug ending on feature blog topics in nav

### DIFF
--- a/network-api/networkapi/nav/models.py
+++ b/network-api/networkapi/nav/models.py
@@ -151,27 +151,37 @@ class NavMenu(
 
     @property
     def localized_featured_blog_topics(self):
+        en_locale = wagtail_models.Locale.objects.get(language_code="en")
+        active_locale = wagtail_models.Locale.get_active()
+
+        # Get localized blog_topics
         featured_topics_relationships = self.featured_blog_topics.all().select_related("topic", "icon")
 
-        # Build a cache of the local topics:
-        topic_ids = list(featured_topics_relationships.values_list("topic_id", flat=True))
-        topics = BlogPageTopic.objects.filter(id__in=topic_ids).order_by("nav_menu_featured_topics__sort_order")
-        topics = localize_queryset(topics, preserve_order=True)
-        topics_cache = {topic.translation_key: topic for topic in topics}
+        # If not in the en locale, build a cache of en_topics to efficiently get the topics's en slug
+        # @TODO Localize Slugs TP1-690 / #12367
+        if active_locale != en_locale:
+            # Get topics from the en_menu
+            en_featured_topics_relationships = self.get_translation(en_locale).featured_blog_topics
 
-        # Replace topics with localized versions:
-        for relationship in featured_topics_relationships:
-            if relationship.topic:
-                local_topic = topics_cache.get(relationship.topic.translation_key)
-                if local_topic:
-                    relationship.topic = local_topic
+            # Build a cache of the en topics:
+            en_topic_ids = list(en_featured_topics_relationships.values_list("topic_id", flat=True))
+            en_topics = BlogPageTopic.objects.filter(id__in=en_topic_ids).order_by(
+                "nav_menu_featured_topics__sort_order"
+            )
+            en_topics_cache = {en_topic.translation_key: en_topic for en_topic in en_topics}
 
-        # Annotate with its url:
+        # Build featured topics slugs
         blog_index_page = self.blog_index_page
         for relationship in featured_topics_relationships:
             if relationship.topic:
+                # Use the en slug only until slugs are localized @TODO TP1-690 / #12367
+                if active_locale != en_locale:
+                    topic_slug = en_topics_cache.get(relationship.topic.translation_key).slug
+                else:
+                    topic_slug = relationship.topic.slug
+
                 relationship.topic.url = blog_index_page.url + blog_index_page.reverse_subpage(
-                    "entries_by_topic", args=[relationship.topic.slug]
+                    "entries_by_topic", args=[topic_slug]
                 )
 
         return featured_topics_relationships

--- a/network-api/networkapi/nav/tests/test_models.py
+++ b/network-api/networkapi/nav/tests/test_models.py
@@ -67,7 +67,7 @@ class TestNavMenuFeaturedTopics(test_base.WagtailpagesTestCase):
         )
 
         # Get the localised topics:
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             relationships = self.menu.localized_featured_blog_topics
             topics = [relationship.topic for relationship in relationships]
             icons = [relationship.icon for relationship in relationships]
@@ -101,7 +101,7 @@ class TestNavMenuFeaturedTopics(test_base.WagtailpagesTestCase):
                 sort_order=idx,
             )
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             # Make sure that this property won't blow up to N+1 queries
             relationships = self.menu.localized_featured_blog_topics
             topics = [relationship.topic for relationship in relationships]


### PR DESCRIPTION
# Description

To recreate the issue, visit the [fr production homepage](https://foundation.mozilla.org/fr/), hover over Blog in the nav and note that the first topic under `Popular Topics` is `Plaidoyer` and links to `/fr/blog/topic/plaidoyer`. That slug ending is a translated page name but is invalid, and resolves back to the blog index page. The valid link is actually the `en` slug ending `/fr/blog/topic/advocacy`

This PR will ensure the featured blog topic links in the nav always use the `en` slug ending, regardless of locale. To clarify, it will still link to a translated page URL (i.e. `/fr/blog/topic/advocacy/`) but it will no longer use the translated last part of the slug (i.e. `/fr/blog/topic/plaidoyer/`, which is invalid)

We want to be mindful that localizing the last part of the slug is a potentially useful feature for something like SEO, and so have split off an epic TP1-690 / #12367 to track that effort

Link to sample test page: https://foundation-s-tp1-667-12-2pjgij.herokuapp.com/
Related PRs/issues: [TP1-667](https://mozilla-hub.atlassian.net/browse/TP1-667) / #12343

# To Test

1. Review [en homepage](https://foundation-s-tp1-667-12-2pjgij.herokuapp.com/)
2. Hover over Blog and verify all `Popular Topics` are in English and link to correct /en/ slugs. Particularly note `Advocacy` and `Fellowships and Awards`
3. Review [fr homepage](https://foundation-s-tp1-667-12-2pjgij.herokuapp.com/fr)
4. Hover over Blog and verify that there are some `Popular Topics` translated into French and link to correctly translated /fr/ page URLs but with `en` slug endings. Particularly note `Advocacy` is now translated to `Plaidoyer` and links correctly to `/fr/blog/topic/advocacy/`. `Fellowships and Awards` is now also similarly translated with a correct page URL.

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
~- [ ] Did I update or add new fake data?~
~- [ ] Did I squash my migration?~
~- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~

**Documentation:**
- [x] Is my code documented?
~- [ ] Did I update the READMEs or wagtail documentation?~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-693)
