### PR TITLE
Wagtail Footnotes Upgrade Part 1

### DIFF
--- a/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
+++ b/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         ("wagtailcore", "0066_collection_management_permissions"),
         ("wagtailinventory", "0002_pageblock_unique_constraint"),
         ("wagtailforms", "0004_add_verbose_name_plural"),
-        ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        #("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
         ("wagtailredirects", "0007_add_autocreate_fields"),
         ("wagtailpages", "0009_auto_20220325_1735"),
     ]

--- a/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
+++ b/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         ("wagtailcore", "0066_collection_management_permissions"),
         ("wagtailinventory", "0002_pageblock_unique_constraint"),
         ("wagtailforms", "0004_add_verbose_name_plural"),
-        #("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        # ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
         ("wagtailredirects", "0007_add_autocreate_fields"),
         ("wagtailpages", "0009_auto_20220325_1735"),
     ]

--- a/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
+++ b/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        #("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        # ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
         ("wagtailcore", "0078_referenceindex"),
         ("wagtailinventory", "0003_pageblock_id_bigautofield"),
         ("wagtailredirects", "0008_add_verbose_name_plural"),

--- a/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
+++ b/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        #("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
         ("wagtailcore", "0078_referenceindex"),
         ("wagtailinventory", "0003_pageblock_id_bigautofield"),
         ("wagtailredirects", "0008_add_verbose_name_plural"),

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ wagtail==5.2.6
 wagtail-ab-testing
 wagtail-color-panel
 wagtail-factories
-wagtail-footnotes
+wagtail-footnotes==0.11.0
 wagtail-localize==1.7
 wagtail-localize-git
 wagtail-inventory

--- a/requirements.in
+++ b/requirements.in
@@ -28,6 +28,7 @@ wagtail==5.2.6
 wagtail-ab-testing
 wagtail-color-panel
 wagtail-factories
+wagtail-footnotes
 wagtail-localize==1.7
 wagtail-localize-git
 wagtail-inventory
@@ -36,5 +37,4 @@ wagtail-metadata
 whitenoise
 psycopg2-binary
 sentry-sdk
-git+https://github.com/MozillaFoundation/wagtail-footnotes.git@localized-footnotes
 scout-apm

--- a/requirements.txt
+++ b/requirements.txt
@@ -269,7 +269,7 @@ wagtail-color-panel==1.5.0
     # via -r requirements.in
 wagtail-factories==4.1.0
     # via -r requirements.in
-wagtail-footnotes @ git+https://github.com/MozillaFoundation/wagtail-footnotes.git@localized-footnotes
+wagtail-footnotes==0.13.0
     # via -r requirements.in
 wagtail-inventory==2.5
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -269,7 +269,7 @@ wagtail-color-panel==1.5.0
     # via -r requirements.in
 wagtail-factories==4.1.0
     # via -r requirements.in
-wagtail-footnotes==0.13.0
+wagtail-footnotes==0.11.0
     # via -r requirements.in
 wagtail-inventory==2.5
     # via -r requirements.in


### PR DESCRIPTION
# Description

This PR is the first part of upgrading `wagtail-footnotes` to the [upstream package](https://github.com/torchbox/wagtail-footnotes/tree/main) from [our fork](https://github.com/MozillaFoundation/wagtail-footnotes).

We can move off of our fork like this:

## Deploy 1 (via this PR)

1. Comment out any forked migration dependencies
2. Upgrade to upstream package at version 0.11.0, which is the equivalent current state of our fork.
3. Fake migrations up to 0005 (the latest in 0.11.0) via the following command: `python manage.py migrate wagtail_footnotes 0005 --fake`

## Deploy 2 (via a follow-up PR)

1. Upgrade `wagtail_footnotes` to 0.13.0
2. Replace commented out forked migration dependency for the equivalent 0005 dependency in 0.11.0
3. Deploy as normal

Link to sample test page: https://foundation-s-tp1-688-12-vwz91u.herokuapp.com/en/research/library/in-transparency-we-trust/research-report/
Related PRs/issues: TP1-688 / #12365

# To Test

1. Sync your local db to a copy of production data
2. Checkout this branch
3. Run `inv pip-sync` to install the upstream `wagtail_footnotes` package
5. Run `inv sh` to shell into the local env
6. `cd network-api` and then run `python manage.py showmigrations wagtail_footnotes`
7. You should see several migrations that haven't run
8. Run `python manage.py migrate wagtail_footnotes 0005 --fake`
9. Then run `python manage.py showmigrations wagtail_footnotes` again
10. You should see the migrations have been "faked" and are now checked off as having been run
11. We are now on the upstream wagtail footnotes package with faked migrations
12. At no point during testing should a page using wagtail_footnotes be broken (i.e. http://localhost:8000/en/research/library/in-transparency-we-trust/research-report/ )

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1921)
