### PR TITLE
Bugfix: Reset Review App Database before Restoring

### DIFF
--- a/copy_staging_db_to_review_app.py
+++ b/copy_staging_db_to_review_app.py
@@ -64,6 +64,10 @@ def main(ctx, review_app_name):
         execute_command(ctx, f"heroku pg:backups:capture -a {review_app_name}")
         log_step_completed("Review App DB backup")
 
+        log_step("Reset Review App DB")
+        execute_command(ctx, f"heroku pg:reset -a '{review_app_name}' --confirm '{review_app_name}'")
+        log_step_completed("Review App DB has been reset")
+
         log_step("Restoring the latest Staging backup to Review App")
         backup_staging_url = execute_command(ctx, f"heroku pg:backups:url -a {STAGING_APP}")
         execute_command(


### PR DESCRIPTION
# Description

This bugfix addresses an issue where trying to overwrite the Reviewing Apps database with the Staging database caused errors. By adding an extra step to reset the Reviewing Apps database, we can handle two scenarios:

- If the Staging Restore fails, we can still use the Review App Restore, and the Review App will have the same database as before.
- If the Staging Restore succeeds, the process completes without any problems.

In summary, this extra step does not affect the current process of copying the Staging database to the Review App.

~~Link to sample test page:~~
~~Related PRs/issues:~~

# Checklist

~~**Tests**~~
~~- [ ] Is the code I'm adding covered by tests?~~

~~**Changes in Models:**~~
~~- [ ] Did I update or add new fake data?~~
~~- [ ] Did I squash my migration?~~
~~- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?~~

~~**Documentation:**~~
~~- [ ] Is my code documented?~~
~~- [ ] Did I update the READMEs or wagtail documentation?~~

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-900)
