### PR TITLE
Homepage component fixes

### DIFF
--- a/foundation_cms/static/js/components/primary_nav.js
+++ b/foundation_cms/static/js/components/primary_nav.js
@@ -167,13 +167,14 @@ export function initPrimaryNav() {
  * Hides the navigation wordmark when the kinetic type wordmark is visible in the viewport.
  */
 export function initWordmarkVisibilityOnScroll() {
+  const nav = document.querySelector(SELECTORS.primaryNav);
   const grid = document.querySelector(SELECTORS.primaryNavGrid);
   const wordmark = document.querySelector(SELECTORS.wordmark);
   const kineticTypeWordmark = document.querySelector(
     SELECTORS.kineticTypeWordmark,
   );
 
-  if (!grid || !wordmark) return;
+  if (!nav || !grid || !wordmark) return;
 
   // If kineticTypeWordmark is not present, always show the wordmark
   if (!kineticTypeWordmark) {
@@ -181,6 +182,8 @@ export function initWordmarkVisibilityOnScroll() {
     grid.classList.remove(CLASSNAMES.hiddenWordmark);
     return;
   }
+
+  const navHeight = nav.offsetHeight;
 
   const observer = new IntersectionObserver(
     ([entry]) => {
@@ -194,6 +197,7 @@ export function initWordmarkVisibilityOnScroll() {
     },
     {
       root: null, // viewport
+      rootMargin: `-${navHeight}px  0px 0px 0px`,
       threshold: 0.01, // as soon as even 1% is visible/invisible
     },
   );

--- a/foundation_cms/static/scss/blocks/themes/default/featured_card_block.scss
+++ b/foundation_cms/static/scss/blocks/themes/default/featured_card_block.scss
@@ -55,10 +55,15 @@ body.redesign {
     &__content {
       display: flex;
       flex-direction: column;
+      gap: 1rem;
+
+      p {
+        margin: 0;
+      }
 
       @include breakpoint(large up) {
+        gap: 2rem;
         width: 50%;
-        gap: 1rem;
       }
     }
 

--- a/foundation_cms/static/scss/components/primary_nav.scss
+++ b/foundation_cms/static/scss/components/primary_nav.scss
@@ -295,7 +295,7 @@ $hamburger-bar-spacing: 0.8rem;
 body.primary-nav-ns-open {
   height: 100vh;
   overflow: hidden;
-  padding-top: 8rem;
+  padding-top: 5rem;
 
   .primary-nav-ns {
     position: fixed;

--- a/foundation_cms/static/scss/pages/home_page.scss
+++ b/foundation_cms/static/scss/pages/home_page.scss
@@ -10,3 +10,9 @@
 // Homepage Specific Components
 @import "../components/home_page/kinetic_type_wordmark";
 @import "../components/home_page/kinetic_type_brand_line";
+
+body.template-homepage {
+  .kinetic-type-wordmark {
+    margin-top: 3rem;
+  }
+}


### PR DESCRIPTION
# Description

This PR fixes various homepage issues:

## 1. Primary navigation wordmark scroll animation

With the current implementation the scroll animation wasn't triggered on sync when the `kinetic_type_wordmark` scrolled past the navigation bar but until it went over the document's top offset instead. Intersection Observer `rootMargin` property is now correctly calculated and set. This results in a really organic transition which looks and feels better and is less distracting in consequence.

### Current state
<img src="https://github.com/user-attachments/assets/a788b583-f246-4f65-819f-9caae067e3b7" width="650">
<img src="https://github.com/user-attachments/assets/5c05f907-c713-4b39-b01a-b6749f913f53" width="250">

*Current wrong offset `large` and `small` viewports layout wordmark scroll animation*

### Fixed state
<img src="https://github.com/user-attachments/assets/a751d3c5-c3ec-4bce-a780-31551f029a52" width="650">
<img src="https://github.com/user-attachments/assets/a9783a10-4296-44b1-bb6e-feb91ef88acf" width="250">

*Fixed offset `large` and `small` viewports layout wordmark scroll animation*

## 2. Mobile primary navigation layout shift

When the mobile nav menu open due to an outdated body padding value. This value was updated to allow blocks to be immediately positioned after the primary navigation bar in other page types. The spacing was restored by adding a custom rule to the `home_page.scss` stylesheet.

### Current state
<img src="https://github.com/user-attachments/assets/103f0537-1d26-45da-b405-92aabaa275fc" width="250">

### Fixed state
<img src="https://github.com/user-attachments/assets/8eb55da7-83f0-4130-a589-df7a7e186f54" width="250">

## 3. Explicit vertical spacing in the `featured_card_block`

For both `small` and `large` viewport layouts. Currently the visible space between elements is produced by the default paragraph `<p>` browser style, which is inconsistent with our grid (18px vs 16px) and could vary depending on browser implementation altering the component appearance.

### Current state

<img width="300" alt="image" src="https://github.com/user-attachments/assets/33880e2b-ab11-4d49-bfd6-631fcf86a1e9" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7cccfe17-3224-4b30-8c65-bbb6d917dae8" />

*1: No gap due to paragraph element not present. 2: Paragraph element present and rendering imprecise margins.*

### Fixed state

<img width="300" alt="image" src="https://github.com/user-attachments/assets/39c05700-af23-4eb2-b6d4-ece038589fc4" />

*Native `flexbox` gap*



Link to sample test page: https://foundation-s-fix-featur-df14el.herokuapp.com/en/
Related PRs/issues: #

┆Issue is synchronized with this [Jira Story](https://mozilla-hub.atlassian.net/browse/TP1-2935)
