### PR TITLE
Fix link index reference in tabbed content card image link tag

### DIFF
--- a/foundation_cms/templates/patterns/blocks/themes/default/tabbed_content_card_set_block.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/tabbed_content_card_set_block.html
@@ -4,7 +4,7 @@
     <div class="tab-card__image">
         {% image value.image fill-500x500 as img %}
         {% if value.link %}
-            <a href="{{ value.link.url }}">
+            <a href="{{ value.link.0.url }}">
                 <img src="{{ img.url }}" height="{{ img.height }}" width="{{ img.width }}" alt="{{ value.title }}">
             </a>
         {% else %}


### PR DESCRIPTION
# Description

This PR fixes the broken links in the tabbed content card set block by updating the link field index reference in the link template parameter of the link tab.

<img width="441" height="636" alt="image" src="https://github.com/user-attachments/assets/8e51fcb7-a1a8-403d-b3b9-4c1d3821f450" />

*Link correctly rendering as reflected in statusbar*

## To test

1. Open the [test page](https://foundation-s-tp1-3054-q-ob4och.herokuapp.com/en/tabbed-content-test-page/).
2. Click the tabbed content card block image and link block, both should point to the target test page.

Link to sample test page: https://foundation-s-tp1-3054-q-ob4och.herokuapp.com/en/tabbed-content-test-page/
Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-3054)
