### PR TITLE
added hotfix for donatebanner not being localized when no AB test is active

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -52,7 +52,7 @@ class BasePage(FoundationMetadataPageMixin, FoundationNavigationPageMixin, Page)
 
         # If there's no A/B test found or DNT is enabled, return the page's donate_banner field as usual.
         if not active_ab_test or dnt_enabled:
-            return donate_banner_page.donate_banner
+            return donate_banner_page.donate_banner.localized
 
         # Check for the cookie related to this A/B test.
         # In wagtail-ab-testing, the cookie name follows the format:


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
Related PRs/issues: https://mozilla-hub.atlassian.net/browse/TP1-1514


This PR updates the get_donate_banner() method to return a localized version of the donate banner, even when a test is **not** running. 

