### PR TITLE
Fix mozfest cookie banner domain check

### DIFF
--- a/network-api/networkapi/utility/templatetags/mofo_common.py
+++ b/network-api/networkapi/utility/templatetags/mofo_common.py
@@ -29,7 +29,7 @@ def onetrust_data_domain(context):
     # TODO this can get cleaned up to use the mozfest site id
     # but depends on re-design if the site id will remain the same. Use domains for now.
     mozfest_domains = {
-        "mozillafestival.org",
+        "www.mozillafestival.org",
         "mozillafestival.mofostaging.net",
         "mozfest.localhost:8000",
     }


### PR DESCRIPTION
# Description

This PR fixes mozfest's cookie banner domain check

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2198)
