### PR TITLE
Move wagtailcustomizations above wagtail

### DIFF
--- a/foundation_cms/settings/base.py
+++ b/foundation_cms/settings/base.py
@@ -213,6 +213,7 @@ INSTALLED_APPS = list(
             "django.contrib.redirects",
             "django.contrib.sitemaps",
             "django.contrib.humanize",
+            "foundation_cms.legacy_apps.wagtailcustomization",
             "wagtailmetadata",
             "wagtail.embeds",
             "wagtail.sites",
@@ -255,7 +256,6 @@ INSTALLED_APPS = list(
             "pattern_library" if PATTERN_LIBRARY_ENABLED else None,
             # the network site
             "foundation_cms.legacy_apps.s3_file_storage" if USE_S3 else None,
-            "foundation_cms.legacy_apps.wagtailcustomization",
             "foundation_cms.legacy_apps.campaign",
             "foundation_cms.legacy_apps.events",
             "foundation_cms.legacy_apps.news",


### PR DESCRIPTION
# Description

This PR will fix wagtailcustomizations [which must be above wagtail](https://docs.wagtail.org/en/stable/advanced_topics/customization/admin_templates.html#customizing-admin-templates).

# To Test
The custom wagtail templates will now load properly (i.e. custom login page, custom 404, etc.)