### PR TITLE
Minor donate banner updates

### DIFF
--- a/network-api/networkapi/donate_banner/models.py
+++ b/network-api/networkapi/donate_banner/models.py
@@ -106,7 +106,7 @@ class DonateBanner(TranslatableMixin, PreviewableMixin, models.Model):
     )
 
     panels = [
-        HelpPanel(content="To enable banner on site, go to Settings > Donate Banner."),
+        HelpPanel(content="To enable banner on site, visit the DonateBannerPage that is a child of the Homepage."),
         FieldPanel("name"),
         FieldPanel("title"),
         FieldPanel("subtitle"),

--- a/network-api/networkapi/templates/fragments/donate_banner.html
+++ b/network-api/networkapi/templates/fragments/donate_banner.html
@@ -5,7 +5,12 @@
 {% endif %}
 {% with btn_class="tw-btn-pop tw-py-7 tw-px-16 tw-text-white tw-border-black tw-shadow-black tw-shadow-[6px_6px] tw-w-full small:tw-w-[300px] tw-text-[20px] small:tw-text-[24px] !tw-leading-[1]" %}
 
-    <div data-banner-id="{{ banner.id }}" data-banner-title="{{ banner.title }}" class="donate-banner {{ banner.background_color }} tw-py-8 tw-pb-12 medium:tw-py-16 medium:tw-pb-20 tw-relative tw-z-20 tw-w-full tw-hidden print:tw-hidden"
+    <div data-banner-id="{{ banner.id }}"
+         data-banner-title="{{ banner.title }}"
+         data-banner-name="{{ banner.name }}"
+         data-banner-variant-version="{{ banner.variant_version }}"
+         data-banner-active-ab-test="{{ banner.active_ab_test }}"
+         class="donate-banner {{ banner.background_color }} tw-py-8 tw-pb-12 medium:tw-py-16 medium:tw-pb-20 tw-relative tw-z-20 tw-w-full tw-hidden print:tw-hidden"
          {% if banner.background_image %}
              style="background-image: url('{{ background_image.url }}'); background-size: cover; background-position: center;"
          {% endif %}>

--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -52,7 +52,10 @@ class BasePage(FoundationMetadataPageMixin, FoundationNavigationPageMixin, Page)
 
         # If there's no A/B test found or DNT is enabled, return the page's donate_banner field as usual.
         if not active_ab_test or dnt_enabled:
-            return donate_banner_page.donate_banner.localized
+            donate_banner = donate_banner_page.donate_banner.localized
+            donate_banner.variant_version = "N/A"
+            donate_banner.active_ab_test = "N/A"
+            return donate_banner
 
         # Check for the cookie related to this A/B test.
         # In wagtail-ab-testing, the cookie name follows the format:
@@ -78,11 +81,13 @@ class BasePage(FoundationMetadataPageMixin, FoundationNavigationPageMixin, Page)
 
         # Return the appropriate donate banner
         if is_variant:
-            donate_banner = active_ab_test.variant_revision.as_object().donate_banner
+            donate_banner = active_ab_test.variant_revision.as_object().donate_banner.localized
         else:
-            donate_banner = donate_banner_page.donate_banner
+            donate_banner = donate_banner_page.donate_banner.localized
 
-        return donate_banner.localized
+        donate_banner.variant_version = test_version
+        donate_banner.active_ab_test = active_ab_test.name
+        return donate_banner
 
     def get_context(self, request):
         context = super().get_context(request)


### PR DESCRIPTION
# Description

This PR updates the help text found on the DonateBanner creation/edit page to better reflect the process of enabling a sitewide donate banner.

This PR also updates the list of data attributes for use in GTM to:
- **Banner ID**
- **Banner Title**
- **Banner Name**
- **Banner Variant Version** (if applicable. Returns "N/A" if no test is running)
- **Banner Active AB Test Name** (if applicable. Returns "N/A" if no test is running)

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1519)
