### PR TITLE
rendering eoy banner on PNI pages

### DIFF
--- a/network-api/networkapi/templates/pages/buyersguide/base.html
+++ b/network-api/networkapi/templates/pages/buyersguide/base.html
@@ -78,7 +78,6 @@
     <script src="{% static "_js/bg-main.compiled.js" %}" async defer></script>
 {% endblock %}
 
-{% block donate_banner %}{% endblock %}
 
 {% block body_wrapped %}
 

--- a/source/js/buyers-guide/bg-main.js
+++ b/source/js/buyers-guide/bg-main.js
@@ -17,6 +17,7 @@ import injectMultipageNav from "../multipage-nav.js";
 
 import primaryNav from "../primary-nav.js";
 
+import DonateBanner from "../donate-banner.js"
 import HomepageSlider from "./template-js-handler/homepage-c-slider.js";
 import NewsletterBox from "./template-js-handler/newsletter-box.js";
 import PNIMobileCategoryNav from "./template-js-handler/mobile-category-nav.js";
@@ -74,6 +75,7 @@ let main = {
       this.injectReactComponents();
       this.bindHandlers();
       NewsletterBox.toggleVisibilityClasses();
+      DonateBanner.init();
       initializePrimaryNav(networkSiteURL, primaryNav);
       injectMultipageNav();
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->


Related PRs/issues: [TP1-1560](https://mozilla-hub.atlassian.net/browse/TP1-1560)


This PR updates the Buyersguide (PNI) `base.html` template by removing the donate_banner block override. This allows the EOY donate banner to also be rendered on PNI pages.

This PR also imports the necessary donate banner related JS files in `bg-main.js`, so the banner will render/hide as expected.

# Steps to test:

1. Visit https://foundation-s-tp1560-add-cfnm6v.mofostaging.net/en/
2. Note that the donate banner is rendering
3. Visit https://foundation-s-tp1560-add-cfnm6v.mofostaging.net/en/privacynotincluded/
4. Note that the donate banner is also rendering


# Screenshots

Foundation Site:
![Screenshot 2024-11-21 at 14-00-32 RA Homepage - Mozilla Foundation](https://github.com/user-attachments/assets/9ecd155d-117d-4a46-b0ee-a63a8b84b85c)

Foundation Site (FR Locale):
![Screenshot 2024-11-21 at 14-01-12 RA Homepage - Fondation Mozilla](https://github.com/user-attachments/assets/b060d195-cf6c-4c33-bd16-602dfc615b45)


PNI:
![Screenshot 2024-11-21 at 14-00-09 RA Privacy Not Included Privacy not included Mozilla Foundation](https://github.com/user-attachments/assets/80478c29-9ed5-4f3b-8f69-7ba3501a2b3c)

PNI (FR Locale):
![Screenshot 2024-11-21 at 14-01-37 RA Confidentialité non incluse Privacy not included Fondation Mozilla](https://github.com/user-attachments/assets/ab302dd7-baf4-48bc-8b23-8d51fbf02f5b)


┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1565)
