### PR TITLE
Restore of previous GTM ID

### DIFF
--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -9,14 +9,14 @@
 
 {% block ga_identifier %}
     <meta name="google-site-verification" content="xuTYNuCtTC9SLIkAUtmUY9Wce5RDJofc4z4fMprPYUk" />
-    <!-- The current GTM ID replaced an unkown GTM container with no clear access -->
-    <meta name="gtm-identifier" content="GTM-PQQ8H6PM">
+    <meta name="ga-identifier" content="UA-87658599-15">
+    <meta name="gtm-identifier" content="GTM-5TFTDCX">
     <script nonce="{{ request.csp_nonce }}">window.dataLayer = window.dataLayer || [];</script>
     <script nonce="{{ request.csp_nonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                                                   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-PQQ8H6PM');</script>
+    })(window,document,'script','dataLayer','GTM-5TFTDCX');</script>
 {% endblock %}
 
 

--- a/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
+++ b/network-api/networkapi/mozfest/templates/mozfest/mozfest-base.html
@@ -10,6 +10,7 @@
 {% block ga_identifier %}
     <meta name="google-site-verification" content="xuTYNuCtTC9SLIkAUtmUY9Wce5RDJofc4z4fMprPYUk" />
     <meta name="ga-identifier" content="UA-87658599-15">
+    <!-- This GTM ID belongs to a Mozilla Festival container that is different from Mozilla Foundation GTM -->
     <meta name="gtm-identifier" content="GTM-5TFTDCX">
     <script nonce="{{ request.csp_nonce }}">window.dataLayer = window.dataLayer || [];</script>
     <script nonce="{{ request.csp_nonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
# Description

This PR is a hotfix for restoring the GTM ID previously removed from MozFest and MoFo due to unknown credentials to access it. Due to this change, metrics from MozFest were mixed unintentionally into MoFo, so with this changes the previous ID is set back into MozFest in order to have data properly separated.

Link to sample test page: https://foundation-s-hotfix-res-qdb5hi.herokuapp.com/en/
Related PRs/issues: https://github.com/MozillaFoundation/foundation.mozilla.org/pull/12744

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1257)
