### PR TITLE
Fix Docker build failures by installing `wheel` and missing system-level dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,10 @@ EXPOSE 8000
 RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
     build-essential \
     libpq-dev \
+    python3-dev \
+    libffi-dev \
+    python3-setuptools \
+    python3-wheel \
     curl \
     git \
     gettext \
@@ -83,12 +87,12 @@ USER mozilla
 
 # Install your app's Python requirements.
 RUN python -m venv $VIRTUAL_ENV
-RUN pip install -U pip==23.3.2 && pip install pip-tools
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+RUN pip install -U pip==23.3.2 && pip install pip-tools setuptools wheel
 # Normally we won't install dev dependencies in production, but we do it here to optimise
 # docker build cache for local build
 COPY --chown=mozilla ./requirements.txt ./dev-requirements.txt ./
-# We use pip-tools instead of pip install. This will installing, upgrading, or uninstalling
-# all dependencies necessary to match the contents of the requirements files.
+# Pre-install wheel before syncing, even though it's in dev-requirements.in
 RUN pip-sync requirements.txt dev-requirements.txt
 
 # Copy application code.

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,3 +1,8 @@
+# Ensure wheel is available in virtualenv
+# Required to avoid "invalid command 'bdist_wheel'" when pip-sync builds packages like psutil or django-admin-sortable.
+# Safe to include — has no effect on runtime and helps Docker builds work reliably.
+wheel
+
 -c requirements.txt
 black
 django-debug-toolbar


### PR DESCRIPTION
This PR fixes a Docker build issue that surfaced during a clean build of the `foundation.mozilla.org site`. The root cause: packages like `psutil` and `django-admin-sortable` rely on `bdist_wheel`, but:

- `wheel` is no longer bundled with pip in newer Python versions
- `wheel` wasn’t explicitly listed in `dev-requirements.in`
- system packages required to build wheels (like `python3-dev`, `libffi-dev`, etc.) were missing from our image

These issues went unnoticed previously because:
- My environment had cached `wheel` from a previous install
- I wasn't doing fresh Docker builds for this project
- I was switching between Python 3.7 (network-pulse-api) and 3.11 (foundation site), which masked the problem

### What's changed
- Added `wheel` to `dev-requirements.in` with a helpful comment
- Updated `Dockerfile` to install:
  - `python3-dev`
  - `libffi-dev`
  - `python3-setuptools`
  - `python3-wheel`
- Pre-installs `setuptools` and `wheel` before running `pip-sync`

### Why it’s safe
These changes shouldn’t impact any teammates who already have working setups or use cached builds. The system-level packages are safe to include, and `wheel` has no effect on runtime behavior.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2403)
