### PR TITLE
Update FRU widget selector to fix a Playwright timeout issue

### DIFF
--- a/tests/integration/petition/002-thank-you.spec.js
+++ b/tests/integration/petition/002-thank-you.spec.js
@@ -62,7 +62,7 @@ test.describe("Donation modal", () => {
     expect(page.url()).toContain(`form=donate`);
 
     // test if FRU iframe is visible
-    const widgetIframe = page.locator(`iframe[title="Donation Widget"]`);
+    const widgetIframe = page.locator(`iframe[title="Donation Form"]`);
     await widgetIframe.waitFor({ state: "visible" });
     expect(await widgetIframe.count()).toBe(1);
   });


### PR DESCRIPTION
Since the FRU widget's title attribute was recently modified, it triggered a timeout issue in CI integration tests. To resolve this, I updated the selector used in our Playwright tests.

<img width="998" alt="image" src="https://github.com/user-attachments/assets/2a366a70-04ea-432d-948a-7db064602615" />
