### PR TITLE
Remove old frontend volume from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
       - ./translation-management.sh:/app/translation-management.sh
 
       # Frontend config for legacy site
-      - ./frontend:/app/frontend
       - ./eslint.config.a11y.js:/app/eslint.config.a11y.js
       - ./eslint.config.js:/app/eslint.config.js
       - ./.editorconfig:/app/.editorconfig


### PR DESCRIPTION
# Description

This PR removes an old reference to the `frontend` volume that got carried over in the sync-up merge.

Will fix issue with build steps.

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2695)
