### PR TITLE
Fix CampaignIndexPage Preview Panel Bug

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/campaign_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaign_index.py
@@ -71,7 +71,9 @@ class CampaignIndexPage(IndexPage):
         and returns them as their specific page instances.
         """
         relations = self.featured_campaign_pages.all().order_by("sort_order")
-        featured_pages = [relation.featured_page.specific for relation in relations if hasattr(relation.featured_page, 'specific')]
+        featured_pages = [
+            relation.featured_page.specific for relation in relations if hasattr(relation.featured_page, "specific")
+        ]
         return featured_pages
 
     def get_context(self, request):

--- a/network-api/networkapi/wagtailpages/pagemodels/campaign_index.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaign_index.py
@@ -71,7 +71,7 @@ class CampaignIndexPage(IndexPage):
         and returns them as their specific page instances.
         """
         relations = self.featured_campaign_pages.all().order_by("sort_order")
-        featured_pages = [relation.featured_page.specific for relation in relations]
+        featured_pages = [relation.featured_page.specific for relation in relations if hasattr(relation.featured_page, 'specific')]
         return featured_pages
 
     def get_context(self, request):


### PR DESCRIPTION
# Description

This PR addresses a problem with the preview panel on the `CampaignIndexPage` by ensuring it only renders a preview for pages that have been selected.

Related PRs/issues: TP1-540 #12226

# To Test

## Recreating the issue
1) Checkout `main` branch and login to the admin dashboard
2) Navigate to the campaign index page (http://localhost:8000/en/campaigns/) and edit the page
3) Toggle open the wagtai live preview panel
4) Click the action to "Add featured pages"
5) Note the preview panel errors out.

## Testing the bugfix
1) Checkout this branch to your local and login to the admin dashboard
2) Repeat steps 2-5 above and note there is no longer an error.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1035)
