### PR TITLE
Remove localized from custom_hero_guts template

### DIFF
--- a/network-api/networkapi/templates/fragments/custom_hero_guts.html
+++ b/network-api/networkapi/templates/fragments/custom_hero_guts.html
@@ -10,7 +10,7 @@
     {% if is_publication_article or is_publication_page %}
         <div class="mb-2 body-small publication-breadcrumb">
             {% for entry in self.breadcrumb_list %}
-                {% with parent_page=entry.localized %}
+                {% with parent_page=entry %}
                     <a href="{{ parent_page.url }}" class="body-small {% if page.hero_text_color == page.HERO_TEXT_COLOR_DARK %} tw-text-black {% endif %}">{{ parent_page.title }}</a>
                     <span class='body-small {% if page.hero_text_color == page.HERO_TEXT_COLOR_LIGHT %} tw-text-gray-20 {% endif %}' > › </span>
                 {% endwith %}


### PR DESCRIPTION
# Description

This PR removes .localized from custom_hero_guts.html template, reducing the number of .localized attributes in the codebase, and still keeping the entry in `self.breadcrumb_list` translated and displayed properly.

Link to sample test page: 
Related PRs/issues: https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10008

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
