### PR TITLE
updated query to grab featured blog pages in the correct order

### DIFF
--- a/network-api/networkapi/nav/models.py
+++ b/network-api/networkapi/nav/models.py
@@ -190,7 +190,7 @@ class NavMenu(
     def localized_featured_blog_posts(self):
         default_locale = settings.LANGUAGE_CODE
         posts = BlogPage.objects.filter(
-            featured_pages_relationship__isnull=False, locale__language_code=default_locale
+            featured_pages_relationship__page=self.blog_index_page, locale__language_code=default_locale
         ).order_by("featured_pages_relationship__sort_order")
         posts = localize_queryset(posts, preserve_order=True).prefetch_related("topics")
         return posts[:3]

--- a/network-api/networkapi/nav/tests/test_models.py
+++ b/network-api/networkapi/nav/tests/test_models.py
@@ -286,7 +286,7 @@ class TestNavMenuFeaturedPosts(BlogIndexTestCase):
 
     def test_localized_featured_posts(self) -> None:
         # Get the localised posts:
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(6):
             posts = self.menu.localized_featured_blog_posts
             self.assertEqual(len(posts), 3)
 


### PR DESCRIPTION
# Description

This PR refines the method for fetching the Blog Index Page’s "Featured blog posts" to ensure they display in the correct order within the site's navigation.

Previously, the method queried for featured_pages_relationships that were not null, which I believe would work initially, given that only five such relationships would exist in the database. However, this approach introduces the risk of ambiguity in the navigation bar if the featured pages are rearranged or if additional relationships are accidentally left in the database.

With this update, only relationships specifically linked to the Blog Index Page are retrieved, ensuring the correct set of pages is always displayed in the intended order.