### PR TITLE
Map ai_is_untrustworthy "yes" and "no" values to "CD"

### DIFF
--- a/network-api/networkapi/wagtailpages/fields.py
+++ b/network-api/networkapi/wagtailpages/fields.py
@@ -38,6 +38,10 @@ class ExtendedYesNoField(models.CharField):
     description = "Yes, No, Not Applicable, or Can’t Determine"
 
     choice_list = [
+        ("Good", "Good"),
+        ("AV", "Average"),
+        ("NI", "Needs Improvement"),
+        ("Bad", "Bad"),
         ("Yes", "Yes"),
         ("No", "No"),
         ("NA", "Not Applicable"),
@@ -49,7 +53,7 @@ class ExtendedYesNoField(models.CharField):
     def __init__(self, *args, **kwargs):
         kwargs["choices"] = self.choice_list
         kwargs["default"] = self.default_choice
-        kwargs["max_length"] = 3
+        kwargs["max_length"] = 4
         super().__init__(*args, **kwargs)
 
     def deconstruct(self):

--- a/network-api/networkapi/wagtailpages/fields.py
+++ b/network-api/networkapi/wagtailpages/fields.py
@@ -39,7 +39,7 @@ class ExtendedYesNoField(models.CharField):
 
     choice_list = [
         ("Good", "Good"),
-        ("AV", "Average"),
+        ("AVG", "Average"),
         ("NI", "Needs Improvement"),
         ("Bad", "Bad"),
         ("NA", "Not Applicable"),

--- a/network-api/networkapi/wagtailpages/fields.py
+++ b/network-api/networkapi/wagtailpages/fields.py
@@ -42,8 +42,6 @@ class ExtendedYesNoField(models.CharField):
         ("AV", "Average"),
         ("NI", "Needs Improvement"),
         ("Bad", "Bad"),
-        ("Yes", "Yes"),
-        ("No", "No"),
         ("NA", "Not Applicable"),
         ("CD", "Can’t Determine"),
     ]

--- a/network-api/networkapi/wagtailpages/migrations/0167_map_generalproductpage_yesno_to_cd.py
+++ b/network-api/networkapi/wagtailpages/migrations/0167_map_generalproductpage_yesno_to_cd.py
@@ -1,0 +1,26 @@
+
+from django.db import migrations
+
+def map_yes_no_to_cant_determine(apps, schema_editor):
+    GeneralProductPage = apps.get_model('wagtailpages', 'GeneralProductPage')
+
+    # Filter all instances where 'ai_is_untrustworthy' is 'Yes' or 'No'
+    pages_to_update = GeneralProductPage.objects.filter(ai_is_untrustworthy__in=['Yes', 'No'])
+    
+    # Iterate over the pages and update them
+    for page in pages_to_update:
+        print(f"Product '{page.title}' with ID {page.id} has 'ai_is_untrustworthy' set as '{page.ai_is_untrustworthy}'. Updating to 'CD'.")
+        page.ai_is_untrustworthy = 'CD'
+        page.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailpages", "0166_homepagehighlights_replace_homepagenewsyoucanuse"),
+    ]
+
+    operations = [
+        migrations.RunPython(map_yes_no_to_cant_determine),
+    ]
+


### PR DESCRIPTION
# Description

This PR updates the `ai_is_untrustworthy` field on the `GeneralProductPage`, mapping any values of "Yes" or "No" to "Can't Determine" (CD) through a custom migration operation. 

Additionally, new options ("Good," "Average," "Needs Improvement," and "Bad") have been added to the `ExtendedYesNoField`, and the "Yes"/"No" options have been removed.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1336)
