### PR TITLE
Returning localized help page notice through context

### DIFF
--- a/network-api/networkapi/donate/pagemodels/help_page.py
+++ b/network-api/networkapi/donate/pagemodels/help_page.py
@@ -50,9 +50,16 @@ class DonateHelpPage(BaseDonationPage):
 
     def get_context(self, request):
         context = super().get_context(request)
+        context["localized_notice"] = self.get_localized_notice()
         context["thank_you_url"] = self.get_thank_you_url(request)
         context["show_formassembly_thank_you"] = context["request"].GET.get("thank_you") == "true"
         return context
+ 
+    def get_localized_notice(self):
+        """Returns the localized notice if it exists, otherwise None."""
+        if self.notice:
+            return self.notice.localized
+        return None
 
     def get_thank_you_url(self, request):
         base_url = self.get_full_url()

--- a/network-api/networkapi/donate/pagemodels/help_page.py
+++ b/network-api/networkapi/donate/pagemodels/help_page.py
@@ -54,7 +54,7 @@ class DonateHelpPage(BaseDonationPage):
         context["thank_you_url"] = self.get_thank_you_url(request)
         context["show_formassembly_thank_you"] = context["request"].GET.get("thank_you") == "true"
         return context
- 
+
     def get_localized_notice(self):
         """Returns the localized notice if it exists, otherwise None."""
         if self.notice:

--- a/network-api/networkapi/templates/donate/pages/help_page.html
+++ b/network-api/networkapi/templates/donate/pages/help_page.html
@@ -11,8 +11,8 @@
     <div class="tw-container tw-py-12 medium:tw-py-24">
         <div class="cms donate-help-page-content">
             <h1 class="tw-h1-heading"> {{ page.title }} </h1>
-            {% if page.notice %}
-                {% include "../fragments/help_page_notice.html" with notice=page.notice %}
+            {% if localized_notice %}
+                {% include "../fragments/help_page_notice.html" with notice=localized_notice%}
             {% endif %}
             <p>
                 {% blocktrans with link="?form=donor-care-intake" trimmed %}

--- a/network-api/networkapi/templates/donate/pages/help_page.html
+++ b/network-api/networkapi/templates/donate/pages/help_page.html
@@ -12,7 +12,7 @@
         <div class="cms donate-help-page-content">
             <h1 class="tw-h1-heading"> {{ page.title }} </h1>
             {% if localized_notice %}
-                {% include "../fragments/help_page_notice.html" with notice=localized_notice%}
+                {% include "../fragments/help_page_notice.html" with notice=localized_notice %}
             {% endif %}
             <p>
                 {% blocktrans with link="?form=donor-care-intake" trimmed %}


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->

Related PRs/issues: [TP1-1561](https://mozilla-hub.atlassian.net/browse/TP1-1561)


This PR updates the `DonateHelpPage` template `help_page.html` by returning a localized version of the `notice` field through the context. Previously, it was only grabbing the non-localized version.


# Steps to test

1. Visit https://foundation-s-localize-d-xqhsft.mofostaging.net/en/donate/help/
2. Note that the notice at the top of the page is rendering in English
![Screenshot 2024-11-20 at 18-04-20 RA Donate Help - Mozilla Foundation](https://github.com/user-attachments/assets/61925f3a-1d22-4fd1-be7a-66b574229e80)

3. Visit https://foundation-s-localize-d-xqhsft.mofostaging.net/fr/donate/help/
4. Note that the notice at the top of the page is rendering in French
![Screenshot 2024-11-20 at 18-05-19 RA Donate Help - Fondation Mozilla](https://github.com/user-attachments/assets/0ce367c7-336d-4237-877a-d8beb7279750)


5. If everything is working as expected, testing is complete! 
