### PR TITLE
Revert "Bump pygit2 from 1.14.0 to 1.15.0 (#12356)"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ Faker
 future
 gunicorn
 heroku3
-pygit2==1.15.0
+pygit2==1.14.0
 python-slugify
 requests
 social-auth-app-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,7 +171,7 @@ psycopg2-binary==2.9.9
     # via -r requirements.in
 pycparser==2.21
     # via cffi
-pygit2==1.15.0
+pygit2==1.14.0
     # via
     #   -r requirements.in
     #   wagtail-localize-git


### PR DESCRIPTION
This reverts commit 8481a5187243a4b6ea0594ee02e91d893a1565af.

1.15 appears to have broken wagtail localize syncing

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-798)
