### PR TITLE
Add english language code to the `x-default` link attribute

### DIFF
--- a/network-api/networkapi/templates/fragments/canonical_url.html
+++ b/network-api/networkapi/templates/fragments/canonical_url.html
@@ -6,7 +6,7 @@
 <link rel="canonical" href="{{ CANONICAL_SITE_URL }}/{{ LANGUAGE_CODE }}{{ CANONICAL_PATH }}">
 
 {% with "en" as ENGLISH_LANG_CODE %}
-<link rel="alternate" hreflang="x-default" href="{{ CANONICAL_SITE_URL }}/{{ ENGLISH_LANG_CODE }}{{ CANONICAL_PATH }}">
+    <link rel="alternate" hreflang="x-default" href="{{ CANONICAL_SITE_URL }}/{{ ENGLISH_LANG_CODE }}{{ CANONICAL_PATH }}">
 {% endwith %}
 
 {% for CODE, NAME in LANGUAGES %}

--- a/network-api/networkapi/templates/fragments/canonical_url.html
+++ b/network-api/networkapi/templates/fragments/canonical_url.html
@@ -5,7 +5,7 @@
 
 <link rel="canonical" href="{{ CANONICAL_SITE_URL }}/{{ LANGUAGE_CODE }}{{ CANONICAL_PATH }}">
 
-{% with 'en' as ENGLISH_LANG_CODE %}
+{% with "en" as ENGLISH_LANG_CODE %}
 <link rel="alternate" hreflang="x-default" href="{{ CANONICAL_SITE_URL }}/{{ ENGLISH_LANG_CODE }}{{ CANONICAL_PATH }}">
 {% endwith %}
 

--- a/network-api/networkapi/templates/fragments/canonical_url.html
+++ b/network-api/networkapi/templates/fragments/canonical_url.html
@@ -4,7 +4,11 @@
 {% get_available_languages as LANGUAGES %}
 
 <link rel="canonical" href="{{ CANONICAL_SITE_URL }}/{{ LANGUAGE_CODE }}{{ CANONICAL_PATH }}">
-<link rel="alternate" hreflang="x-default" href="{{ CANONICAL_SITE_URL }}{{ CANONICAL_PATH }}">
+
+{% with 'en' as ENGLISH_LANG_CODE %}
+<link rel="alternate" hreflang="x-default" href="{{ CANONICAL_SITE_URL }}/{{ ENGLISH_LANG_CODE }}{{ CANONICAL_PATH }}">
+{% endwith %}
+
 {% for CODE, NAME in LANGUAGES %}
     {% get_language_info for CODE as lang %}
     {% if CODE == 'es' %}


### PR DESCRIPTION
# Description

This PR modifies the `x-default` alternate link tag from the site, adding the `en` language code to the url so SEO improves by reducing redirects following that metadata.

<img width="1408" alt="image" src="https://github.com/MozillaFoundation/foundation.mozilla.org/assets/169965225/4766f1fc-8e21-4d8c-96ed-d48c73a4b88d">

# To Test

Open any page of the site, right click on any part of the body and select `View Source` from the context menu, updated metadata is located at line 182 inside the `head`tag.

Link to sample test page: https://foundation-s-tp1-332-hr-cs8gft.herokuapp.com/en/
Related PRs/issues: #8834

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-803)
