### PR TITLE
Fix inconsistency in homepage vs other pages streamblock wrapping.

### DIFF
--- a/foundation_cms/templates/patterns/pages/core/general_page.html
+++ b/foundation_cms/templates/patterns/pages/core/general_page.html
@@ -8,7 +8,9 @@
                 {% include "patterns/components/hero.html" %}
             {% endif %}
             <div class="container">
-                {{ page.body }}
+                {% if page.body %}
+                    {% include "patterns/components/streamfield.html" with streamfield=page.body %}
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Description

This PR fixes the inconsistency in how body content blocks are wrapped in the `General page` template, so that a `.grid-container` is added when the block renders, just like the homepage. This will result in components being displayed within the container unless they are listed under the `should_wrap_block` filter exceptions.

## Current state

<img width="1870" height="1519" alt="image" src="https://github.com/user-attachments/assets/67079da4-e6cc-45dd-83f1-d73230c4af6c" />

*Blocks bleed into the viewport full width.*

## Fixed state

<img width="1874" height="1539" alt="image" src="https://github.com/user-attachments/assets/b6d3e95a-68eb-4877-8fa9-a797d889c036" />

*Block is wrapped in a `.grid-container` element that constrains width to grid.*


Link to sample test page: https://foundation-s-fix-genera-avwhkq.herokuapp.com/en/general-test-page/
Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-3001)