### PR TITLE
Updated CMS edit interface to include missing fields of Signup, Petition, and Callpower Snippets

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/campaigns.py
@@ -74,6 +74,8 @@ class CTABase(models.Model):
 
 
 class CTA(CTABase):
+    panels = CTABase.panels
+
     class Meta:
         ordering = ["-id"]
         verbose_name_plural = "CTA"
@@ -136,6 +138,16 @@ class Callpower(TranslatableMixin, CTA):
         index.FilterField("locale_id"),
     ]
 
+    panels = CTA.panels + [
+        FieldPanel("campaign_id"),
+        FieldPanel("call_button_label"),
+        FieldPanel("success_heading"),
+        FieldPanel("success_text"),
+        FieldPanel("share_twitter"),
+        FieldPanel("share_facebook"),
+        FieldPanel("share_email"),
+    ]
+
     class Meta(TranslatableMixin.Meta):
         ordering = ["name"]
         verbose_name = "Callpower"
@@ -164,6 +176,11 @@ class Signup(TranslatableMixin, CTA):
         index.SearchField("campaign_id", boost=2),
         index.FilterField("locale_id"),
         index.FilterField("ask_name"),
+    ]
+
+    panels = CTA.panels + [
+        FieldPanel("campaign_id"),
+        FieldPanel("ask_name"),
     ]
 
     class Meta(TranslatableMixin.Meta):
@@ -310,6 +327,17 @@ class Petition(TranslatableMixin, CTA):
         index.FilterField("show_country_field"),
         index.FilterField("show_postal_code_field"),
         index.FilterField("show_comment_field"),
+    ]
+
+    panels = CTA.panels + [
+        FieldPanel("campaign_id"),
+        FieldPanel("show_country_field"),
+        FieldPanel("show_postal_code_field"),
+        FieldPanel("show_comment_field"),
+        FieldPanel("share_twitter"),
+        FieldPanel("share_facebook"),
+        FieldPanel("share_email"),
+        FieldPanel("thank_you"),
     ]
 
     class Meta(TranslatableMixin.Meta):


### PR DESCRIPTION
# Description

Because of a regression bug introduced in a previous PR, a few fields were missing from `Signup`, `Petition`, and `Callpower` snippet's edit interface. This PR adds those fields back. I've attached screenshots of a older build below for comparison. Note that we have decided to move up `newsletter` field up before the header field (see context [here](https://github.com/MozillaFoundation/foundation.mozilla.org/pull/11398#pullrequestreview-1743206684)).

Related PRs/issues: #12823 

---

## Review App Creds

https://foundation-s-tp1-1172-1-h10kwk.herokuapp.com/cms/
Login: admin
Password: Oma^N7jw3!mz!ORG

## CTA Snippet
- review app: https://foundation-s-tp1-1172-1-h10kwk.herokuapp.com/cms/snippets/wagtailpages/cta/add/
- before regression: https://github.com/user-attachments/assets/7e46d540-2bb0-49c1-a0b6-67e2e6b30829


## Signup Snippet
- review app: https://foundation-s-tp1-1172-1-h10kwk.herokuapp.com/cms/snippets/wagtailpages/signup/add/?locale=en
- before regression: https://github.com/user-attachments/assets/00424850-fee6-4d0d-9ab8-7935deae853e


## Blog Signup Snippet
- review app: https://foundation-s-tp1-1172-1-h10kwk.herokuapp.com/cms/snippets/wagtailpages/blogsignup/add/?locale=en
- before regression: https://github.com/user-attachments/assets/dc671454-61c8-4c02-9248-63e4c8f59b50

## Petition Snippet
- review app: https://foundation-s-tp1-1172-1-h10kwk.herokuapp.com/cms/snippets/wagtailpages/petition/add/?locale=en
- before regression: https://github.com/user-attachments/assets/e8a6f400-2305-4d05-9675-58dce72371a9

## Callpower Snippet
- review app: https://foundation-s-tp1-1172-1-h10kwk.herokuapp.com/cms/snippets/wagtailpages/callpower/add/?locale=en
- before regression: https://github.com/user-attachments/assets/f9163ae7-9db6-4be4-9234-c4b42f5f6f7e

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1175)
