### PR TITLE
Wagtail Search Functionality Iteration

### DIFF
--- a/foundation_cms/search/tests/test_views.py
+++ b/foundation_cms/search/tests/test_views.py
@@ -1,0 +1,41 @@
+from django.test import Client, TestCase
+from django.contrib.auth.models import User
+from wagtail.models import Page, Site
+
+
+class SearchViewTestCase(TestCase):
+    def setUp(self):
+        # Set up the client for making requests
+        self.client = Client()
+
+        self.user = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="password"
+        )
+
+        # Log in as the superuser
+        self.client.login(username="admin", password="password")
+
+        # Create sample pages
+        self.root_page = Page.get_first_root_node()
+        site = Site.objects.get(is_default_site=True)
+
+        self.page1 = self.root_page.add_child(
+            instance=Page(title="Page One", slug="page-one")
+        )
+
+        # Add another child page under the root (depth=2)
+        self.page2 = self.root_page.add_child(
+            instance=Page(title="Page Two", slug="page-two")
+        )
+        site.save()
+
+    def test_search_returns_multiple_pages(self):
+        # Perform a search that should match multiple pages
+        response = self.client.get("/admin/pages/search/", {"query": "Page"})
+
+        # Confirm the response is successful
+        self.assertEqual(response.status_code, 200)
+
+        # Ensure both pages appear in the search results
+        self.assertContains(response, "Page One")
+        self.assertContains(response, "Page Two")

--- a/foundation_cms/search/tests/test_views.py
+++ b/foundation_cms/search/tests/test_views.py
@@ -31,7 +31,7 @@ class SearchViewTestCase(TestCase):
 
     def test_search_returns_multiple_pages(self):
         # Perform a search that should match multiple pages
-        response = self.client.get("/admin/pages/search/", {"query": "Page"})
+        response = self.client.get("/cms/pages/search/", {"query": "Page"})
 
         # Confirm the response is successful
         self.assertEqual(response.status_code, 200)

--- a/foundation_cms/search/views.py
+++ b/foundation_cms/search/views.py
@@ -1,0 +1,66 @@
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.http import JsonResponse
+from django.template.response import TemplateResponse
+from wagtail.models import Page, Locale
+from wagtail.search.query import PlainText
+
+
+# To enable logging of search queries for use with the "Promoted search results" module
+# <https://docs.wagtail.org/en/stable/reference/contrib/searchpromotions.html>
+# uncomment the following line and the lines indicated in the search function
+# (after adding wagtail.contrib.search_promotions to INSTALLED_APPS):
+
+# from wagtail.contrib.search_promotions.models import Query
+
+
+def search(request):
+    search_query = request.GET.get("query", None)
+    page = request.GET.get("page", 1)
+
+    # Search
+    if search_query:
+        search_results = Page.objects.live().filter(
+            locale=Locale.get_active()
+        ).search(search_query)
+
+        # To log this query for use with the "Promoted search results" module:
+
+        # query = Query.get(search_query)
+        # query.add_hit()
+
+    else:
+        search_results = Page.objects.none()
+
+    # Pagination
+    paginator = Paginator(search_results, 10)
+    try:
+        search_results = paginator.page(page)
+    except PageNotAnInteger:
+        search_results = paginator.page(1)
+    except EmptyPage:
+        search_results = paginator.page(paginator.num_pages)
+
+    return TemplateResponse(
+        request,
+        "search/search.html",
+        {
+            "search_query": search_query,
+            "search_results": search_results,
+        },
+    )
+
+
+def search_autocomplete(request):
+    search_query = request.GET.get('query', '').strip()
+    if search_query:
+        results = Page.objects.live().filter(
+            locale=Locale.get_active()
+        ).autocomplete(
+            PlainText(search_query),
+            fields=['title'],
+            operator='or'
+        )[:5]  # Limit to 5 suggestions
+        return JsonResponse({
+            'results': [{'title': page.title, 'url': page.url} for page in results]
+        })
+    return JsonResponse({'results': []})

--- a/foundation_cms/templates/base.html
+++ b/foundation_cms/templates/base.html
@@ -22,8 +22,6 @@
         {% if request.in_preview_panel %}<base target="_blank">{% endif %}
         {# Global stylesheets #}
         {% block extra_css %}{# Override this in templates to add extra stylesheets #}{% endblock %}
-
-
     </head>
     {# Basic breadcrumbs for dev navigation #}
     {% with self as page %}
@@ -37,6 +35,5 @@
         {% block content %}{% endblock %}
         {# Global javascript #}
         {% block extra_js %}{# Override this in templates to add extra javascript #}{% endblock %}
-
     </body>
 </html>

--- a/foundation_cms/templates/base.html
+++ b/foundation_cms/templates/base.html
@@ -21,11 +21,7 @@
         {# Force all links in the live preview panel to be opened in a new tab #}
         {% if request.in_preview_panel %}<base target="_blank">{% endif %}
         {# Global stylesheets #}
-        {% block extra_css %}{# Override this in templates to add extra stylesheets #}
-
-        {% endblock %}
-        <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-        <link rel="stylesheet" href="{% static 'foundation_cms/css/base.css' %}">
+        {% block extra_css %}{# Override this in templates to add extra stylesheets #}{% endblock %}
 
 
     </head>

--- a/foundation_cms/templates/base.html
+++ b/foundation_cms/templates/base.html
@@ -21,7 +21,13 @@
         {# Force all links in the live preview panel to be opened in a new tab #}
         {% if request.in_preview_panel %}<base target="_blank">{% endif %}
         {# Global stylesheets #}
-        {% block extra_css %}{# Override this in templates to add extra stylesheets #}{% endblock %}
+        {% block extra_css %}{# Override this in templates to add extra stylesheets #}
+
+        {% endblock %}
+        <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+        <link rel="stylesheet" href="{% static 'foundation_cms/css/base.css' %}">
+
+
     </head>
     {# Basic breadcrumbs for dev navigation #}
     {% with self as page %}
@@ -35,5 +41,6 @@
         {% block content %}{% endblock %}
         {# Global javascript #}
         {% block extra_js %}{# Override this in templates to add extra javascript #}{% endblock %}
+
     </body>
 </html>

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -7,21 +7,21 @@
           rel="stylesheet"
           href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <style>
-  .ui-autocomplete {
-    max-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 5px 0;
-    background: white;
-    border: 1px solid #ddd;
-}
-.ui-menu-item {
-    padding: 5px 10px;
-    cursor: pointer;
-}
-.ui-menu-item:hover {
-    background: #f5f5f5;
-}
+        .ui-autocomplete {
+            max-height: 200px;
+            overflow-y: auto;
+            overflow-x: hidden;
+            padding: 5px 0;
+            background: white;
+            border: 1px solid #ddd;
+        }
+        .ui-menu-item {
+            padding: 5px 10px;
+            cursor: pointer;
+        }
+        .ui-menu-item:hover {
+            background: #f5f5f5;
+        }
     </style>
 {% endblock %}
 {% block content %}

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -1,13 +1,11 @@
 {% extends "base.html" %}
 {% load static wagtailcore_tags %}
-
 {% block body_class %}template-searchresults{% endblock %}
-
 {% block title %}Search{% endblock %}
-
 {% block extra_css %}
-    <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-  <style>
+    <link rel="stylesheet"
+          href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+    <style>
   .ui-autocomplete {
     max-height: 200px;
     overflow-y: auto;
@@ -23,41 +21,34 @@
 .ui-menu-item:hover {
     background: #f5f5f5;
 }
-</style>
+    </style>
 {% endblock %}
-
 {% block content %}
     <h1>Search</h1>
-
     <form action="{% url 'search' %}" method="get" class="search-form">
-        <input
-            type="text"
-            name="query"
-            id="search-input"
-            {% if search_query %}
-                value="{{ search_query }}"
-            {% endif %}
-            placeholder="Search..."
-            autocomplete="off"
-        >
+        <input type="text"
+               name="query"
+               id="search-input"
+               {% if search_query %}value="{{ search_query }}"{% endif %}
+               placeholder="Search..."
+               autocomplete="off">
         <input type="submit" value="Search" class="button">
     </form>
-
     {% if search_results %}
         <ul class="search-results">
             {% for result in search_results %}
                 <li>
-                    <h4><a href="{% pageurl result %}">{{ result }}</a></h4>
+                    <h4>
+                        <a href="{% pageurl result %}">{{ result }}</a>
+                    </h4>
                 </li>
             {% endfor %}
         </ul>
-
         {% if search_results.paginator.num_pages > 1 %}
             <div class="pagination">
                 {% if search_results.has_previous %}
                     <a href="{% url 'search' %}?query={{ search_query|urlencode }}&page={{ search_results.previous_page_number }}">Previous</a>
                 {% endif %}
-
                 {% if search_results.has_next %}
                     <a href="{% url 'search' %}?query={{ search_query|urlencode }}&page={{ search_results.next_page_number }}">Next</a>
                 {% endif %}
@@ -67,7 +58,6 @@
         <p>No results found for "{{ search_query }}"</p>
     {% endif %}
 {% endblock %}
-
 {% block extra_js %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -60,37 +60,86 @@
     {% endif %}
 {% endblock %}
 {% block extra_js %}
-    <script nonce="{{ request.csp_nonce }}"
-            src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script nonce="{{ request.csp_nonce }}"
-            src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
     <script nonce="{{ request.csp_nonce }}">
-        $(document).ready(function() {
-            $("#search-input").autocomplete({
-                source: function(request, response) {
-                    $.ajax({
-                        url: "{% url 'search_autocomplete' %}",
-                        dataType: "json",
-                        data: {
-                            query: request.term
-                        },
-                        success: function(data) {
-                            response($.map(data.results, function(item) {
-                                return {
-                                    label: item.title,
-                                    value: item.title,
-                                    url: item.url
-                                };
-                            }));
-                        }
+        document.addEventListener('DOMContentLoaded', function() {
+            const searchInput = document.getElementById('search-input');
+            const autocompleteContainer = document.getElementById('autocomplete-container');
+            let activeIndex = -1;
+
+            searchInput.addEventListener('input', async function() {
+                const query = searchInput.value.trim();
+                if (query.length < 2) {
+                    autocompleteContainer.innerHTML = '';
+                    activeIndex = -1;
+                    return;
+                }
+
+                try {
+                    const response = await fetch("{% url 'search_autocomplete' %}?query=" + encodeURIComponent(query));
+                    if (!response.ok) {
+                        console.error('Error fetching autocomplete results');
+                        return;
+                    }
+
+                    const data = await response.json();
+                    autocompleteContainer.innerHTML = '';
+                    activeIndex = -1;
+
+                    data.results.forEach(item => {
+                        const suggestion = document.createElement('div');
+                        suggestion.className = 'autocomplete-suggestion';
+                        suggestion.textContent = item.title;
+                        suggestion.addEventListener('click', () => {
+                            window.location.href = item.url;
+                        });
+                        autocompleteContainer.appendChild(suggestion);
                     });
-                },
-                minLength: 2,
-                select: function(event, ui) {
-                    window.location.href = ui.item.url;
-                    return false;
+                } catch (error) {
+                    console.error('Error:', error);
                 }
             });
+
+            searchInput.addEventListener('keydown', function(event) {
+                const suggestions = autocompleteContainer.querySelectorAll('.autocomplete-suggestion');
+                if (suggestions.length === 0) return;
+
+                if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    activeIndex = (activeIndex + 1) % suggestions.length;
+                    updateActiveSuggestion(suggestions);
+                } else if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    activeIndex = (activeIndex - 1 + suggestions.length) % suggestions.length;
+                    updateActiveSuggestion(suggestions);
+                } else if (event.key === 'Enter') {
+                    event.preventDefault();
+                    if (activeIndex >= 0 && activeIndex < suggestions.length) {
+                        const activeSuggestion = suggestions[activeIndex];
+                        window.location.href = activeSuggestion.dataset.url;
+                    }
+                } else if (event.key === 'Escape') {
+                    autocompleteContainer.innerHTML = '';
+                    activeIndex = -1;
+                }
+            });
+
+            document.addEventListener('click', function(event) {
+                if (!autocompleteContainer.contains(event.target) && event.target !== searchInput) {
+                    autocompleteContainer.innerHTML = '';
+                    activeIndex = -1;
+                }
+            });
+
+            function updateActiveSuggestion(suggestions) {
+                suggestions.forEach((suggestion, index) => {
+                    if (index === activeIndex) {
+                        suggestion.classList.add('active');
+                        suggestion.scrollIntoView({ block: 'nearest' });
+                    } else {
+                        suggestion.classList.remove('active');
+                    }
+                });
+            }
         });
     </script>
 {% endblock %}

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -34,6 +34,7 @@
                placeholder="Search..."
                autocomplete="off">
         <input type="submit" value="Search" class="button">
+        <div id="autocomplete-container" class="autocomplete-suggestions"></div>
     </form>
     {% if search_results %}
         <ul class="search-results">

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -3,7 +3,7 @@
 {% block body_class %}template-searchresults{% endblock %}
 {% block title %}Search{% endblock %}
 {% block extra_css %}
-    <link rel="stylesheet"
+    <link nonce="{{ request.csp_nonce }}" rel="stylesheet"
           href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <style>
   .ui-autocomplete {
@@ -59,8 +59,8 @@
     {% endif %}
 {% endblock %}
 {% block extra_js %}
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+    <script nonce="{{ request.csp_nonce }}" src="https://code.jquery.com/jquery-3.6.0.min.js" ></script>
+    <script nonce="{{ request.csp_nonce }}" src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
     <script>
         $(document).ready(function() {
             $("#search-input").autocomplete({

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -3,7 +3,8 @@
 {% block body_class %}template-searchresults{% endblock %}
 {% block title %}Search{% endblock %}
 {% block extra_css %}
-    <link nonce="{{ request.csp_nonce }}" rel="stylesheet"
+    <link nonce="{{ request.csp_nonce }}"
+          rel="stylesheet"
           href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <style>
   .ui-autocomplete {
@@ -59,8 +60,10 @@
     {% endif %}
 {% endblock %}
 {% block extra_js %}
-    <script nonce="{{ request.csp_nonce }}" src="https://code.jquery.com/jquery-3.6.0.min.js" ></script>
-    <script nonce="{{ request.csp_nonce }}" src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+    <script nonce="{{ request.csp_nonce }}"
+            src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script nonce="{{ request.csp_nonce }}"
+            src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
     <script nonce="{{ request.csp_nonce }}">
         $(document).ready(function() {
             $("#search-input").autocomplete({

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+{% load static wagtailcore_tags %}
+
+{% block body_class %}template-searchresults{% endblock %}
+
+{% block title %}Search{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
+  <style>
+  .ui-autocomplete {
+    max-height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 5px 0;
+    background: white;
+    border: 1px solid #ddd;
+}
+.ui-menu-item {
+    padding: 5px 10px;
+    cursor: pointer;
+}
+.ui-menu-item:hover {
+    background: #f5f5f5;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+    <h1>Search</h1>
+
+    <form action="{% url 'search' %}" method="get" class="search-form">
+        <input
+            type="text"
+            name="query"
+            id="search-input"
+            {% if search_query %}
+                value="{{ search_query }}"
+            {% endif %}
+            placeholder="Search..."
+            autocomplete="off"
+        >
+        <input type="submit" value="Search" class="button">
+    </form>
+
+    {% if search_results %}
+        <ul class="search-results">
+            {% for result in search_results %}
+                <li>
+                    <h4><a href="{% pageurl result %}">{{ result }}</a></h4>
+                </li>
+            {% endfor %}
+        </ul>
+
+        {% if search_results.paginator.num_pages > 1 %}
+            <div class="pagination">
+                {% if search_results.has_previous %}
+                    <a href="{% url 'search' %}?query={{ search_query|urlencode }}&page={{ search_results.previous_page_number }}">Previous</a>
+                {% endif %}
+
+                {% if search_results.has_next %}
+                    <a href="{% url 'search' %}?query={{ search_query|urlencode }}&page={{ search_results.next_page_number }}">Next</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% elif search_query %}
+        <p>No results found for "{{ search_query }}"</p>
+    {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+    <script>
+        $(document).ready(function() {
+            $("#search-input").autocomplete({
+                source: function(request, response) {
+                    $.ajax({
+                        url: "{% url 'search_autocomplete' %}",
+                        dataType: "json",
+                        data: {
+                            query: request.term
+                        },
+                        success: function(data) {
+                            response($.map(data.results, function(item) {
+                                return {
+                                    label: item.title,
+                                    value: item.title,
+                                    url: item.url
+                                };
+                            }));
+                        }
+                    });
+                },
+                minLength: 2,
+                select: function(event, ui) {
+                    window.location.href = ui.item.url;
+                    return false;
+                }
+            });
+        });
+    </script>
+{% endblock %}

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -61,7 +61,7 @@
 {% block extra_js %}
     <script nonce="{{ request.csp_nonce }}" src="https://code.jquery.com/jquery-3.6.0.min.js" ></script>
     <script nonce="{{ request.csp_nonce }}" src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
-    <script>
+    <script nonce="{{ request.csp_nonce }}">
         $(document).ready(function() {
             $("#search-input").autocomplete({
                 source: function(request, response) {

--- a/foundation_cms/templates/search/search.html
+++ b/foundation_cms/templates/search/search.html
@@ -3,24 +3,26 @@
 {% block body_class %}template-searchresults{% endblock %}
 {% block title %}Search{% endblock %}
 {% block extra_css %}
-    <link nonce="{{ request.csp_nonce }}"
-          rel="stylesheet"
-          href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <style>
-        .ui-autocomplete {
+        .autocomplete-suggestions {
             max-height: 200px;
             overflow-y: auto;
             overflow-x: hidden;
-            padding: 5px 0;
             background: white;
             border: 1px solid #ddd;
+            position: absolute;
+            z-index: 1000;
+            width: 30em;
         }
-        .ui-menu-item {
+        .autocomplete-suggestions:empty {
+            display: none;
+        }
+        .autocomplete-suggestion {
             padding: 5px 10px;
             cursor: pointer;
         }
-        .ui-menu-item:hover {
-            background: #f5f5f5;
+        .autocomplete-suggestion:hover, .autocomplete-suggestion.active {
+            background: #ccc;
         }
     </style>
 {% endblock %}

--- a/foundation_cms/urls.py
+++ b/foundation_cms/urls.py
@@ -146,7 +146,6 @@ path("search/", search_views.search, name="search"),
     # wagtail-managed data
     path("", include(wagtail_urls)),
     path("sitemap.xml", cache_page(86400)(sitemap)),
-
 )
 
 if settings.USE_S3 is not True:

--- a/foundation_cms/urls.py
+++ b/foundation_cms/urls.py
@@ -21,6 +21,7 @@ from foundation_cms.legacy_apps.wagtailcustomization.image_url_tag_urls import (
     urlpatterns as image_url_tag_urls,
 )
 from foundation_cms.legacy_apps.wagtailpages.rss import AtomFeed, RSSFeed
+from foundation_cms.search import views as search_views
 
 from .redirects import foundation_redirects
 from .sitemaps import sitemap, sitemap_index
@@ -135,6 +136,8 @@ urlpatterns = list(
 # url format with /<language_code>/ infixed needs
 # to be wrapped by django's i18n_patterns feature:
 urlpatterns += i18n_patterns(
+path("search/", search_views.search, name="search"),
+    path('search/autocomplete/', search_views.search_autocomplete, name='search_autocomplete'),
     # Blog RSS feed
     path("blog/rss/", RSSFeed(), name="rss-feed"),
     path("blog/atom/", AtomFeed()),
@@ -143,6 +146,7 @@ urlpatterns += i18n_patterns(
     # wagtail-managed data
     path("", include(wagtail_urls)),
     path("sitemap.xml", cache_page(86400)(sitemap)),
+
 )
 
 if settings.USE_S3 is not True:


### PR DESCRIPTION
# Description

This PR introduces the search functionality for Wagtail live pages. For this iteration we will see a simple UI, but also an autocomplete feature inside the input field powered by small jQuery/Ajax script, and simple CSS. Right now, I included the CSS and JS inside of `templates/search/search.html` template, given that on coming iterations we will modify the UI and will separate static files inside of the compiled directory.

Files added/updated:
- foundation_cms/search/views.py
- foundation_cms/search/tests/test_views.py (copied from prototype branch)
- foundation_cms/templates/search/search.html
- foundation_cms/urls.py

Link to sample test page: https://foundation-s-tp1-1628-s-lmg2pj.herokuapp.com/en/search/
Related PRs/issues: https://mozilla-hub.atlassian.net/browse/TP1-1628

**Tests**
- Go to review app [link](https://foundation-s-tp1-1628-s-lmg2pj.herokuapp.com/en/search/)
- You should see the search page and the input field.
- Start typing, and after the first 2 characters, suggestions should display.
- Confirm the locale is working correctly, and if the search is under `en` locale, only English results are showed. 

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2255)
