### PR TITLE
Upgrade CI runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test_node:
     name: Node CI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       ALLOWED_HOSTS: localhost,mozfest.localhost,default-site.com,secondary-site.com
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +31,7 @@ jobs:
 
   test_wagtail:
     name: Wagtail CI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:15
@@ -109,7 +109,7 @@ jobs:
 
   test_integration:
     name: Integration testing
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -12,7 +12,7 @@ jobs:
   visual_regression_tests:
     name: Percy CI
     if: (github.event_name == 'push' && github.event.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.label.name == 'run visual regression tests') || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres:13.2


### PR DESCRIPTION
# Description

[Github has started a “brown out” campaign](https://github.com/actions/runner-images/issues/11101) and cancelling CI jobs to raise awareness on Ubuntu 20 deprecation.

We need to upgrade to Ubuntu 22 for our CI runner.

Related PRs/issues: TP1-2077 #13567

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2078)
