### PR TITLE
Remove localized from partner html template and moved to get_context

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -1013,4 +1013,5 @@ class Homepage(FoundationMetadataPageMixin, Page):
         context["MEDIA_URL"] = settings.MEDIA_URL
         context["menu_root"] = self
         context["menu_items"] = self.get_children().live().in_menu()
+        context["localized_partner_page"] = self.partner_page.localized
         return context

--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/fragments/partner.html
@@ -11,7 +11,7 @@
                         {{ page.partner_intro_text }}
                     </p>
                 {% endif %}
-                <a href="{{ page.partner_page.localized.url }}" class="text-white tw-cta-link font-weight-bold" id="partner-cta">
+                <a href="{{ localized_partner_page.url }}" class="text-white tw-cta-link font-weight-bold" id="partner-cta">
                     {{ page.partner_page_text }}
                 </a>
             </div>


### PR DESCRIPTION
# Description
This PR removed `.localized` attribute  from `partner.html` template as part of the `localize` cleanup. This also moves the logic to page's `get_context` function `context["localized_partner_page"]` returning a localized version.

Link to sample test page:
Related PRs/issues: https://github.com/MozillaFoundation/foundation.mozilla.org/issues/10011
# How to test
- You can scroll down to the partner section.
- Click on the link "Let's work together" and make sure the locale is kept.

See images below.
![image](https://github.com/user-attachments/assets/af266933-7e7b-45a6-8598-9387777afb7f)
![image](https://github.com/user-attachments/assets/a5b6c593-14e3-4927-a01e-509e0601255e)

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
