### PR TITLE
Add padding to dropdown content for improved spacing on mobile

### DIFF
--- a/network-api/networkapi/templates/fragments/blocks/nav/dropdown.html
+++ b/network-api/networkapi/templates/fragments/blocks/nav/dropdown.html
@@ -33,7 +33,7 @@
 
     <div class="{{ content_base_styles }} {{ content_desktop_positioning }} {{ content_desktop }} {{ alignment_class }}" data-accordion-content>
         <div class="tw-container xlarge:tw-max-w-[1200px] xlarge:tw-px-0">
-            <div class="{% block content_width %} xlarge:tw-w-{{ value.ncols }}/4 {% endblock content_width %} {{ content_desktop_border }}">
+            <div class="{% block content_width %} xlarge:tw-w-{{ value.ncols }}/4 {% endblock content_width %} {{ content_desktop_border }} tw-pb-24">
                 <div class="tw-nav-accordion-content-inner {% block grid_columns %} xlarge:tw-grid-cols-{{ value.ncols }} {% if value.has_featured_column %}tw-has-featured-column{% endif %}{% endblock grid_columns %}">
                     {% block content %}
                         {% if value.has_overview %}

--- a/network-api/networkapi/templates/fragments/blocks/nav/dropdown.html
+++ b/network-api/networkapi/templates/fragments/blocks/nav/dropdown.html
@@ -33,7 +33,7 @@
 
     <div class="{{ content_base_styles }} {{ content_desktop_positioning }} {{ content_desktop }} {{ alignment_class }}" data-accordion-content>
         <div class="tw-container xlarge:tw-max-w-[1200px] xlarge:tw-px-0">
-            <div class="{% block content_width %} xlarge:tw-w-{{ value.ncols }}/4 {% endblock content_width %} {{ content_desktop_border }} tw-pb-24">
+            <div class="{% block content_width %} xlarge:tw-w-{{ value.ncols }}/4 {% endblock content_width %} {{ content_desktop_border }} tw-pb-32">
                 <div class="tw-nav-accordion-content-inner {% block grid_columns %} xlarge:tw-grid-cols-{{ value.ncols }} {% if value.has_featured_column %}tw-has-featured-column{% endif %}{% endblock grid_columns %}">
                     {% block content %}
                         {% if value.has_overview %}


### PR DESCRIPTION
# Description

This PR attempts to correct a navigation issue present in current mobile navigation, when an accordion drop down is opened, it wont take into account as available viewport space the lower browser chrome toolbar, effectively hiding the lower buttons of the dropdown.

## Current state
<img src="https://github.com/user-attachments/assets/3fe63b0b-35e9-4f80-97be-d017ba51dabd" alt="BROKEN" width="300"/>

## Fixed state/
<img src="https://github.com/user-attachments/assets/15268ad6-e72c-4eb1-aa77-5cfc05f7156f" alt="FIXED" width="300"/>


Link to sample test page: https://foundation-s-tp1-2414-n-xcycxo.herokuapp.com/en/
Related PRs/issues: #13821

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2418)
