### PR TITLE
Remove ref to welcome_page.css

### DIFF
--- a/foundation_cms/templates/patterns/pages/core/home_page.html
+++ b/foundation_cms/templates/patterns/pages/core/home_page.html
@@ -4,12 +4,7 @@
 
 {% block body_class %}template-homepage{% endblock %}
 
-{% block extra_css %}
-
-{% comment %}
-Delete the line below if you're just getting started and want to remove the welcome screen!
-{% endcomment %}
-{% endblock extra_css %}
+{% block extra_css %}{% endblock extra_css %}
 
 {% block content %}
   <div style="margin-left: 200px; margin-top: 50px;">

--- a/foundation_cms/templates/patterns/pages/core/home_page.html
+++ b/foundation_cms/templates/patterns/pages/core/home_page.html
@@ -9,7 +9,6 @@
 {% comment %}
 Delete the line below if you're just getting started and want to remove the welcome screen!
 {% endcomment %}
-  <link rel="stylesheet" href="{% static 'css/welcome_page.css' %}">
 {% endblock extra_css %}
 
 {% block content %}


### PR DESCRIPTION
`welcome_page.css` has been removed as part of [PR #13787.](https://github.com/MozillaFoundation/foundation.mozilla.org/pull/13787/files#diff-a770de8c5491cf820e11747b8a290aafd24e1114c798c55f2eb33521f27d5221) This follwoup PR addresses the following error we get from visiting the homepage
```bash
ValueError: Missing staticfiles manifest entry for 'css/welcome_page.css'
```

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2399)
