### PR TITLE
Close menu dropdown on scroll offset update

### DIFF
--- a/source/js/components/nav/desktop-dropdown.js
+++ b/source/js/components/nav/desktop-dropdown.js
@@ -79,6 +79,8 @@ class NavDesktopDropdown extends Accordion {
         sibling.classList.remove("tw-highlighted");
       }
     });
+
+    document.addEventListener("scroll", this.handleScroll);
   }
 
   closeSiblings() {
@@ -115,7 +117,24 @@ class NavDesktopDropdown extends Accordion {
 
     this.closeAccordion(this.accordion, this.titleButton, this.content);
     this.closeSiblings();
+
+    document.removeEventListener("scroll", this.handleScroll);
   }
+
+  scrollListener() {
+    console.log("scrollListener");
+    const newTopOffset = document
+      .querySelector(".wide-screen-menu-container")
+      .getBoundingClientRect().bottom;
+    const currentTopOffset = parseFloat(
+      this.content.style.top.replace("px", "")
+    );
+    if (currentTopOffset !== newTopOffset) {
+      this.close();
+    }
+  }
+
+  handleScroll = this.scrollListener.bind(this);
 }
 
 export default NavDesktopDropdown;


### PR DESCRIPTION
# Description

This PR updates the behavior of the desktop main navigation dropdown so that it closes when scrolled and the top offset changes. This new behavior wont apply when its in the top fixed position, including cases when the donate banner is closed or when it has scrolled past it.

Link to sample test page:
Related PRs/issues: #13299