### PR TITLE
Localized attribute removed from bannered_campaign_page.html

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/bannered_campaign_page.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/bannered_campaign_page.html
@@ -61,7 +61,7 @@ An extra check has been added so as to not show the fixed "Take action" button o
                         {% cta page %}
 
                         {% if page.signup %}
-                            {% with localized_signup=page.signup.localized %}
+                            {% with localized_signup=page.signup %}
                                 <div
                                     class="newsletter-signup-module tw-mb-24"
                                     data-module-type="default"


### PR DESCRIPTION
# Description

This PR removes `.localized `attribute from `bannered_campaign_page.html` to avoid duplicity in querying for localized content.

Link to sample test page:
Related PRs/issues: #

# How to test


