### PR TITLE
Update page width calculation for tabbed content card set block

### DIFF
--- a/foundation_cms/static/js/blocks/tabbed_content_container.js
+++ b/foundation_cms/static/js/blocks/tabbed_content_container.js
@@ -102,7 +102,8 @@ export function initTabbedContentCardSets() {
     let currentPageIndex = 0;
     const initialScrollLeft = panel.scrollLeft;
     const firstPage = panel.querySelector(`.${CLASSNAMES.tabCardPage}`);
-    const pageWidth = firstPage ? firstPage.clientWidth : 0;
+    const gap = parseInt(window.getComputedStyle(panel).gap || "0", 10);
+    const pageWidth = firstPage ? firstPage.clientWidth + gap : 0;
 
     if (initialScrollLeft > 0) {
       currentPageIndex = Math.floor(initialScrollLeft / pageWidth);
@@ -113,7 +114,7 @@ export function initTabbedContentCardSets() {
       if (currentPageIndex < pages - 1) {
         currentPageIndex++;
         panel.scrollTo({
-          left: panel.clientWidth * currentPageIndex,
+          left: pageWidth * currentPageIndex,
           behavior: "smooth",
         });
         currentPage.textContent = `${currentPageIndex + 1} / ${pages}`;
@@ -124,7 +125,7 @@ export function initTabbedContentCardSets() {
       if (currentPageIndex > 0) {
         currentPageIndex--;
         panel.scrollTo({
-          left: panel.clientWidth * currentPageIndex,
+          left: pageWidth * currentPageIndex,
           behavior: "smooth",
         });
         currentPage.textContent = `${currentPageIndex + 1} / ${pages}`;


### PR DESCRIPTION
# Description

This PR fixes the incorrect page width calculation in `tabbed_content_card_set_block` for `small` viewports, by including the gap in the total page width allowing multiple pages to scroll accurately.

## Current state

<img width="428" height="883" alt="image" src="https://github.com/user-attachments/assets/6fd6d4ad-0580-45a8-b0e1-6fdc23036f68" />

## Fixed state

<img width="429" height="760" alt="image" src="https://github.com/user-attachments/assets/adfb6301-972f-4310-a833-47f690571d6d" />



Link to sample test page: https://foundation-s-fix-tabbed-mmxuia.herokuapp.com/en/tabbed-content-test-page/
Related PRs/issues: Jira ticket