### PR TITLE
Remove localized from cause_statement template

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -986,7 +986,6 @@ class Homepage(FoundationMetadataPageMixin, Page):
         TranslatableField("highlights_title"),
     ]
 
-
     subpage_types = [
         "AppInstallPage",
         "BanneredCampaignPage",

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -945,7 +945,6 @@ class Homepage(FoundationMetadataPageMixin, Page):
             classname="collapsible collapsed",
         ),
     ]
-
     translatable_fields = [
         # Promote tab fields
         SynchronizedField("slug"),
@@ -965,6 +964,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
         TranslatableField("ideas_title"),
         SynchronizedField("ideas_image"),
         TranslatableField("ideas_headline"),
+        SynchronizedField("show_cause_statement"),
         TranslatableField("cause_statement"),
         TranslatableField("cause_statement_link_text"),
         TranslatableField("cause_statement_link_page"),
@@ -985,6 +985,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
         TranslatableField("highlights"),
         TranslatableField("highlights_title"),
     ]
+
 
     subpage_types = [
         "AppInstallPage",

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -945,6 +945,7 @@ class Homepage(FoundationMetadataPageMixin, Page):
             classname="collapsible collapsed",
         ),
     ]
+
     translatable_fields = [
         # Promote tab fields
         SynchronizedField("slug"),

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/cause_statement.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/cause_statement.html
@@ -3,7 +3,7 @@
         <div class="section-cause-statement tw-dark p-5 text-center">
             <p class="tw-h4-heading">{{ page.cause_statement }}</p>
             {% if page.cause_statement_link_text and page.cause_statement_link_page %}
-                <a href="{{ page.cause_statement_link_page.localized.url }}" class="tw-cta-link" id="homepage-cause-statement-cta">{{ page.cause_statement_link_text }}</a>
+                <a href="{{ page.cause_statement_link_page.url }}" class="tw-cta-link" id="homepage-cause-statement-cta">{{ page.cause_statement_link_text }}</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
# Description
This PR removes localization from `cause_statement_link_page.url` within the `cause_statement.html` template, preserving the content structure as it was, while ensuring proper translation. Additionally, this PR introduces `show_cause_statement` as a `SynchronizedField` to address translation inconsistencies.

Link to sample test page: https://foundation-s-tp1-106-re-kwkigd.herokuapp.com/en/
Related PRs/issues: https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10013

# Example
![image](https://github.com/user-attachments/assets/834e86a5-84c4-4a8e-91a3-a21b0e8fa77c)
![image](https://github.com/user-attachments/assets/20ea90e1-952c-45c6-87db-0fc9b1d449ff)




# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1351)
