### PR TITLE
Added language code logic to mozfest page model

### DIFF
--- a/foundation_cms/legacy_apps/mozfest/models.py
+++ b/foundation_cms/legacy_apps/mozfest/models.py
@@ -22,7 +22,9 @@ from foundation_cms.legacy_apps.wagtailpages.pagemodels.customblocks.full_conten
     full_content_rich_text_options,
 )
 from foundation_cms.legacy_apps.wagtailpages.utils import (
+    get_language_from_request,
     get_page_tree_information,
+    map_language_code_to_tito_supported_language_code,
     set_main_site_nav_information,
 )
 
@@ -250,6 +252,9 @@ class MozfestPrimaryPage(FoundationMetadataPageMixin, FoundationBannerInheritanc
         context = super().get_context(request)
         context = set_main_site_nav_information(self, context, "MozfestHomepage")
         context = get_page_tree_information(self, context)
+
+        request_language_code = get_language_from_request(context["request"])
+        context["tito_widget_lang_code"] = map_language_code_to_tito_supported_language_code(request_language_code)
 
         # primary nav information
         context["menu_root"] = self

--- a/foundation_cms/legacy_apps/mozfest/templates/fragments/primary_cta.html
+++ b/foundation_cms/legacy_apps/mozfest/templates/fragments/primary_cta.html
@@ -1,5 +1,5 @@
 {% if root.nav_cta %}
     {% for block in root.nav_cta %}
-        {% include "wagtailpages/fragments/tito_button.html" with value=block.value request=request %}
+        {% include "wagtailpages/fragments/tito_button.html" with value=block.value %}
     {% endfor %}
 {% endif %}

--- a/foundation_cms/legacy_apps/mozfest/templates/mozfest/mozfest_homepage.html
+++ b/foundation_cms/legacy_apps/mozfest/templates/mozfest/mozfest_homepage.html
@@ -12,7 +12,7 @@
 {% block bodyclass %}mozfest {% if banner_video_type %}banner-type-{{ banner_video_type }}{% endif %}{% endblock bodyclass %}
 
 {% block hero_guts %}
-    {% include "partials/primary_hero.html" with page=page request=request %}
+    {% include "partials/primary_hero.html" with page=page %}
 {% endblock %}
 
 {% block bootstrap_width %}col-lg-12{% endblock bootstrap_width %}

--- a/foundation_cms/legacy_apps/mozfest/templates/partials/primary_hero.html
+++ b/foundation_cms/legacy_apps/mozfest/templates/partials/primary_hero.html
@@ -16,7 +16,7 @@
                     <p class="tw-body-large">{{ page.banner_text }}</p>
                 {% endif %}
                 {% if page.banner_cta %}
-                    {% include "wagtailpages/fragments/tito_button.html" with value=page.banner_cta.0.value request=request %}
+                    {% include "wagtailpages/fragments/tito_button.html" with value=page.banner_cta.0.value %}
                 {% endif %}
 
             </div>


### PR DESCRIPTION
This PR updates the Mozfest Primary page model to add the "tito language code" variable to the templates context. That way the tito button can render in the appropriate locale when applicable. 

This PR also removes the request variable from the `tito_button.html` template as it is not needed.