### PR TITLE
Translate Topic Names in Nav Featured Blog Posts

### DIFF
--- a/network-api/networkapi/templates/fragments/nav/blog/post.html
+++ b/network-api/networkapi/templates/fragments/nav/blog/post.html
@@ -1,12 +1,12 @@
-{% load static i18n wagtailadmin_tags wagtailcore_tags %}
+{% load static i18n localization wagtailadmin_tags wagtailcore_tags %}
 
 {% fragment as font_styles %}tw-text-xl large:tw-text-lg tw-font-semibold tw-text-black{% endfragment %}
 {% fragment as hover_styles %}group-hover/item:tw-text-blue-80 group-hover/item:tw-underline{% endfragment %}
 
-<div class="tw-group/item tw-flex tw-flex-col tw-gap-2 xlarge:hover:tw-bg-blue-03 xlarge:hover:tw-rounded {{ link_hover_padding }}">
-    {% with topic=post.topics.all|first %}
-        <p class="tw-font-sans tw-font-normal tw-text-xs tw-text-gray-40 tw-uppercase tw-my-0">{{ topic.name }}</p>
-    {% endwith %}
+{% localized_version post.topics.all|first as localized_topic %}
+
+<div class="tw-group/item tw-flex tw-flex-col tw-gap-2 xlarge:hover:tw-bg-blue-03 xlarge:hover:tw-rounded {{ link_hover_padding }}">        
+        <p class="tw-font-sans tw-font-normal tw-text-xs tw-text-gray-40 tw-uppercase tw-my-0">{{ localized_topic.name }}</p>
     <a class="{{ font_styles }} {{ hover_styles }}" href="{% pageurl post %}">{{ post.title }}</a>
     <p class="tw-font-light tw-text-sm tw-text-gray-80 tw-line-clamp-3 tw-hidden medium:tw-block">
         {{ post.get_meta_description }}

--- a/network-api/networkapi/templates/fragments/nav/blog/post.html
+++ b/network-api/networkapi/templates/fragments/nav/blog/post.html
@@ -5,8 +5,8 @@
 
 {% localized_version post.topics.all|first as localized_topic %}
 
-<div class="tw-group/item tw-flex tw-flex-col tw-gap-2 xlarge:hover:tw-bg-blue-03 xlarge:hover:tw-rounded {{ link_hover_padding }}">        
-        <p class="tw-font-sans tw-font-normal tw-text-xs tw-text-gray-40 tw-uppercase tw-my-0">{{ localized_topic.name }}</p>
+<div class="tw-group/item tw-flex tw-flex-col tw-gap-2 xlarge:hover:tw-bg-blue-03 xlarge:hover:tw-rounded {{ link_hover_padding }}">
+    <p class="tw-font-sans tw-font-normal tw-text-xs tw-text-gray-40 tw-uppercase tw-my-0">{{ localized_topic.name }}</p>
     <a class="{{ font_styles }} {{ hover_styles }}" href="{% pageurl post %}">{{ post.title }}</a>
     <p class="tw-font-light tw-text-sm tw-text-gray-80 tw-line-clamp-3 tw-hidden medium:tw-block">
         {{ post.get_meta_description }}


### PR DESCRIPTION
# Description

The current navigation only shows English topic names above the Featured Posts in the Blog dropdown menu. This PR introduces the localized_version of the topic names.

Link to sample test page: https://foundation-s-tp1-769-ma-ek0wqq.herokuapp.com/en/
Related PRs/issues: TP1-769 / #12446

# To Test
1) View staging's [French homepage](https://foundation.mofostaging.net/fr/), hover over `Blog` and notice the Blog Topics are all in English
2) View the review app's [French homepage](https://foundation-s-tp1-769-ma-ek0wqq.herokuapp.com/fr/) and notice the Blog Topics are now accurately translated to French.
3) Verify the review app's [English homepage](https://foundation-s-tp1-769-ma-ek0wqq.herokuapp.com/en/) will also still show English.


┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-854)
