### PR TITLE
Move wagtail user bar to `bottom-right` section

### DIFF
--- a/network-api/networkapi/templates/pages/base.html
+++ b/network-api/networkapi/templates/pages/base.html
@@ -100,7 +100,7 @@
     </head>
     <body class="{% block bodyclass %}{% endblock %}" id="view-{% block body_id %}{% endblock %}">
         {% if user.is_authenticated %}
-            {% wagtailuserbar 'bottom-left' %}
+            {% wagtailuserbar 'bottom-right' %}
         {% endif %}
 
         {% if page.live == False %}

--- a/source/sass/onetrust-override.scss
+++ b/source/sass/onetrust-override.scss
@@ -154,7 +154,7 @@ $font-family-serif: "Zilla Slab", serif;
       }
     }
     .ot-floating-button__front {
-      background-color: rgba(0,0,0,0);
+      background-color: rgba(0, 0, 0, 0);
     }
   }
 

--- a/source/sass/onetrust-override.scss
+++ b/source/sass/onetrust-override.scss
@@ -153,6 +153,9 @@ $font-family-serif: "Zilla Slab", serif;
         margin: 0 auto;
       }
     }
+    .ot-floating-button__front {
+      background-color: rgba(0,0,0,0);
+    }
   }
 
   /* Desktop Layout Changes */


### PR DESCRIPTION
# Description

This PR attempts to solve the overlapping of the cookie banner button and the wagtail user bar for authenticated users by repositioning the wagtail user bar button in the bottom right section of the page. It also fixes the pixelated outline shown in the OneTrust cookie banner button.

## Current state

<img width="430" alt="image" src="https://github.com/user-attachments/assets/65530386-8514-4adc-9b78-be5ef2e51010">

*Mobile view*

## Updated state
<img width="429" alt="image" src="https://github.com/user-attachments/assets/e6e3a433-c5c4-40af-8eb7-4b2cfcbf8159">

*Mobile view*

Link to sample test page: https://foundation-s-tp1-1260-w-6ybuw5.herokuapp.com/en/
Related PRs/issues: #

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1348)
