### PR TITLE
Returning None if no donate_banner is set

### DIFF
--- a/network-api/networkapi/wagtailpages/pagemodels/base.py
+++ b/network-api/networkapi/wagtailpages/pagemodels/base.py
@@ -41,7 +41,8 @@ class BasePage(FoundationMetadataPageMixin, FoundationNavigationPageMixin, Page)
         default_locale = Locale.get_default()
         donate_banner_page = DonateBannerPage.objects.filter(locale=default_locale).first()
 
-        if not donate_banner_page:
+        # If there is no DonateBannerPage or no donate_banner is set, return None.
+        if not donate_banner_page or not donate_banner_page.donate_banner:
             return None
 
         # Check if the user has Do Not Track enabled by inspecting the DNT header.


### PR DESCRIPTION
# Description

This PR updates the `get_donate_banner` method to return `None` when no donate banner is set on the DonateBannerPage. This resolves an issue where if a DonateBannerPage exists in the DB but no donate_banner is set, an error would be returned when the method attempted to run `.localize` on `None`

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1533)
