### PR TITLE
PNI - Closing the search bar on mobile should also clear search

### DIFF
--- a/source/js/buyers-guide/template-js-handler/mobile-search-bar.js
+++ b/source/js/buyers-guide/template-js-handler/mobile-search-bar.js
@@ -17,6 +17,12 @@ export default () => {
     if (burger && burger.classList.contains("menu-open")) {
       document.querySelector(".burger").click();
     }
+
+    // if the search bar is open, clear the search bar
+    if (!searchContainer.classList.contains("tw-hidden")) {
+      searchContainer.querySelector(`.clear-icon`).click();
+    }
+
     searchContainer.classList.toggle("tw-hidden");
     mobileCatNav.classList.toggle("tw-hidden");
   });


### PR DESCRIPTION
# Description

Notice now closing the search bar clears the search and brings users back to the "all products" view.

https://github.com/user-attachments/assets/cdc73314-4779-4fc3-830e-d98750f5daf9



Link to sample test page: https://foundation-s-tp1-123-10-9w9yxw.herokuapp.com/en/privacynotincluded/
Related PRs/issues: #10120

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1084)
