### PR TITLE
Remove `donate/base.html`'s primary_nav override

### DIFF
--- a/network-api/networkapi/templates/donate/pages/base.html
+++ b/network-api/networkapi/templates/donate/pages/base.html
@@ -36,10 +36,6 @@
 
 {% block sticky_top_class %} tw-sticky tw-z-[1020] tw-top-0 {% endblock %}
 
-{% block primary_nav %}
-    {% include "fragments/primary_nav.html" %}
-{% endblock %}
-
 {% block header_wrapped %}
 {% endblock %}
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues: [TP1-1221](https://mozilla-hub.atlassian.net/browse/TP1-1221)

This PR removes the `primary_nav` block override from the Donate page base template. Previously, the template included a custom `primary_nav` block that rendered the old nav template `fragments/primary_nav.html.` By removing this override, the template will now use the "new nav" (the one used on the rest of the foundation site) as defined in the extended `pages/base.html` template.

# Screenshots

## Before:
<img width="1917" alt="Screenshot 2024-10-01 at 5 11 51 PM" src="https://github.com/user-attachments/assets/946111ce-210f-42f8-a812-67b6dedbf71e">

## After:
<img width="1917" alt="Screenshot 2024-10-01 at 5 10 37 PM" src="https://github.com/user-attachments/assets/88624223-1433-4436-aa92-894e4fdae665">

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1330)
