### PR TITLE
Fix blog entries block error for certain locales

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/customblocks/recent_blog_entries.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/customblocks/recent_blog_entries.py
@@ -60,7 +60,7 @@ class RecentBlogEntries(blocks.StructBlock):
 
         BlogIndexPage = apps.get_model("wagtailpages.BlogIndexPage")
         locale = get_locale_from_request(context["request"])
-        blog_page = BlogIndexPage.objects.get(title__iexact="blog", locale=locale)
+        blog_page = BlogIndexPage.objects.filter(locale=locale).live().first()
 
         tag = value.get("tag_filter", False)
         topic = value.get("topic_filter", False)


### PR DESCRIPTION
# Description

This PR updates a blog index query, removing the hard-coded title match in the `recent_blog_entries` block since the title was not `blog` in some translations

Link to sample test page: https://foundation-s-tp1-145-10-ewxwcs.mofostaging.net/sw/common-voice/blog/
Related PRs/issues: TP1-145 / #10343

# To Test

1) View the [production site](https://foundation.mozilla.org/sw/common-voice/blog/) and note the internal error.
2) View the [review app](https://foundation-s-tp1-145-10-ewxwcs.mofostaging.net/sw/common-voice/blog/) and note the page loads without error.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1010)
