### PR TITLE
Swap portrait card colors, add min height for label

### DIFF
--- a/foundation_cms/static/scss/blocks/themes/default/portrait_card_set.scss
+++ b/foundation_cms/static/scss/blocks/themes/default/portrait_card_set.scss
@@ -18,8 +18,8 @@ $carousel-transition: transform 0.3s ease;
   $cardset-colors: (
     1: color(blue, "300"),
     2: color(yellow, "300"),
-    3: color(orange, "200"),
-    4: color(green, "300"),
+    3: color(green, "300"),
+    4: color(orange, "200"),
   );
 
   @include breakpoint(large up) {
@@ -132,6 +132,7 @@ $carousel-transition: transform 0.3s ease;
 
     &__label {
       margin-top: 1.9rem;
+      min-height: 1rem;
     }
 
     &__headline {

--- a/foundation_cms/templates/patterns/blocks/themes/default/portrait_card.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/portrait_card.html
@@ -9,9 +9,7 @@
 {% endif %}
 
 <div class="portrait-card__text">
-  {% if card.label %}
-    <p class="portrait-card__label label-text-regular">{{ card.label }}</p>
-  {% endif %}
+  <p class="portrait-card__label label-text-regular">{{ card.label }}</p>
   <h4 class="portrait-card__headline">
     {{ card.headline }}
   </h4>


### PR DESCRIPTION
# Description

This PR addresses spacing issues to ensure adequate spacing if label exists or not and swaps the 3rd and 4th colors.

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
