### PR TITLE
Feature: Add factory for AppInstallPage

### DIFF
--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -675,6 +675,18 @@ def generate_mixed_content_field():
     )
 
 
+def generate_app_install_download_button_field():
+    return generate_field(
+        "button",
+        {
+            "link_to": "external_url",
+            "external_url": fake.url(schemes=["https"]),
+            "label": " ".join(fake.words(nb=2)),
+            "new_window": True,
+        },
+    )
+
+
 class StreamfieldProvider(BaseProvider):
     """
     A custom Faker Provider for relative image urls, for use with factory_boy
@@ -734,6 +746,7 @@ class StreamfieldProvider(BaseProvider):
             "profiles": generate_profiles_field,
             "newsletter_signup": generate_newsletter_signup_with_background_field,
             "mixed_content": generate_mixed_content_field,
+            "app_install_download_button": generate_app_install_download_button_field,
         }
 
         streamfield_data = []

--- a/network-api/networkapi/wagtailpages/factory/__init__.py
+++ b/network-api/networkapi/wagtailpages/factory/__init__.py
@@ -1,6 +1,7 @@
 from networkapi.wagtailpages.factory.libraries import rcc, research_hub
 
 from . import (
+    app_install_page,
     bannered_campaign_page,
     blog,
     buyersguide,
@@ -50,6 +51,7 @@ def generate(seed):
     rcc.generate(seed)
     # homepage_cause_statement_link requires child pages of homepage to exist
     homepage_cause_statement_link.generate(seed)
+    app_install_page.generate(seed)
 
 
 __all__ = [

--- a/network-api/networkapi/wagtailpages/factory/app_install_page.py
+++ b/network-api/networkapi/wagtailpages/factory/app_install_page.py
@@ -1,6 +1,8 @@
 from factory import Faker, SubFactory
 from wagtail_factories import PageFactory
 
+from networkapi.utility.faker.helpers import reseed
+from networkapi.wagtailpages import models as pagemodels
 from networkapi.wagtailpages.factory import image_factory
 from networkapi.wagtailpages.models import AppInstallPage
 
@@ -24,3 +26,14 @@ class AppInstallPageFactory(PageFactory):
     download_buttons = Faker("streamfield", fields=["app_install_download_button"] * 2)
     cta = SubFactory(PetitionFactory)
     body = Faker("streamfield", fields=["header", "paragraph", "image", "spacer", "image_text", "quote"])
+
+
+def generate(seed):
+    reseed(seed)
+
+    print("Generating PNI Homepage")
+    AppInstallPageFactory.create(
+        parent=pagemodels.Homepage.objects.first(),
+        title="App Install Page",
+        slug="app-install-page",
+    )

--- a/network-api/networkapi/wagtailpages/factory/app_install_page.py
+++ b/network-api/networkapi/wagtailpages/factory/app_install_page.py
@@ -1,0 +1,26 @@
+from factory import Faker, SubFactory
+from wagtail_factories import PageFactory
+
+from networkapi.wagtailpages.factory import image_factory
+from networkapi.wagtailpages.models import AppInstallPage
+
+from .petition import PetitionFactory
+
+
+class AppInstallPageFactory(PageFactory):
+    class Meta:
+        model = AppInstallPage
+        exclude = (
+            "title_text",
+            "header_text",
+            "header",
+        )
+
+    title = "Regrets Reporter Page"
+    slug = "regretsreporter"
+    hero_heading = Faker("text", max_nb_chars=50)
+    hero_subheading = Faker("text", max_nb_chars=50)
+    hero_background = SubFactory(image_factory.ImageFactory)
+    download_buttons = Faker("streamfield", fields=["app_install_download_button"] * 2)
+    cta = SubFactory(PetitionFactory)
+    body = Faker("streamfield", fields=["header", "paragraph", "image", "spacer", "image_text", "quote"])

--- a/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
+++ b/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
@@ -48,7 +48,7 @@ class AppInstallPageFactory(PageFactory):
     hero_heading = Faker("text", max_nb_chars=50)
     hero_subheading = Faker("text", max_nb_chars=50)
     hero_background = SubFactory(image_factory.ImageFactory)
-    hero_video = Faker("url")
+    download_buttons = Faker("streamfield", fields=["app_install_download_button"] * 2)
     cta = SubFactory(PetitionFactory)
     body = Faker("streamfield", fields=["header", "paragraph", "image", "spacer", "image_text", "quote"])
 

--- a/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
+++ b/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
@@ -4,15 +4,12 @@ from wagtail_factories import PageFactory
 
 from networkapi.utility.faker.helpers import get_homepage, reseed
 from networkapi.wagtailpages.models import (
-    AppInstallPage,
     YoutubeRegrets2021Page,
     YoutubeRegrets2022Page,
     YoutubeRegretsPage,
     YoutubeRegretsReporterPage,
 )
 
-from .app_install_page import AppInstallPageFactory
-from .bannered_campaign_page import BanneredCampaignPageFactory
 from .campaign_page import CampaignIndexPageFactory
 
 

--- a/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
+++ b/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
@@ -1,16 +1,20 @@
-from factory import Faker
+from factory import Faker, SubFactory
 from wagtail.models import Page as WagtailPage
 from wagtail_factories import PageFactory
 
 from networkapi.utility.faker.helpers import get_homepage, reseed
+from networkapi.wagtailpages.factory import image_factory
 from networkapi.wagtailpages.models import (
+    AppInstallPage,
     YoutubeRegrets2021Page,
     YoutubeRegrets2022Page,
     YoutubeRegretsPage,
     YoutubeRegretsReporterPage,
 )
 
+from .bannered_campaign_page import BanneredCampaignPageFactory
 from .campaign_page import CampaignIndexPageFactory
+from .petition import PetitionFactory
 
 
 class YoutubeRegretsPageFactory(PageFactory):
@@ -28,6 +32,25 @@ class YoutubeRegretsPageFactory(PageFactory):
     intro_images = Faker("streamfield", fields=["basic_image"] * 10)
     faq = Faker("streamfield", fields=["paragraph"])
     regret_stories = Faker("streamfield", fields=["regret_story"] * 28)
+
+
+class AppInstallPageFactory(PageFactory):
+    class Meta:
+        model = AppInstallPage
+        exclude = (
+            "title_text",
+            "header_text",
+            "header",
+        )
+
+    title = "Regrets Reporter Page"
+    slug = "regretsreporter"
+    hero_heading = Faker("text", max_nb_chars=50)
+    hero_subheading = Faker("text", max_nb_chars=50)
+    hero_background = SubFactory(image_factory.ImageFactory)
+    hero_video = Faker("url")
+    cta = SubFactory(PetitionFactory)
+    body = Faker("streamfield", fields=["header", "paragraph", "image", "spacer", "image_text", "quote"])
 
 
 class YoutubeRegrets2021PageFactory(PageFactory):
@@ -108,4 +131,29 @@ def generate(seed):
         )
         YoutubeRegrets2021PageFactory.create(parent=youtube_regrets)
         YoutubeRegrets2022PageFactory.create(parent=youtube_regrets)
+    reseed(seed)
+
+    # App Install Page
+    # Checking for a bannered campaign page titled "Youtube Regrets", and then creating the landing page if
+    # it does not exist.
+    try:
+        youtube_bannered_campaign_page = WagtailPage.objects.child_of(home_page).get(title=title)
+        print("Youtube Regrets Bannered Campaign Page exists")
+        # If extension landing page does not exist, create it.
+        if not WagtailPage.objects.child_of(youtube_bannered_campaign_page).type(AppInstallPage):
+            print("Generating App Install Page")
+            AppInstallPageFactory.create(parent=youtube_bannered_campaign_page)
+
+    # If bannered "YouTube Regrets" campaign page does not exist, create it and the extension landing page.
+    except WagtailPage.DoesNotExist:
+        print("Generating a Youtube Bannered Campaign Page and App Install Page")
+        youtube_bannered_campaign_page = BanneredCampaignPageFactory.create(
+            parent=home_page,
+            title="YouTube Regrets",
+            slug="youtube",
+            show_in_menus=False,
+            live=True,
+        )
+        AppInstallPageFactory.create(parent=youtube_bannered_campaign_page)
+
     reseed(seed)

--- a/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
+++ b/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
@@ -1,9 +1,8 @@
-from factory import Faker, SubFactory
+from factory import Faker
 from wagtail.models import Page as WagtailPage
 from wagtail_factories import PageFactory
 
 from networkapi.utility.faker.helpers import get_homepage, reseed
-from networkapi.wagtailpages.factory import image_factory
 from networkapi.wagtailpages.models import (
     AppInstallPage,
     YoutubeRegrets2021Page,
@@ -12,9 +11,9 @@ from networkapi.wagtailpages.models import (
     YoutubeRegretsReporterPage,
 )
 
+from .app_install_page import AppInstallPageFactory
 from .bannered_campaign_page import BanneredCampaignPageFactory
 from .campaign_page import CampaignIndexPageFactory
-from .petition import PetitionFactory
 
 
 class YoutubeRegretsPageFactory(PageFactory):
@@ -32,25 +31,6 @@ class YoutubeRegretsPageFactory(PageFactory):
     intro_images = Faker("streamfield", fields=["basic_image"] * 10)
     faq = Faker("streamfield", fields=["paragraph"])
     regret_stories = Faker("streamfield", fields=["regret_story"] * 28)
-
-
-class AppInstallPageFactory(PageFactory):
-    class Meta:
-        model = AppInstallPage
-        exclude = (
-            "title_text",
-            "header_text",
-            "header",
-        )
-
-    title = "Regrets Reporter Page"
-    slug = "regretsreporter"
-    hero_heading = Faker("text", max_nb_chars=50)
-    hero_subheading = Faker("text", max_nb_chars=50)
-    hero_background = SubFactory(image_factory.ImageFactory)
-    download_buttons = Faker("streamfield", fields=["app_install_download_button"] * 2)
-    cta = SubFactory(PetitionFactory)
-    body = Faker("streamfield", fields=["header", "paragraph", "image", "spacer", "image_text", "quote"])
 
 
 class YoutubeRegrets2021PageFactory(PageFactory):

--- a/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
+++ b/network-api/networkapi/wagtailpages/factory/youtube_regrets_page.py
@@ -112,28 +112,3 @@ def generate(seed):
         YoutubeRegrets2021PageFactory.create(parent=youtube_regrets)
         YoutubeRegrets2022PageFactory.create(parent=youtube_regrets)
     reseed(seed)
-
-    # App Install Page
-    # Checking for a bannered campaign page titled "Youtube Regrets", and then creating the landing page if
-    # it does not exist.
-    try:
-        youtube_bannered_campaign_page = WagtailPage.objects.child_of(home_page).get(title=title)
-        print("Youtube Regrets Bannered Campaign Page exists")
-        # If extension landing page does not exist, create it.
-        if not WagtailPage.objects.child_of(youtube_bannered_campaign_page).type(AppInstallPage):
-            print("Generating App Install Page")
-            AppInstallPageFactory.create(parent=youtube_bannered_campaign_page)
-
-    # If bannered "YouTube Regrets" campaign page does not exist, create it and the extension landing page.
-    except WagtailPage.DoesNotExist:
-        print("Generating a Youtube Bannered Campaign Page and App Install Page")
-        youtube_bannered_campaign_page = BanneredCampaignPageFactory.create(
-            parent=home_page,
-            title="YouTube Regrets",
-            slug="youtube",
-            show_in_menus=False,
-            live=True,
-        )
-        AppInstallPageFactory.create(parent=youtube_bannered_campaign_page)
-
-    reseed(seed)


### PR DESCRIPTION
# Description

The code below introduces a Factory for the `AppInstallPage`, serving as a replacement for the `YoutubeRegretsReporterExtensionPage`, which was removed in a previous pull request -> #12573 

The following fields were populated with fake data:
- title
- slug
- hero_heading
- hero_subheading
- hero_background
- download_buttons
- cta
- body

For further details, please refer to the code.

## Test

[This the link](https://foundation-s-feature-12-cislwu.herokuapp.com/en/youtube/regretsreporter/) that you can visit to review the AppInstallPage that was created with the Factory

![image](https://github.com/MozillaFoundation/foundation.mozilla.org/assets/169944061/18d7d23a-fdc2-4e07-9f92-60c516f46575)

Link to sample test page: https://foundation-s-feature-12-cislwu.herokuapp.com/en/youtube/regretsreporter/
Related PRs/issues: #12218 

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [x] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-912)
