### PR TITLE
Add cache-metadata-parameters attribute to tito-button

### DIFF
--- a/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
+++ b/network-api/networkapi/wagtailpages/templates/wagtailpages/blocks/tito_widget_block.html
@@ -5,5 +5,5 @@
 {% block block_content %}
     <script src='https://js.tito.io/v2' async></script>
 
-    <tito-button event="{{ value.event.event_id }}" source="{% if value.source %}{{ value.source }}{% endif %}" save-metadata-parameters="utm_*" locale="{{ tito_widget_lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-8">{{ value.button_label }}</tito-button>
+    <tito-button event="{{ value.event.event_id }}" source="{% if value.source %}{{ value.source }}{% endif %}" save-metadata-parameters="utm_*" cache-metadata-parameters locale="{{ tito_widget_lang_code }}"{% if value.releases %} releases="{{ value.releases }}"{% endif %} class="tw-{{ value.styling }} link-button tw-my-8">{{ value.button_label }}</tito-button>
 {% endblock %}


### PR DESCRIPTION
# Description
This PR adds the `cache-metadata-parameters` attribute to the `tito-button` widgets, ensuring that UTM parameters persist throughout the user session regardless of the browser state. This allows accurate tracking of UTM metadata even if the user navigates away or the URL parameters are removed.

# Testing
In order to test this feature:
1. Browse the [test ticket page with UTM params](https://mozfest-foundation-s-tp1-1998-s-4h0r8y.mofostaging.net/en/tickets-test-page/?utm_source=test_facebook&utm_medium=test_social&utm_campaign=test_mozfest2025&utm_term=test_tech_newsletter&utm_content=test_cta_button) and authenticate with credentials `admin2:admin2`.

2. Right after page load, open the developer tools by pressing `F12`. Open the `Console` drawer and look for the `saveMetadataParameters` log. It should list the URL UTM attributes correctly.

   <img src="https://github.com/user-attachments/assets/95dd5758-ba32-485a-b089-c081a118947d" width="60%">

3. Open the `Storage` drawer in the developer tools and select the `Session Storage` item in the list from the left. It should show the `titoMetadataPassthrough` key on the right, with the value holding the UTM data.

   <img src="https://github.com/user-attachments/assets/aa05f470-bca8-4475-963c-9f8742555ceb" width="60%">

4. Browse the [test page without UTM parameters](https://mozfest-foundation-s-tp1-1998-s-4h0r8y.mofostaging.net/en/tickets-test-page/), emulating user navigation and URL parameters being removed. The `Storage` drawer should still show the same keys and values, and the `Console` drawer should also list the `saveMetadataParameters` log entry with the previous parameters.

   <img src="https://github.com/user-attachments/assets/ff91ae7a-5263-47a2-aec3-315a3019ff05" width="60%">

5. Click the `Test Tito Button` and check the added log entries for the `[Tito] Using metadata` row. It should display the previous UTM parameters correctly, even if the source widget page did not have URL parameters.

   <img src="https://github.com/user-attachments/assets/31e74882-fc66-4cf6-999f-1f9208259e92" width="60%">




Link to sample test page: https://mozfest-foundation-s-tp1-1998-s-4h0r8y.mofostaging.net/en/tickets-test-page/?utm_source=test_facebook&utm_medium=test_social&utm_campaign=test_mozfest2025&utm_term=test_tech_newsletter&utm_content=test_cta_button

Related PRs/issues: #13512

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2214)
