### PR TITLE
Vertical alignment with icon text and input

### DIFF
--- a/foundation_cms/static/scss/components/newsletter_signup/newsletter_signup_form.scss
+++ b/foundation_cms/static/scss/components/newsletter_signup/newsletter_signup_form.scss
@@ -93,7 +93,7 @@
     }
   }
 
-  &__button {
+  &__button.btn-primary {
     margin: 0;
     width: 100%;
     line-height: 150%;


### PR DESCRIPTION
# Description

This PR fixes an unexpected margin being applied to the `newsletter_signup_form` component submit button, by increasing the specificity in the component style declaration.

## Current state
<img width="1438" height="149" alt="image" src="https://github.com/user-attachments/assets/90e866e9-7e48-467c-971f-d663fcf1a01d" />

## Fixed state
<img width="1437" height="117" alt="image" src="https://github.com/user-attachments/assets/711a80fc-9788-4167-a4fe-f165b311e0b9" />
<img width="533" height="150" alt="image" src="https://github.com/user-attachments/assets/2166fa26-efd0-457a-a59a-af64e9792309" />



Link to sample test page: https://foundation-s-tp1-2960-c-f6uurx.herokuapp.com/en/
Related PRs/issues: [Jira Ticket](https://mozilla-hub.atlassian.net/browse/TP1-2960)
