### PR TITLE
Main Nav Fake Data Factory

### DIFF
--- a/network-api/networkapi/management/commands/load_fake_data.py
+++ b/network-api/networkapi/management/commands/load_fake_data.py
@@ -11,6 +11,7 @@ from taggit.models import Tag
 import networkapi.donate.factory as donate_factory
 import networkapi.highlights.factory as highlights_factory
 import networkapi.mozfest.factory as mozfest_factory
+import networkapi.nav.factories as nav_factory
 import networkapi.news.factory as news_factory
 import networkapi.wagtailpages.factory as wagtailpages_factory
 from networkapi.utility.faker.helpers import reseed
@@ -89,6 +90,7 @@ class Command(BaseCommand):
                 wagtailpages_factory,
                 mozfest_factory,
                 donate_factory,
+                nav_factory,
             ]
         ]
 

--- a/network-api/networkapi/nav/factories.py
+++ b/network-api/networkapi/nav/factories.py
@@ -7,7 +7,9 @@ from wagtail.rich_text import RichText
 
 from networkapi.nav import blocks as nav_blocks
 from networkapi.nav import models as nav_models
+from networkapi.utility.faker.helpers import get_homepage, reseed
 from networkapi.wagtailcustomization.factories.blocks import ExtendedStructBlockFactory
+from networkapi.wagtailpages.models import BlogPageTopic
 
 
 class NavItemFactory(ExtendedStructBlockFactory):
@@ -265,3 +267,372 @@ class NavMenuFeaturedBlogTopicRelationshipFactory(DjangoModelFactory):
     locale = factory.LazyFunction(lambda: wagtail_models.Locale.get_default())
     menu = factory.SubFactory("networkapi.nav.factories.NavMenuFactory")
     topic = factory.SubFactory("networkapi.wagtailpages.factory.blog.BlogPageTopicFactory")
+
+
+# Build "Who We Are" dropdown
+def generate_first_dropdown(seed):
+    reseed(seed)
+    # Create pre-requisite data
+    ## Set dropdown title
+    title = "Who We Are"
+    ## Create a test page for linking purposes only
+    page_a1 = wagtail_factories.PageFactory(parent=get_homepage(), title="Test Page")
+
+    ## Create Overview section for dropdown
+    overview = wagtail_factories.ListBlockFactory(
+        NavOverviewFactory,
+        **{
+            "0__title": "About Us",
+            "0__description": RichText(
+                "Mozilla is a global nonprofit dedicated to keeping the Internet a public resource that is open and accessible to all."
+            ),
+        },
+    )
+
+    ## Build out nav items (columns)
+    ### Column 1 nav items
+    nav_items_0 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__link_to": "page",
+            "0__page": page_a1,
+            "0__description": "",
+            "1__external_url_link": True,
+            "1__external_url": "https://mozilla.org/",
+            "1__description": "",
+        },
+    )
+    ### Column 2 nav items
+    nav_items_1 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__external_url_link": True,
+            "0__description": "",
+            "0__external_url": "https://mozilla.org/",
+            "1__external_url_link": True,
+            "1__external_url": "https://mozilla.org/",
+            "1__description": "",
+        },
+    )
+    ## Build out columns
+    columns = wagtail_factories.ListBlockFactory(
+        NavColumnFactory,
+        **{
+            "0__title": "Approach",
+            "0__nav_items": nav_items_0,
+            "0__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+            "1__title": "Legal",
+            "1__nav_items": nav_items_1,
+            "1__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+        },
+    )
+    ## Build button
+    button = factory.SubFactory(
+        NavButtonFactory, link_to="relative_url", relative_url="/who-we-are/", label="Learn More"
+    )
+
+    # Generate dropdown
+    dropdown = NavDropdownFactory(
+        title=title,
+        overview=overview,
+        columns=columns,
+        button=button,
+    )
+
+    return dropdown
+
+
+# Build "What We Do" dropdown
+def generate_second_dropdown(seed):
+    reseed(seed)
+    # Create pre-requisite data
+    ## Set dropdown title
+    title = "What We Do"
+
+    ## Build out nav items (columns)
+    ### Column 1 nav items
+    nav_items_0 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+            "2__relative_url_link": True,
+            "2__relative_url": "/",
+        },
+    )
+    ### Column 2 nav items
+    nav_items_1 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "0__description": "",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+            "2__relative_url_link": True,
+            "2__relative_url": "/",
+        },
+    )
+    ### Column 3 nav items
+    nav_items_2 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+        },
+    )
+    ### Column 4 nav items
+    nav_items_3 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+        },
+    )
+
+    ## Build out columns
+    columns = wagtail_factories.ListBlockFactory(
+        NavColumnFactory,
+        **{
+            "0__title": "Connect People",
+            "0__nav_items": nav_items_0,
+            "0__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+            "1__title": "Rally Communities",
+            "1__nav_items": nav_items_1,
+            "1__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+            "2__title": "Influence Policies",
+            "2__nav_items": nav_items_2,
+            "2__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+            "3__title": "Research & Analysis",
+            "3__nav_items": nav_items_3,
+            "3__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+        },
+    )
+
+    ## Build button
+    button = factory.SubFactory(
+        NavButtonFactory, link_to="relative_url", relative_url="/", label="Learn more about what we do"
+    )
+
+    # Generate dropdown
+    dropdown = NavDropdownFactory(
+        title=title,
+        columns=columns,
+        button=button,
+    )
+
+    return dropdown
+
+
+# Build "What You Can Do" dropdown
+def generate_third_dropdown(seed):
+    reseed(seed)
+    # Create pre-requisite data
+    ## Set dropdown title
+    title = "What You Can Do"
+    ## Create a test page for linking purposes only
+    page_a2 = wagtail_factories.PageFactory()
+
+    ## Create Overview section for dropdown
+    overview = wagtail_factories.ListBlockFactory(
+        NavOverviewFactory,
+        **{
+            "0__title": "Get Involved",
+            "0__description": RichText(
+                "From donating funds or data, to signing a petition, to applying to become a volunteer or fellow there are many ways to get involved with the community."
+            ),
+        },
+    )
+
+    ## Build out nav items (columns)
+    ### Column 1 nav items
+    nav_items_0 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "0__description": "",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+            "2__relative_url_link": True,
+            "2__relative_url": "/",
+        },
+    )
+    ### Column 2 nav items
+    nav_items_1 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "0__description": "",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+            "2__relative_url_link": True,
+            "2__relative_url": "/",
+        },
+    )
+
+    ## Build out columns
+    columns = wagtail_factories.ListBlockFactory(
+        NavColumnFactory,
+        **{
+            "0__title": "Act",
+            "0__nav_items": nav_items_0,
+            "0__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+            "1__title": "Learn",
+            "1__nav_items": nav_items_1,
+            "1__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+        },
+    )
+
+    ## Build featured nav items
+    featured_nav_items = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__label": "Make a Donation",
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "0__description": "",
+            "1__label": "Ways to Give",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+            "1__description": "",
+        },
+    )
+
+    ## Build featured column
+    featured_column = wagtail_factories.ListBlockFactory(
+        NavFeaturedColumnFactory,
+        **{
+            "0__title": "Donate",
+            "0__nav_items": featured_nav_items,
+        },
+    )
+
+    ## Build button
+    button = factory.SubFactory(NavButtonFactory, link_to="page", page=page_a2, label="Learn More")
+
+    # Generate dropdown
+    dropdown = NavDropdownFactory(
+        title=title,
+        overview=overview,
+        columns=columns,
+        featured_column=featured_column,
+        button=button,
+    )
+
+    return dropdown
+
+
+# Build "What We Fund" dropdown
+def generate_fourth_dropdown(seed):
+    reseed(seed)
+    # Create pre-requisite data
+    ## Set dropdown title
+    title = "What We Fund"
+    ## Create a test page for linking purposes only
+    page_a2 = wagtail_factories.PageFactory()
+
+    ## Create Overview section for dropdown
+    overview = wagtail_factories.ListBlockFactory(
+        NavOverviewFactory,
+        **{
+            "0__title": "Apply for Funding",
+            "0__description": RichText(
+                "The Mozilla Foundation provides funding and resources to individuals, groups, and organizations aligned with creating a more human-centered internet."
+            ),
+        },
+    )
+
+    ## Build out nav items (columns)
+    ### Column 1 nav items
+    nav_items_0 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+        },
+    )
+    ### Column 2 nav items
+    nav_items_1 = wagtail_factories.ListBlockFactory(
+        NavItemFactory,
+        **{
+            "0__relative_url_link": True,
+            "0__relative_url": "/",
+            "1__relative_url_link": True,
+            "1__relative_url": "/",
+        },
+    )
+
+    ## Build out columns
+    columns = wagtail_factories.ListBlockFactory(
+        NavColumnFactory,
+        **{
+            "0__title": "Opportunities",
+            "0__nav_items": nav_items_0,
+            "0__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+            "1__title": "Community Impact",
+            "1__nav_items": nav_items_1,
+            "1__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
+        },
+    )
+
+    ## Build button
+    button = factory.SubFactory(NavButtonFactory, link_to="page", page=page_a2, label="Learn More")
+
+    # Generate dropdown
+    dropdown = NavDropdownFactory(
+        title=title,
+        overview=overview,
+        columns=columns,
+        button=button,
+    )
+
+    return dropdown
+
+
+# Generate the Nav Menu
+def generate(seed):
+    reseed(seed)
+
+    try:
+        menu = nav_models.NavMenu.objects.get()
+        print("Main Navigation exists")
+    except nav_models.NavMenu.DoesNotExist:
+        print("Generating Main Navigation")
+
+        dropdown_0 = generate_first_dropdown(seed)
+        dropdown_1 = generate_second_dropdown(seed)
+        dropdown_2 = generate_third_dropdown(seed)
+        dropdown_3 = generate_fourth_dropdown(seed)
+
+        # Build menu
+        menu = NavMenuFactory(
+            dropdowns__0__dropdown=dropdown_0,
+            dropdowns__1__dropdown=dropdown_1,
+            dropdowns__2__dropdown=dropdown_2,
+            dropdowns__3__dropdown=dropdown_3,
+            enable_blog_dropdown=True,
+            blog_button_label="See all blog posts",
+        )
+
+        print("Linking blog topics to New Main Navigation")
+        # Get existing topics and create relationships
+        topics = BlogPageTopic.objects.all()[:5]
+        for topic in topics:
+            NavMenuFeaturedBlogTopicRelationshipFactory(menu=menu, topic=topic)
+
+        # Activate menu
+        print("Activating New Main Navigation")
+        site = wagtail_models.Site.objects.first()
+        site_active_nav = nav_models.SiteNavMenu.for_site(site)
+        site_active_nav.active_nav_menu = menu
+        site_active_nav.save()

--- a/network-api/networkapi/nav/factories.py
+++ b/network-api/networkapi/nav/factories.py
@@ -272,7 +272,7 @@ class NavMenuFeaturedBlogTopicRelationshipFactory(DjangoModelFactory):
 # Build "Who We Are" dropdown
 def generate_first_dropdown(seed):
     reseed(seed)
-    # Create pre-requisite data
+    # Create prerequisite data
     # Set dropdown title
     title = "Who We Are"
     # Create a test page for linking purposes only
@@ -284,7 +284,10 @@ def generate_first_dropdown(seed):
         **{
             "0__title": "About Us",
             "0__description": RichText(
-                "Mozilla is a global nonprofit dedicated to keeping the Internet a public resource that is open and accessible to all."
+                (
+                    "Mozilla is a global nonprofit dedicated to keeping the Internet"
+                    " a public resource that is open and accessible to all."
+                )
             ),
         },
     )
@@ -345,7 +348,7 @@ def generate_first_dropdown(seed):
 # Build "What We Do" dropdown
 def generate_second_dropdown(seed):
     reseed(seed)
-    # Create pre-requisite data
+    # Create prerequisite data
     # Set dropdown title
     title = "What We Do"
 
@@ -433,19 +436,22 @@ def generate_second_dropdown(seed):
 # Build "What You Can Do" dropdown
 def generate_third_dropdown(seed):
     reseed(seed)
-    # Create pre-requisite data
+    # Create prerequisite data
     # Set dropdown title
     title = "What You Can Do"
     # Create a test page for linking purposes only
     page_a2 = wagtail_factories.PageFactory()
 
-    ## Create Overview section for dropdown
+    # Create Overview section for dropdown
     overview = wagtail_factories.ListBlockFactory(
         NavOverviewFactory,
         **{
             "0__title": "Get Involved",
             "0__description": RichText(
-                "From donating funds or data, to signing a petition, to applying to become a volunteer or fellow there are many ways to get involved with the community."
+                (
+                    "From donating funds or data, to signing a petition, to applying to become a "
+                    "volunteer or fellow there are many ways to get involved with the community."
+                )
             ),
         },
     )
@@ -533,7 +539,7 @@ def generate_third_dropdown(seed):
 # Build "What We Fund" dropdown
 def generate_fourth_dropdown(seed):
     reseed(seed)
-    # Create pre-requisite data
+    # Create prerequisite data
     # Set dropdown title
     title = "What We Fund"
     # Create a test page for linking purposes only
@@ -545,7 +551,10 @@ def generate_fourth_dropdown(seed):
         **{
             "0__title": "Apply for Funding",
             "0__description": RichText(
-                "The Mozilla Foundation provides funding and resources to individuals, groups, and organizations aligned with creating a more human-centered internet."
+                (
+                    "The Mozilla Foundation provides funding and resources to individuals,"
+                    " groups, and organizations aligned with creating a more human-centered internet."
+                )
             ),
         },
     )

--- a/network-api/networkapi/nav/factories.py
+++ b/network-api/networkapi/nav/factories.py
@@ -273,12 +273,12 @@ class NavMenuFeaturedBlogTopicRelationshipFactory(DjangoModelFactory):
 def generate_first_dropdown(seed):
     reseed(seed)
     # Create pre-requisite data
-    ## Set dropdown title
+    # Set dropdown title
     title = "Who We Are"
-    ## Create a test page for linking purposes only
+    # Create a test page for linking purposes only
     page_a1 = wagtail_factories.PageFactory(parent=get_homepage(), title="Test Page")
 
-    ## Create Overview section for dropdown
+    # Create Overview section for dropdown
     overview = wagtail_factories.ListBlockFactory(
         NavOverviewFactory,
         **{
@@ -289,8 +289,8 @@ def generate_first_dropdown(seed):
         },
     )
 
-    ## Build out nav items (columns)
-    ### Column 1 nav items
+    # Build out nav items (columns)
+    # Column 1 nav items
     nav_items_0 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -302,7 +302,7 @@ def generate_first_dropdown(seed):
             "1__description": "",
         },
     )
-    ### Column 2 nav items
+    # Column 2 nav items
     nav_items_1 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -314,7 +314,7 @@ def generate_first_dropdown(seed):
             "1__description": "",
         },
     )
-    ## Build out columns
+    # Build out columns
     columns = wagtail_factories.ListBlockFactory(
         NavColumnFactory,
         **{
@@ -326,7 +326,7 @@ def generate_first_dropdown(seed):
             "1__button": wagtail_factories.ListBlockFactory(NavButtonFactory, **{}),
         },
     )
-    ## Build button
+    # Build button
     button = factory.SubFactory(
         NavButtonFactory, link_to="relative_url", relative_url="/who-we-are/", label="Learn More"
     )
@@ -346,11 +346,11 @@ def generate_first_dropdown(seed):
 def generate_second_dropdown(seed):
     reseed(seed)
     # Create pre-requisite data
-    ## Set dropdown title
+    # Set dropdown title
     title = "What We Do"
 
-    ## Build out nav items (columns)
-    ### Column 1 nav items
+    # Build out nav items (columns)
+    # Column 1 nav items
     nav_items_0 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -362,7 +362,7 @@ def generate_second_dropdown(seed):
             "2__relative_url": "/",
         },
     )
-    ### Column 2 nav items
+    # Column 2 nav items
     nav_items_1 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -375,7 +375,7 @@ def generate_second_dropdown(seed):
             "2__relative_url": "/",
         },
     )
-    ### Column 3 nav items
+    # Column 3 nav items
     nav_items_2 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -385,7 +385,7 @@ def generate_second_dropdown(seed):
             "1__relative_url": "/",
         },
     )
-    ### Column 4 nav items
+    # Column 4 nav items
     nav_items_3 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -396,7 +396,7 @@ def generate_second_dropdown(seed):
         },
     )
 
-    ## Build out columns
+    # Build out columns
     columns = wagtail_factories.ListBlockFactory(
         NavColumnFactory,
         **{
@@ -415,7 +415,7 @@ def generate_second_dropdown(seed):
         },
     )
 
-    ## Build button
+    # Build button
     button = factory.SubFactory(
         NavButtonFactory, link_to="relative_url", relative_url="/", label="Learn more about what we do"
     )
@@ -434,9 +434,9 @@ def generate_second_dropdown(seed):
 def generate_third_dropdown(seed):
     reseed(seed)
     # Create pre-requisite data
-    ## Set dropdown title
+    # Set dropdown title
     title = "What You Can Do"
-    ## Create a test page for linking purposes only
+    # Create a test page for linking purposes only
     page_a2 = wagtail_factories.PageFactory()
 
     ## Create Overview section for dropdown
@@ -450,8 +450,8 @@ def generate_third_dropdown(seed):
         },
     )
 
-    ## Build out nav items (columns)
-    ### Column 1 nav items
+    # Build out nav items (columns)
+    # Column 1 nav items
     nav_items_0 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -464,7 +464,7 @@ def generate_third_dropdown(seed):
             "2__relative_url": "/",
         },
     )
-    ### Column 2 nav items
+    # Column 2 nav items
     nav_items_1 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -478,7 +478,7 @@ def generate_third_dropdown(seed):
         },
     )
 
-    ## Build out columns
+    # Build out columns
     columns = wagtail_factories.ListBlockFactory(
         NavColumnFactory,
         **{
@@ -491,7 +491,7 @@ def generate_third_dropdown(seed):
         },
     )
 
-    ## Build featured nav items
+    # Build featured nav items
     featured_nav_items = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -506,7 +506,7 @@ def generate_third_dropdown(seed):
         },
     )
 
-    ## Build featured column
+    # Build featured column
     featured_column = wagtail_factories.ListBlockFactory(
         NavFeaturedColumnFactory,
         **{
@@ -515,7 +515,7 @@ def generate_third_dropdown(seed):
         },
     )
 
-    ## Build button
+    # Build button
     button = factory.SubFactory(NavButtonFactory, link_to="page", page=page_a2, label="Learn More")
 
     # Generate dropdown
@@ -534,12 +534,12 @@ def generate_third_dropdown(seed):
 def generate_fourth_dropdown(seed):
     reseed(seed)
     # Create pre-requisite data
-    ## Set dropdown title
+    # Set dropdown title
     title = "What We Fund"
-    ## Create a test page for linking purposes only
+    # Create a test page for linking purposes only
     page_a2 = wagtail_factories.PageFactory()
 
-    ## Create Overview section for dropdown
+    # Create Overview section for dropdown
     overview = wagtail_factories.ListBlockFactory(
         NavOverviewFactory,
         **{
@@ -550,8 +550,8 @@ def generate_fourth_dropdown(seed):
         },
     )
 
-    ## Build out nav items (columns)
-    ### Column 1 nav items
+    # Build out nav items (columns)
+    # Column 1 nav items
     nav_items_0 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -561,7 +561,7 @@ def generate_fourth_dropdown(seed):
             "1__relative_url": "/",
         },
     )
-    ### Column 2 nav items
+    # Column 2 nav items
     nav_items_1 = wagtail_factories.ListBlockFactory(
         NavItemFactory,
         **{
@@ -572,7 +572,7 @@ def generate_fourth_dropdown(seed):
         },
     )
 
-    ## Build out columns
+    # Build out columns
     columns = wagtail_factories.ListBlockFactory(
         NavColumnFactory,
         **{
@@ -585,7 +585,7 @@ def generate_fourth_dropdown(seed):
         },
     )
 
-    ## Build button
+    # Build button
     button = factory.SubFactory(NavButtonFactory, link_to="page", page=page_a2, label="Learn More")
 
     # Generate dropdown

--- a/tests/integration/navigation/001-site-nav.spec.js
+++ b/tests/integration/navigation/001-site-nav.spec.js
@@ -26,11 +26,6 @@ test.describe("Main site primary nav", () => {
     await navToggleButton.click();
     await expect(nav).toBeInViewport();
 
-    // check if the active link is the current page
-    const activeLink = nav.locator(".nav-links a.active");
-    expect(await activeLink.count()).toBe(1);
-    expect(await activeLink.getAttribute("href")).toBe(PAGE_URL);
-
     // check if clicking the nav button again hides the nav
     await navToggleButton.click();
     await expect(nav).not.toBeInViewport();


### PR DESCRIPTION
# Description

This PR introduces a fake data factory for the main navigation.

The factory should mimic fairly closely as far as number and types of items. Like any fake data factory, there is a lot of fake generated links/pages/content, but some of the nav is real in order to more accurately capture the essence of the main nav on production. The factory is granular enough that we can specify any real content that might be helpful to have.

If there's anything specific you'd like to have linked within the factory instead of fake data, please let me know and I can adjust.

Link to sample test page: https://foundation-s-tp1-353-ma-liqlqz.herokuapp.com/
Related PRs/issues: TP-353 #12131

# To Test

1) Review the [review app](https://foundation-s-tp1-353-ma-liqlqz.herokuapp.com/)
2) Note the autogenerated fake main navigation
3) Check out this branch locally
4) Run `inv new-db` to get a new database
5) Note the autogenerated fake main navigation

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-901)
