### PR TITLE
Fix alt text bug in `image_block.html`

### DIFF
--- a/foundation_cms/templates/patterns/blocks/themes/default/image_block.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/image_block.html
@@ -3,7 +3,7 @@
     <div class="image-block image-block--{{ value.orientation }}">
         {% image value.image width-600 as img %}
         <img src="{{ img.url }}"
-             alt="{{ value.title }}"
+             alt="{{ img.alt }}"
              height="{{ img.height }}"
              width="{{ img.width }}"
              class="image-block__image">


### PR DESCRIPTION
# Description

This PR fixes a bug in `image_block.html` that caused alt text to not render correctly for many images. 

<!-- Describe the PR here -->

Link to sample test page:
Related PRs/issues: [Jira Ticket TP1-3052](https://mozilla-hub.atlassian.net/browse/TP1-3052)
