### PR TITLE
Revert "Wagtail Footnotes Upgrade Part 1"

### DIFF
--- a/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
+++ b/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         ("wagtailcore", "0066_collection_management_permissions"),
         ("wagtailinventory", "0002_pageblock_unique_constraint"),
         ("wagtailforms", "0004_add_verbose_name_plural"),
-        # ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
         ("wagtailredirects", "0007_add_autocreate_fields"),
         ("wagtailpages", "0009_auto_20220325_1735"),
     ]

--- a/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
+++ b/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        # ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
         ("wagtailcore", "0078_referenceindex"),
         ("wagtailinventory", "0003_pageblock_id_bigautofield"),
         ("wagtailredirects", "0008_add_verbose_name_plural"),

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,6 @@ wagtail==5.2.6
 wagtail-ab-testing
 wagtail-color-panel
 wagtail-factories
-wagtail-footnotes==0.11.0
 wagtail-localize==1.7
 wagtail-localize-git
 wagtail-inventory
@@ -37,4 +36,5 @@ wagtail-metadata
 whitenoise
 psycopg2-binary
 sentry-sdk
+git+https://github.com/MozillaFoundation/wagtail-footnotes.git@localized-footnotes
 scout-apm

--- a/requirements.txt
+++ b/requirements.txt
@@ -269,7 +269,7 @@ wagtail-color-panel==1.6.0
     # via -r requirements.in
 wagtail-factories==4.1.0
     # via -r requirements.in
-wagtail-footnotes==0.11.0
+wagtail-footnotes @ git+https://github.com/MozillaFoundation/wagtail-footnotes.git@localized-footnotes
     # via -r requirements.in
 wagtail-inventory==2.5
     # via -r requirements.in


### PR DESCRIPTION
Reverts MozillaFoundation/foundation.mozilla.org#13450

Release failing, will need to adjust `release-steps.sh` to accommodate for the fake migrations.