### PR TITLE
PNI - homepage header text should not say 'None'

### DIFF
--- a/source/js/buyers-guide/search/utils.js
+++ b/source/js/buyers-guide/search/utils.js
@@ -38,7 +38,8 @@ export class Utils {
   static updateHeader(category, parent) {
     const datasetName =
       parent || (category === "None" ? ALL_CATEGORY_LABEL : category);
-    const headerText = parent || category;
+    const headerText =
+      category === "None" ? ALL_CATEGORY_LABEL : parent || category;
 
     this.setCategoryHeader(datasetName, headerText);
   }


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues: #12993

## To test

### Part 1

- Go to https://foundation-s-tp1-1383-1-34196q.herokuapp.com/privacynotincluded
- Click on “All Reviews” on the category nav
- The header should say “All Reviews” and not "None"

<img width="566" alt="image" src="https://github.com/user-attachments/assets/c81029ab-3432-495c-9fc6-b83bd6ff26d8">

### Part 2

- Make sure clicking on other category will change the header to the name of category.  (e.g., `Health & Exercise`)
<img width="629" alt="image" src="https://github.com/user-attachments/assets/e98f46a2-2a17-4592-b6eb-f563cb7ff0a4">
