### PR TITLE
Refactor translation management

### DIFF
--- a/translation-management.sh
+++ b/translation-management.sh
@@ -54,24 +54,56 @@ case $command in
   "import")
     echogreen "Importing latest translation files from fomo-l10n repository"
     for FOLDER in "${FOLDERS[@]}"; do
+      # Step 1: Reset Django folder(s)
+      echoyellow "  Removing existing folder: ${CODE_REPO}${FOLDER}"
+      rm -rf "${CODE_REPO}${FOLDER}"
+
+      # Step 2: Copy l10n (source of truth) to Django
+      echoyellow "  Copying l10n folder: ${L10N_REPO}${FOLDER} into ${CODE_REPO}${FOLDER}"
       cp -r "${L10N_REPO}${FOLDER}" "${CODE_REPO}${FOLDER}"
 
-      # Django >=3.2 stopped processing locale codes containing hyphens, we need to move the files between the two folders
+      # Step 3: Remove stray underscore-locale dirs / symlinks (cleanup)
+      for HYPHEN_LOCALE in "${LOCALES[@]}"; do
+        UNDERSCORE="${CODE_REPO}${FOLDER}${HYPHEN_LOCALE//-/_}"
+        if [[ -e "$UNDERSCORE" ]]; then
+          echoyellow "  Removing stray underscore locale (usually symlinks): $UNDERSCORE"
+          rm -rf "$UNDERSCORE"
+        fi
+      done
+
+      # Step 4: Copy hyphenated → underscore for Django
       for HYPHEN_LOCALE in "${LOCALES[@]}"; do
         cp -r "${L10N_REPO}${FOLDER}${HYPHEN_LOCALE}/" "${CODE_REPO}${FOLDER}${HYPHEN_LOCALE//-/_}/"
       done
     done
+    ;;
 esac
 
 case $command in
   "export")
     echogreen "Exporting generated translation files to fomo-l10n repository"
     for FOLDER in "${FOLDERS[@]}"; do
-      cp -r "${CODE_REPO}${FOLDER}" "${L10N_REPO}${FOLDER}"
+      # Step 1: Reset l10n folder(s)
+      echoyellow "  Removing existing folder: ${L10N_REPO}${FOLDER}"
+      rm -rf "${L10N_REPO}${FOLDER}"
 
-      # Django >=3.2 stopped processing locale codes containing hyphens, we need to move the files between the two folders
+      # Step 2: Copy Django (new source of truth) to l10n
+      echoyellow "  Copying Django folder: ${CODE_REPO}${FOLDER} into ${L10N_REPO}${FOLDER}"
+      mkdir -p "${L10N_REPO}${FOLDER}"
+      cp -r "${CODE_REPO}${FOLDER}"* "${L10N_REPO}${FOLDER}"
+
+      # Step 3: Copy Django underscore dirs to l10n hyphen dirs for Pontoon (i.e. pt_BR in Django to pt-BR in l10n)
       for HYPHEN_LOCALE in "${LOCALES[@]}"; do
         cp -r "${CODE_REPO}${FOLDER}${HYPHEN_LOCALE//-/_}/" "${L10N_REPO}${FOLDER}${HYPHEN_LOCALE}/"
+
+        # Step 4: Remove underscore locale dirs in l10n since not needed in l10n repo (i.e. pt_BR)
+        UNDERSCORE_LOCALE_PATH="${L10N_REPO}${FOLDER}${HYPHEN_LOCALE//-/_}"
+        if [[ -e "$UNDERSCORE_LOCALE_PATH" ]]; then
+          echoyellow "  Removing underscore locale from l10n: $UNDERSCORE_LOCALE_PATH"
+          rm -rf "$UNDERSCORE_LOCALE_PATH"
+        fi
+      
       done
     done
+    ;;
 esac

--- a/translation-management.sh
+++ b/translation-management.sh
@@ -74,6 +74,14 @@ case $command in
       # Step 4: Copy hyphenated → underscore for Django
       for HYPHEN_LOCALE in "${LOCALES[@]}"; do
         cp -r "${L10N_REPO}${FOLDER}${HYPHEN_LOCALE}/" "${CODE_REPO}${FOLDER}${HYPHEN_LOCALE//-/_}/"
+
+        # Step 5: Remove hyphenated l10n dirs since not needed in Django repo (i.e. pt-BR)
+        HYPHEN_LOCALE_PATH="${CODE_REPO}${FOLDER}${HYPHEN_LOCALE}"
+        if [[ -e "$HYPHEN_LOCALE_PATH" ]]; then
+          echoyellow "  Removing hyphen locale from code repo: $HYPHEN_LOCALE_PATH"
+          rm -rf "$HYPHEN_LOCALE_PATH"
+        fi
+
       done
     done
     ;;


### PR DESCRIPTION
# Description

This PR will refactor the `translation-management.sh` script a bit. It adds in some clean-up steps / logging and moves away from symlink approach which is starting to error out with directories copying over to symlinks.

In summary:

1. `Import` will reset the code repo and treat l10n repo as source of truth, copying hyphen locales to underscore locales and then remove the hyphens (no longer needed in django)
2. `Export` will reset the l10n repo and treat the code repo strings as new source of truth, copying underscore locales to hypen locales and then remove the underscores (no longer needed in l10n repo)

Note: the first commit here will remove the symlinking, and it also caught a couple potential misconfigured exports in the l10n repo at:

- `foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale/pt_BR`
- `foundation/translations/networkapi/wagtailpages/templates/wagtailpages/pages/youtube-regrets-2022/locale/fy_NL`

It also creates new `pt` .po files with the `pt-BR` translations instead of symlinking to `pt-BR`. But will wait for feedback on if this is an issue or needs to be tweaked.

The review app linked below has staging data and so should showcase a full suite of contet & translations.

Related Issues: [TP1-2561](https://mozilla-hub.atlassian.net/browse/TP1-2561) / #13937
Link to review app: https://foundation-s-tp1-2561-1-pknhfm.herokuapp.com/fr/