### PR TITLE
Updated DonateHelpPage's "notice" to be synchronized across translations

### DIFF
--- a/network-api/networkapi/donate/pagemodels/help_page.py
+++ b/network-api/networkapi/donate/pagemodels/help_page.py
@@ -44,7 +44,7 @@ class DonateHelpPage(BaseDonationPage):
         SynchronizedField("search_image"),
         # Content tab fields
         TranslatableField("title"),
-        TranslatableField("notice"),
+        SynchronizedField("notice"),
         TranslatableField("body"),
     ]
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Related PRs/issues: https://mozilla-hub.atlassian.net/browse/TP1-1081

This PR updates the DonateHelpPage's "notice" to a `SynchronizedField`. 

Doing so will ensure that any changes to the notice will be synced across translations, fixing the issue mentioned in [TP1-1081](https://mozilla-hub.atlassian.net/browse/TP1-1081).

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1174)
