### PR TITLE
Fixed status 500 errors by making sure the 'static' Django template tag is loaded

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/regrets-reporter-landing-page/youtube_regrets_reporter_extension.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/regrets-reporter-landing-page/youtube_regrets_reporter_extension.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
-
+{% load static %}
 
 {% block body_id %}youtube-regrets-reporter-extension{% endblock %}
 

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_2021.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2021/youtube_regrets_2021.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
-{% load wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
 {% block body_id %}youtube-regrets-2021{% endblock %}
 {% block bodyclass %}youtube-regrets-2021 youtube-regrets-shared{% endblock %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/youtube_regrets_2022.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/youtube_regrets_2022.html
@@ -1,5 +1,5 @@
 {% extends "pages/base.html" %}
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags static %}
 
 {% block body_id %}youtube-regrets-2022{% endblock %}
 {% block bodyclass %}youtube-regrets-2022 youtube-regrets-shared{% endblock %}


### PR DESCRIPTION
<img width="600" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/9d853029-f60c-4fd4-a199-b833474da25c">

# Description

Fixed status 500 errors on by making sure `static` tag is loaded
- https://foundation.mozilla.org/en/youtube/findings/
- https://foundation.mozilla.org/en/youtube/user-controls/

From [CMS ](https://foundation.mozilla.org/cms/pages/15076/), we can tell what page type and the corresponding template files are causing issues. I also noticed though no page on the site is currently of the page type of `YoutubeRegretsReporterExtensionPage`, its underlying template file is also missing the `static` tag. I've also fixed that bug in this PR.

<img width="1061" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/2896608/491a42c3-9847-4fac-976e-526c1d287242">


---

# To QA

Go the following pages and make sure the 500 error is no longer there
- https://foundation-s-12391-tp71-9dgbte.herokuapp.com/youtube/findings/
- https://foundation-s-12391-tp71-9dgbte.herokuapp.com/youtube/user-controls/


---

Related PRs/issues: #12391 & https://mozilla-hub.atlassian.net/browse/TP1-715

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-716)
