### PR TITLE
Adjusted mobile nav offset on PNI

### DIFF
--- a/source/sass/buyers-guide/bg-main.scss
+++ b/source/sass/buyers-guide/bg-main.scss
@@ -65,6 +65,12 @@ html {
 
 // Utilities
 
+body.pni .primary-nav-container .wrapper-burger .narrow-screen-menu {
+  @media screen and (min-width: $bp-lg) {
+    top: 94px;
+  }
+}
+
 .bg-product-image {
   background: $pni-product-image-background;
 }


### PR DESCRIPTION
Addressed the offset issue mentioned below
> in between medium-large breakpoints, the nav bar appears to overlap into the black area of the expanded menu.
> <img src="https://github.com/user-attachments/assets/405e2c2f-62e1-4fd2-8907-d6b7c0881649" width="350">

Note that the following behaviour is by design.
> The close button also jumps to the top of the viewport again, hiding the donate banner.


Link to sample test page: https://foundation-s-13165-tp1--xoavfh.herokuapp.com/privacynotincluded
Related PRs/issues: #13165 
