### PR TITLE
Fix wagtail requirements conflict

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ pygit2==1.14.0
 python-slugify
 requests
 social-auth-app-django
-wagtail==5.2.6
+wagtail==6.3.2
 wagtail-ab-testing
 wagtail-color-panel
 wagtail-factories


### PR DESCRIPTION
# Description

Need to bump pinned wagtail version in `requirements.in`. The mismatch results in [dependabot conflicts](https://github.com/MozillaFoundation/foundation.mozilla.org/actions) that are preventing dependabot from updating

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2031)
