### PR TITLE
Wagtail Footnotes Upgrade Part 2

### DIFF
--- a/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
+++ b/network-api/networkapi/wagtailpages/migrations/0010_delete_softwareproductpage.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
         ("wagtailcore", "0066_collection_management_permissions"),
         ("wagtailinventory", "0002_pageblock_unique_constraint"),
         ("wagtailforms", "0004_add_verbose_name_plural"),
-        # ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        ("wagtail_footnotes", "0005_alter_footnote_locale_alter_footnote_translation_key"),
         ("wagtailredirects", "0007_add_autocreate_fields"),
         ("wagtailpages", "0009_auto_20220325_1735"),
     ]

--- a/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
+++ b/network-api/networkapi/wagtailpages/migrations/0104_delete_redirectingpage_model.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        # ("wagtail_footnotes", "0004_footnote_translatable_mixin_migration"),
+        ("wagtail_footnotes", "0005_alter_footnote_locale_alter_footnote_translation_key"),
         ("wagtailcore", "0078_referenceindex"),
         ("wagtailinventory", "0003_pageblock_id_bigautofield"),
         ("wagtailredirects", "0008_add_verbose_name_plural"),

--- a/release-steps.sh
+++ b/release-steps.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 cd network-api
 
 # Django Migrations
-# python ./manage.py migrate --no-input
+python ./manage.py migrate --no-input
 
 # Clear cache for BuyersGuide
 python ./manage.py clear_cache

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ wagtail==5.2.6
 wagtail-ab-testing
 wagtail-color-panel
 wagtail-factories
-wagtail-footnotes==0.11.0
+wagtail-footnotes
 wagtail-localize==1.7
 wagtail-localize-git
 wagtail-inventory

--- a/requirements.txt
+++ b/requirements.txt
@@ -269,7 +269,7 @@ wagtail-color-panel==1.6.0
     # via -r requirements.in
 wagtail-factories==4.1.0
     # via -r requirements.in
-wagtail-footnotes==0.11.0
+wagtail-footnotes==0.13.0
     # via -r requirements.in
 wagtail-inventory==2.5
     # via -r requirements.in


### PR DESCRIPTION
# Description

This is the Part 2 of the wagtail-footnotes upgrade to upsteam package.

This PR will restore the migrate command in heroku's release steps, bump wagtail-footnotes to 0.13.0, and restore the migration dependencies to the equivalent upstream migration. It should deploy and apply new wagtail-footnote migrations as normal without any bash commands necessary.

Link to sample test page:
Related PRs/issues: #13464 / #12365 / TP1-688

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-1941)
