### PR TITLE
Revert "Remove wagtail utility routes for authentication"

### DIFF
--- a/network-api/networkapi/utility/watail_core_url_override.py
+++ b/network-api/networkapi/utility/watail_core_url_override.py
@@ -2,7 +2,8 @@
 # TO ALLOW NON-SLUG URLS FROM MAKING IT INTO THE serve() FUNCTION
 
 from django.conf import settings
-from django.urls import re_path
+from django.contrib.auth import views as auth_views
+from django.urls import path, re_path
 from wagtail import views
 from wagtail.coreutils import WAGTAIL_APPEND_SLASH
 
@@ -28,6 +29,16 @@ WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(settings, "WAGTAIL_FRONTEND_LOGIN_TEMP
 
 
 urlpatterns = [
+    path(
+        "_util/authenticate_with_password/<int:page_view_restriction_id>/<int:page_id>/",
+        views.authenticate_with_password,
+        name="wagtailcore_authenticate_with_password",
+    ),
+    path(
+        "_util/login/",
+        auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),
+        name="wagtailcore_login",
+    ),
     # Front-end page views are handled through Wagtail's core.views.serve
     # mechanism
     re_path(serve_pattern, views.serve, name="wagtail_serve"),


### PR DESCRIPTION
Reverts MozillaFoundation/foundation.mozilla.org#12655 in order to enable password protection for wagtail pages and have the appropiate routes matching urls.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1078)
