### PR TITLE
Fix newsletter signup block homepage

### DIFF
--- a/foundation_cms/templatetags/streamfield_tags.py
+++ b/foundation_cms/templatetags/streamfield_tags.py
@@ -9,5 +9,6 @@ def should_wrap_block(block_type):
     NO_WRAP_BLOCKS = {
         "spotlight_card_set_block",
         "title_block",
+        "newsletter_signup",
     }
     return block_type not in NO_WRAP_BLOCKS


### PR DESCRIPTION
# Description

This PR fixes the double `.grid-container` being applied to the `newsletter_signup` block, resulting in an extra 1rem padding on the sides of the component when rendered.

## Current state:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/8cabd581-82f3-485c-b376-aa5ae28de4b2" />

## Fixed state:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/dff756fd-2a38-4a9f-bea6-5ad2e45649f2" />

# To test

1. Clone the `fix-newsletter-signup-block-homepage` branch, run `inv setup`.
2. Create a new `newsletter_signup` snippet with the `expand_on_focus` variant selected.
3. Add a `Newsletter signup` block to the new Homepage, publish.
4. Check in the live page that the double `.grid-container` is no longer present.
