### PR TITLE
Primary heroguts template divided, heroguts homepage created

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/heroguts_homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/heroguts_homepage.html
@@ -1,0 +1,36 @@
+{% load wagtailcore_tags wagtailimages_tags static %}
+
+<div id="hero">
+    <div class="banner tw-bg-black">
+        {% with banner=page.specific.get_banner %}
+            {% if banner %}
+                <picture>
+                    <source media="(min-width: 1200px)" srcset="{% image_url banner "fill-4032x480" %}">
+                    <source media="(min-width: 992px)" srcset="{% image_url banner "fill-2400x480" %}">
+                    <source media="(min-width: 768px)" srcset="{% image_url banner "fill-1984x480" %}">
+                    <source media="(min-width: 576px)" srcset="{% image_url banner "fill-1536x390" %}">
+                    {# Fallback Image #}
+                    <img src="{% image_url banner "fill-1536x390" %}" alt="">
+                </picture>
+            {% else %}
+                <img src="{% static "_images/banner-black-white-marble.jpg" %}" alt="">
+            {% endif %}
+        {% endwith %}
+
+        <div class="container tw-dark banner-content">
+            <div class="row">
+                <div class="col-12 col-md-9 col-xl-8 mt-3 d-flex flex-column justify-content-end">
+                    <h1 class="tw-h1-heading">{{ page.hero_headline }}</h1>
+                    {% if page.show_hero_button and page.hero_button_text and page.hero_button_url %}
+                        <div>
+                            <a href="{{ page.hero_button_url }}" class="tw-btn-secondary text-wrap mt-3" id="homepage-hero-cta">{{ page.hero_button_text }}</a>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+    {% if singleton_page == True %}
+        {% include "partials/intro_and_content_divider.html" with wrapper_class="d-md-none" %}
+    {% endif %}
+</div>

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/primary_heroguts.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/primary_heroguts.html
@@ -4,58 +4,30 @@
     <div class="banner tw-bg-black">
         {% with banner=page.specific.get_banner %}
             {% if banner %}
-                {% if homepage %}
-                    <picture>
-                        <source media="(min-width: 1200px)" srcset="{% image_url banner "fill-4032x480" %}">
-                        <source media="(min-width: 992px)" srcset="{% image_url banner "fill-2400x480" %}">
-                        <source media="(min-width: 768px)" srcset="{% image_url banner "fill-1984x480" %}">
-                        <source media="(min-width: 576px)" srcset="{% image_url banner "fill-1536x390" %}">
-                        {# Fallback Image #}
-                        <img src="{% image_url banner "fill-1536x390" %}" alt="">
-                    </picture>
-                {% else %}
-                    <picture>
-                        <source media="(min-width: 1200px)" srcset="{% image_url banner "fill-4032x1152" %}">
-                        <source media="(min-width: 992px)" srcset="{% image_url banner "fill-2400x686" %}">
-                        <source media="(min-width: 768px)" srcset="{% image_url banner "fill-1984x567" %}">
-                        <source media="(min-width: 576px)" srcset="{% image_url banner "fill-1536x439" %}">
-                        {# Fallback Image #}
-                        <img src="{% image_url banner "fill-1536x439" %}" alt="">
-                    </picture>
-                {% endif %}
+                <picture>
+                    <source media="(min-width: 1200px)" srcset="{% image_url banner "fill-4032x1152" %}">
+                    <source media="(min-width: 992px)" srcset="{% image_url banner "fill-2400x686" %}">
+                    <source media="(min-width: 768px)" srcset="{% image_url banner "fill-1984x567" %}">
+                    <source media="(min-width: 576px)" srcset="{% image_url banner "fill-1536x439" %}">
+                    {# Fallback Image #}
+                    <img src="{% image_url banner "fill-1536x439" %}" alt="">
+                </picture>
             {% else %}
                 <img src="{% static "_images/banner-black-white-marble.jpg" %}" alt="">
             {% endif %}
         {% endwith %}
-
-        {% if homepage %}
-            <div class="container tw-dark banner-content">
-                <div class="row">
-                    <div class="col-12 col-md-9 col-xl-8 mt-3 d-flex flex-column justify-content-end">
-                        <h1 class="tw-h1-heading">{{ page.hero_headline }}</h1>
-                        {% if page.show_hero_button and page.hero_button_text and page.hero_button_url %}
-                            <div>
-                                <a href="{{ page.hero_button_url }}" class="tw-btn-secondary text-wrap mt-3" id="homepage-hero-cta">{{ page.hero_button_text }}</a>
-                            </div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        {% endif %}
     </div>
 
-    {% if not homepage %}
-        <div class="container">
-            <div class="row cutout-wrapper-row">
-                <div class="cutout col-12 col-lg-8 pt-4">
-                    <h1 class="tw-h1-heading mb-0">{% if root.title %}{{ root.title }}{% elif page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}</h1>
-                    {% if page.intro %}
-                        <p class="tw-body-large mt-3 mb-0">{{ page.intro }}</p>
-                    {% endif %}
-                </div>
+    <div class="container">
+        <div class="row cutout-wrapper-row">
+            <div class="cutout col-12 col-lg-8 pt-4">
+                <h1 class="tw-h1-heading mb-0">{% if root.title %}{{ root.title }}{% elif page.header %}{{ page.header }}{% else %}{{ page.title }}{% endif %}</h1>
+                {% if page.intro %}
+                    <p class="tw-body-large mt-3 mb-0">{{ page.intro }}</p>
+                {% endif %}
             </div>
         </div>
-    {% endif %}
+    </div>
 
     {% if singleton_page == True %}
         {% include "partials/intro_and_content_divider.html" with wrapper_class="d-md-none" %}

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/homepage.html
@@ -24,7 +24,7 @@
 
 
 {% block hero_guts %}
-    {% include "./fragments/primary_heroguts.html" with root=root page=page homepage=True %}
+    {% include "./fragments/heroguts_homepage.html" with root=root page=page homepage=True %}
 {% endblock %}
 
 


### PR DESCRIPTION
# Description

This PR divides `primary_heroguts.html` into two use cases, where the previous "if statements" found together in the current version are separated accordingly. So `heroguts_homepage.html` was created to isolate HTML related to `homepage.html` and `primary_heroguts.html` left for `primary_page.html` and `bannered_campaign_page.html`

Link to sample test page: 
Related PRs/issues: https://github.com/MozillaFoundation/foundation.mozilla.org/issues/9605

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
