### PR TITLE
Fix wrong capitalization of article title in subnav for non-english localized pages

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/fragments/article_subnav.html
+++ b/network-api/networkapi/wagtailpages/templates/fragments/article_subnav.html
@@ -1,10 +1,11 @@
 {% load i18n wagtailimages_tags wagtailcore_tags static %}
+{% get_current_language as LANGUAGE_CODE %}
 
 <div class="article-navbar-container position-relative" aria-hidden="true">
     <div class="article-navbar">
         <div class="tw-container">
             <div class="tw-row tw-items-end">
-                <div class="article-navbar-title tw-body-large tw-capitalize tw-pl-8 tw-hidden medium:tw-block tw-w-[280px] large:tw-w-auto tw-truncate">
+                <div class="article-navbar-title tw-body-large {% if LANGUAGE_CODE == 'en' %}tw-capitalize{% endif %} tw-pl-8 tw-hidden medium:tw-block tw-w-[280px] large:tw-w-auto tw-truncate">
                     {% if get_titles %}
                         {{ page.title|truncatechars:60 }}
                     {% else %}


### PR DESCRIPTION
# Description

Conditioning the `tw-capitalize` classname to only be added to pages with `LANGUAGE_CODE` set to `en`.

`fr` locale:
<img width="1263" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/169965225/227da7fd-8830-4d0c-b3fc-441cc1c40444">

`en` locale:
<img width="1295" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/169965225/e3f51707-d072-440b-8fc4-d19a0c01a47b">


Link to sample test page: https://foundation-s-tp1-16-rem-ptvjeq.herokuapp.com/fr/research/library/accelerating-progress-toward-trustworthy-ai/whitepaper/
Related PRs/issues: #12072

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-791)
