### PR TITLE
Updated `GeneralPage` field panel order

### DIFF
--- a/foundation_cms/core/models/general_page.py
+++ b/foundation_cms/core/models/general_page.py
@@ -67,7 +67,8 @@ class GeneralPage(AbstractGeneralPage):
         blank=True,
     )
 
-    content_panels = AbstractGeneralPage.content_panels + [
+    content_panels = [
+        FieldPanel("title"),
         MultiFieldPanel(
             [
                 FieldPanel("show_hero"),
@@ -82,6 +83,7 @@ class GeneralPage(AbstractGeneralPage):
         ),
         FieldPanel("button_title"),
         FieldPanel("button_url"),
+        FieldPanel("body"),
     ]
 
     translatable_fields = [


### PR DESCRIPTION
# Description

This PR updates the ordering of the GeneralPage's fields so the `body` field gets rendered underneath the hero section fields.

# Screenshots

Before:
<img width="2160" height="3394" alt="Screenshot 2025-07-23 at 17-13-03 New General Page (new) - Wagtail" src="https://github.com/user-attachments/assets/0eee6238-c0d0-43fa-8ec9-209336bd6024" />

After:
<img width="2160" height="3394" alt="Screenshot 2025-07-23 at 17-11-56 New General Page (new) - Wagtail" src="https://github.com/user-attachments/assets/cf4b7d64-62b7-4fef-a49d-ea271cec14ce" />
