### PR TITLE
updated migration to migrate data from all applicable page types

### DIFF
--- a/network-api/networkapi/wagtailpages/migrations/0139_update_annotatedimageblock_with_linkblock.py
+++ b/network-api/networkapi/wagtailpages/migrations/0139_update_annotatedimageblock_with_linkblock.py
@@ -5774,7 +5774,7 @@ class Migration(migrations.Migration):
             model_name="blogpage",
             field_name="body",
             operations_and_block_paths=[
-                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+                (AlterStreamChildBlockDataOperation(block="image", operation=migrate_image_block), ""),
             ],
         ),
         MigrateStreamData(
@@ -5782,7 +5782,7 @@ class Migration(migrations.Migration):
             model_name="buyersguidearticlepage",
             field_name="body",
             operations_and_block_paths=[
-                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+                (AlterStreamChildBlockDataOperation(block="image", operation=migrate_image_block), ""),
             ],
         ),
         MigrateStreamData(
@@ -5790,7 +5790,7 @@ class Migration(migrations.Migration):
             model_name="buyersguidecampaignpage",
             field_name="body",
             operations_and_block_paths=[
-                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+                (AlterStreamChildBlockDataOperation(block="image", operation=migrate_image_block), ""),
             ],
         ),
         MigrateStreamData(
@@ -5798,7 +5798,7 @@ class Migration(migrations.Migration):
             model_name="modularpage",
             field_name="body",
             operations_and_block_paths=[
-                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+                (AlterStreamChildBlockDataOperation(block="image", operation=migrate_image_block), ""),
             ],
         ),
         MigrateStreamData(
@@ -5806,7 +5806,7 @@ class Migration(migrations.Migration):
             model_name="primarypage",
             field_name="body",
             operations_and_block_paths=[
-                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+                (AlterStreamChildBlockDataOperation(block="image", operation=migrate_image_block), ""),
             ],
         ),
         migrations.AlterField(

--- a/network-api/networkapi/wagtailpages/migrations/0139_update_annotatedimageblock_with_linkblock.py
+++ b/network-api/networkapi/wagtailpages/migrations/0139_update_annotatedimageblock_with_linkblock.py
@@ -5774,7 +5774,39 @@ class Migration(migrations.Migration):
             model_name="blogpage",
             field_name="body",
             operations_and_block_paths=[
-                (AlterStreamChildBlockDataOperation(block="image", operation=migrate_image_block), ""),
+                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+            ],
+        ),
+        MigrateStreamData(
+            app_name="wagtailpages",
+            model_name="buyersguidearticlepage",
+            field_name="body",
+            operations_and_block_paths=[
+                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+            ],
+        ),
+        MigrateStreamData(
+            app_name="wagtailpages",
+            model_name="buyersguidecampaignpage",
+            field_name="body",
+            operations_and_block_paths=[
+                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+            ],
+        ),
+        MigrateStreamData(
+            app_name="wagtailpages",
+            model_name="modularpage",
+            field_name="body",
+            operations_and_block_paths=[
+                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
+            ],
+        ),
+        MigrateStreamData(
+            app_name="wagtailpages",
+            model_name="primarypage",
+            field_name="body",
+            operations_and_block_paths=[
+                (AlterStreamChildBlockDataOperation(block="image_text", operation=migrate_image_block), ""),
             ],
         ),
         migrations.AlterField(


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Related PRs/issues: #12481 

In the migration file `0139_update_annotatedimageblock_with_linkblock`, there are 5 instances of `migrations.AlterField()` to add the new `caption_URL` field and 5 instances of `migrations.AlterField()` to remove the old `captionURL` field for the following page models:

- `blogpage`
- `buyersguidearticlepage`
- `buyersguidecampaignpage`
- `modularpage`
- `primarypage`

However, currently, there is only one `MigrateStreamData` operation, which is for the `blogpage` model.

This PR adds four additional `MigrateStreamData` operations to ensure that existing data is properly migrated for all the page types listed above.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-856)
