### PR TITLE
Removed 'Schedule' link from MozFest nav

### DIFF
--- a/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
+++ b/network-api/networkapi/mozfest/templates/partials/primary_mozfest_nav.html
@@ -14,7 +14,6 @@
                                         <div class="nav-links pt-3">
                                             <div><a class="{% primary_active_nav request menu_root.full_url menu_root.full_url %}" href="{{ menu_root.url }}">{{ root_name }}</a></div>
                                             {% include "fragments/nav_links.html" with pre="<div>" post="</div>" %}
-                                            <a target="_blank" href="https://schedule.mozillafestival.org/plaza">{% trans "Schedule" %}</a>
                                         </div>
                                     </div>
                                 </div>
@@ -37,7 +36,6 @@
                                         <div class="wide-screen-menu">
                                             <div class="nav-links d-none d-lg-block">
                                                 {% include "fragments/nav_links.html" %}
-                                                <a target="_blank" href="https://schedule.mozillafestival.org/plaza">{% trans "Schedule" %}</a>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
# Description

Remove "Schedule" link from MozFest nav.

Link to sample test page: [mozfest-foundation-s-13513-tp1--bnn1vu.mofostaging.net ](https://mozfest-foundation-s-13513-tp1--bnn1vu.mofostaging.net/en/)
Related PRs/issues: #13513

Note: This repo is experiencing a timeout issue in CI test. It will be resolved once https://github.com/MozillaFoundation/foundation.mozilla.org/pull/13520 gets merged.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2015)
