### PR TITLE
Add mozfest schedule as a static external link

### DIFF
--- a/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
@@ -36,6 +36,7 @@
                                         <div class="wide-screen-menu">
                                             <div class="nav-links d-none d-lg-block">
                                                 {% include "fragments/nav_links.html" %}
+                                                <a target="_blank" href="https://schedule.mozillafestival.org/plaza">{% trans "Schedule" %}</a>
                                             </div>
                                         </div>
                                     </div>

--- a/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
@@ -14,6 +14,7 @@
                                         <div class="nav-links pt-3">
                                             <div><a class="{% primary_active_nav request menu_root.full_url menu_root.full_url %}" href="{{ menu_root.url }}">{{ root_name }}</a></div>
                                             {% include "fragments/nav_links.html" with pre="<div>" post="</div>" %}
+                                            <a target="_blank" href="https://schedule.mozillafestival.org/plaza">{% trans "Schedule" %}</a>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
# Description

This PR adds a schedule link to the mozfest main nav.

Link to sample test page: https://mozfest-foundation-s-tp1-689-12-tmhlw0.mofostaging.net/en/
Related PRs/issues: TP1-689 #12366

# To Test

1) View the [review app mozfest homepage](https://mozfest-foundation-s-tp1-689-12-tmhlw0.mofostaging.net/en/)
2) Confirm that the link is working as intended

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-695)
