### PR TITLE
Update homepage `News you can use` featured content width

### DIFF
--- a/source/sass/views/home.scss
+++ b/source/sass/views/home.scss
@@ -174,7 +174,7 @@
       .feature-content {
         $border-thickness: 4px;
 
-        width: 50%;
+        width: 40%;
         @apply tw-p-20;
         margin: 10px 0;
         background: $white;


### PR DESCRIPTION
# Description

This PR fixes the width of the featured content inside the homepage section `News you can use` so that it doesn't overlap with the background featured image.

Current state:
![image](https://github.com/user-attachments/assets/6cfea820-eab4-4e56-8d4f-c30fab63618d)

Fixed state:
![image](https://github.com/user-attachments/assets/ed8d51e2-b88a-435a-847a-eeb0b4187486)

Link to sample test page: https://foundation-s-tp1-929-ho-tfnll2.herokuapp.com/en/
Related PRs/issues: #12597

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-998)
