### PR TITLE
Updated HomePage's `hero_intro_link` field to be a translatable field

### DIFF
--- a/network-api/networkapi/utility/faker/streamfield_provider.py
+++ b/network-api/networkapi/utility/faker/streamfield_provider.py
@@ -750,6 +750,12 @@ def generate_homepage_hero_intro_link():
         "external_url": fake.url(schemes=["https"]),
         "label": " ".join(fake.words(nb=3)),
         "new_window": True,
+        "page": None,
+        "relative_url": "",
+        "anchor": "",
+        "email": "",
+        "file": None,
+        "phone": "",
     }
 
     return generate_field("link", link_value)

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -961,7 +961,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
         SynchronizedField("hero_button_url"),
         TranslatableField("hero_intro_heading"),
         TranslatableField("hero_intro_body"),
-        SynchronizedField("hero_intro_link"),
+        TranslatableField("hero_intro_link"),
         TranslatableField("ideas_title"),
         SynchronizedField("ideas_image"),
         TranslatableField("ideas_headline"),


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page: [English Homepage](https://foundation-s-tp1313-tra-dhkfkz.herokuapp.com/en/), [French Homepage](https://foundation-s-tp1313-tra-dhkfkz.herokuapp.com/fr/)
Related PRs/issues: [TP1-1313](https://mozilla-hub.atlassian.net/browse/TP1-1313)

This PR updates the `HomePage` models `hero_intro_link` field from a `SynchronizedField` to a `TranslatableField`, allowing the link's `label` field to be translated.

# Screenshots

## CMS (English):
![Screenshot 2024-10-01 at 16-45-04 Editing Homepage Homepage - Wagtail](https://github.com/user-attachments/assets/35bfc876-26ec-4764-956e-a2f8ae883774)


## CMS (Translate page):
![Screenshot 2024-10-01 at 16-42-53 Translation of Homepage into French - Wagtail](https://github.com/user-attachments/assets/45c4cdc2-937b-4c08-95f3-cfcd4bc98af5)


## Homepage (/en/):
<img width="1691" alt="Screenshot 2024-10-01 at 4 41 38 PM" src="https://github.com/user-attachments/assets/d868c0e3-1577-491b-bafe-f34548e20396">


## Homepage (/fr/):
<img width="1691" alt="Screenshot 2024-10-01 at 4 41 56 PM" src="https://github.com/user-attachments/assets/c6b3c7f0-b91f-4790-b48b-da5aa524475f">

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1329)
