### PR TITLE
First draft for StreamFieldFactory

### DIFF
--- a/network-api/networkapi/wagtailpages/factory/blog.py
+++ b/network-api/networkapi/wagtailpages/factory/blog.py
@@ -1,11 +1,15 @@
 from datetime import timezone
 from random import choice
 
+import factory
 from django.conf import settings
 from factory import Faker, LazyAttribute, SubFactory
 from factory.django import DjangoModelFactory
 from wagtail.models import Page as WagtailPage
-from wagtail_factories import PageFactory
+from wagtail_factories import PageFactory, StreamFieldFactory
+from networkapi.wagtailpages.factory.signup import BlogSignupFactory
+from networkapi.wagtailpages.factory.image_factory import ImageFactory
+
 
 from networkapi.utility.faker.helpers import get_homepage, get_random_objects, reseed
 from networkapi.wagtailpages.models import (
@@ -23,18 +27,6 @@ from .tagging import add_tags
 
 RANDOM_SEED = settings.RANDOM_SEED
 TESTING = settings.TESTING
-blog_body_streamfield_fields = [
-    "paragraph",
-    "blog_newsletter_signup",
-    "paragraph",
-    "image",
-    "image_text",
-    "image_text_mini",
-    "video",
-    "linkbutton",
-    "spacer",
-    "quote",
-]
 
 
 def add_topic(post):
@@ -87,7 +79,18 @@ class BlogPageFactory(PageFactory):
         exclude = ("title_text",)
 
     title = LazyAttribute(lambda o: o.title_text.rstrip("."))
-    body = Faker("streamfield", fields=blog_body_streamfield_fields)
+    body = StreamFieldFactory([
+        ("paragraph", Faker('sentence')),
+        ("blog_newsletter_signup", factory.SubFactory(BlogSignupFactory)),
+        ("image", factory.SubFactory(ImageFactory)),
+        ("image_text", factory.SubFactory(ImageFactory)),
+        ("image_text_mini", factory.SubFactory(ImageFactory)),
+        ("video", factory.Faker('url')),
+        ("linkbutton", factory.Faker('url')),
+        ("spacer", Faker('text')),
+        ("quote", Faker('sentence')),
+    ])
+
     first_published_at = (
         Faker("date_time", tzinfo=timezone.utc)
         if RANDOM_SEED and not TESTING


### PR DESCRIPTION
# Description

This PR refactors `BlogPageFactory` body, with wagtail-compatible structure, implementing `StreamFieldFactory` instead of a custom non-waigatil compatible field "streamfield", also intriducing `factory.SubFactory` inside of the model in order to replicate the complex fields that Faker cannot generate automatically.

# How to test


Link to sample test page: https://github.com/MozillaFoundation/foundation.mozilla.org/issues/11129
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
