### PR TITLE
Refactor topic pill button related code

### DIFF
--- a/foundation_cms/static/scss/buttons.scss
+++ b/foundation_cms/static/scss/buttons.scss
@@ -283,6 +283,8 @@ a.btn-topic {
   @include topic-pill-button-shape;
 
   cursor: pointer;
+  color: map.get($mofo-colors, black);
+  text-decoration: none;
 
   &:hover {
     background: color(orange, "200");

--- a/foundation_cms/static/scss/components/topic_pills.scss
+++ b/foundation_cms/static/scss/components/topic_pills.scss
@@ -14,7 +14,7 @@
 }
 
 ul.topic-pills {
-  @include topic-pills-container();
+  @include topic-pills-container;
 
   &--tight {
     @include topic-pills-container(8);

--- a/foundation_cms/static/scss/components/topic_pills.scss
+++ b/foundation_cms/static/scss/components/topic_pills.scss
@@ -1,0 +1,24 @@
+// ===================================
+// Topic Pills Container
+// ===================================
+
+@mixin topic-pills-container($gap-size-in-px: 12) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: rem-calc($gap-size-in-px);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    display: inline-block;
+  }
+}
+
+ul.topic-pills {
+  @include topic-pills-container();
+
+  &--tight {
+    @include topic-pills-container(8);
+  }
+}

--- a/foundation_cms/static/scss/components/topic_pills.scss
+++ b/foundation_cms/static/scss/components/topic_pills.scss
@@ -1,6 +1,6 @@
 // Displays topic pill buttons side-by-side with wrapping support for responsive layouts.
 // Creates a horizontal list container for topic pill buttons
-@mixin topic-pills-container($gap-size-in-px: 12) {
+@mixin topic-pills-container($gap-size-in-px: 8) {
   display: flex;
   flex-wrap: wrap;
   gap: rem-calc($gap-size-in-px);
@@ -16,7 +16,7 @@
 ul.topic-pills {
   @include topic-pills-container;
 
-  &--tight {
-    @include topic-pills-container(8);
+  &--loose {
+    @include topic-pills-container(12);
   }
 }

--- a/foundation_cms/static/scss/components/topic_pills.scss
+++ b/foundation_cms/static/scss/components/topic_pills.scss
@@ -1,7 +1,5 @@
-// ===================================
-// Topic Pills Container
-// ===================================
-
+// Displays topic pill buttons side-by-side with wrapping support for responsive layouts.
+// Creates a horizontal list container for topic pill buttons
 @mixin topic-pills-container($gap-size-in-px: 12) {
   display: flex;
   flex-wrap: wrap;

--- a/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
@@ -73,23 +73,6 @@ body.nothing-personal.nothing-personal-article-page {
       text-transform: uppercase;
       margin: 0 0 0.5rem;
     }
-
-    ul {
-      display: flex;
-      flex-wrap: wrap;
-      gap: rem-calc(8);
-      margin: 0;
-      padding: 0;
-
-      li {
-        display: inline-block;
-      }
-    }
-
-    a {
-      color: map.get($mofo-colors, black);
-      text-decoration: none;
-    }
   }
 
   .author-info {

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -31,23 +31,6 @@ body.nothing-personal.nothing-personal-podcast-page {
     &__topics {
       width: fit-content;
       margin: 2rem 0;
-
-      ul {
-        display: flex;
-        flex-wrap: wrap;
-        gap: rem-calc(8);
-        margin: 0;
-        padding: 0;
-
-        li {
-          display: inline-block;
-        }
-      }
-
-      a {
-        color: map.get($mofo-colors, black);
-        text-decoration: none;
-      }
     }
 
     &__image {

--- a/foundation_cms/static/scss/pages/topic_listing_page.scss
+++ b/foundation_cms/static/scss/pages/topic_listing_page.scss
@@ -100,21 +100,6 @@ body.topic-listing-page {
 
     &__tags {
       margin: 1.5rem 0 1rem;
-
-      ul {
-        display: flex;
-        flex-wrap: wrap;
-        gap: rem-calc(8);
-
-        li {
-          display: inline-block;
-        }
-      }
-
-      a {
-        color: map.get($mofo-colors, black);
-        text-decoration: none;
-      }
     }
 
     &__title {

--- a/foundation_cms/static/scss/redesign_main.scss
+++ b/foundation_cms/static/scss/redesign_main.scss
@@ -34,6 +34,7 @@
 @import "../scss/components/footer";
 @import "../scss/components/newsletter_signup/newsletter_signup_form";
 @import "../scss/components/share-container";
+@import "../scss/components/topic_pills";
 @import "../scss/components/back_to_top";
 
 // Embed/widget overrides

--- a/foundation_cms/templates/patterns/components/topic_listing/item.html
+++ b/foundation_cms/templates/patterns/components/topic_listing/item.html
@@ -25,15 +25,7 @@
     <div class="cell small-12 medium-7 topic-card__meta-wrapper">
       <div class="topic-card__meta">
         <div class="topic-card__tags">
-          {% with topics=page.topics.all %}
-            {% if topics %}
-              <ul>
-                {% for topic in topics %}
-                  <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
-                {% endfor %}
-              </ul>
-            {% endif %}
-          {% endwith %}
+          {% include "patterns/components/topic_pills.html" with topics=page.topics.all style_variation="tight" %}
         </div>
         <h3 class="topic-card__title"><a href="{{ page.url }}">{{ page.title }}</a></h3>
         <p class="topic-card__description">{{ page.search_description }}</p>

--- a/foundation_cms/templates/patterns/components/topic_listing/item.html
+++ b/foundation_cms/templates/patterns/components/topic_listing/item.html
@@ -25,7 +25,7 @@
     <div class="cell small-12 medium-7 topic-card__meta-wrapper">
       <div class="topic-card__meta">
         <div class="topic-card__tags">
-          {% include "patterns/components/topic_pills.html" with topics=page.topics.all style_variation="tight" %}
+          {% include "patterns/components/topic_pills.html" with topics=page.topics.all %}
         </div>
         <h3 class="topic-card__title"><a href="{{ page.url }}">{{ page.title }}</a></h3>
         <p class="topic-card__description">{{ page.search_description }}</p>

--- a/foundation_cms/templates/patterns/components/topic_pills.html
+++ b/foundation_cms/templates/patterns/components/topic_pills.html
@@ -1,7 +1,7 @@
 {% if topics %}
-<ul class="topic-pills {% if style_variation %}topic-pills--{{ style_variation }}{% endif %}">
-{% for topic in topics %}
-    <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
-{% endfor %}
-</ul>
+    <ul class="topic-pills {% if style_variation %}topic-pills--{{ style_variation }}{% endif %}">
+        {% for topic in topics %}
+            <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
+        {% endfor %}
+    </ul>
 {% endif %}

--- a/foundation_cms/templates/patterns/components/topic_pills.html
+++ b/foundation_cms/templates/patterns/components/topic_pills.html
@@ -1,0 +1,7 @@
+{% if topics %}
+<ul class="topic-pills {% if style_variation %}topic-pills--{{style_variation}}{% endif %}">
+{% for topic in topics %}
+    <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
+{% endfor %}
+</ul>
+{% endif %}

--- a/foundation_cms/templates/patterns/components/topic_pills.html
+++ b/foundation_cms/templates/patterns/components/topic_pills.html
@@ -1,5 +1,5 @@
 {% if topics %}
-<ul class="topic-pills {% if style_variation %}topic-pills--{{style_variation}}{% endif %}">
+<ul class="topic-pills {% if style_variation %}topic-pills--{{ style_variation }}{% endif %}">
 {% for topic in topics %}
     <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
 {% endfor %}

--- a/foundation_cms/templates/patterns/pages/nothing_personal/article_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/article_page.html
@@ -36,12 +36,8 @@
                             {% with topics=page.topics.all %}
                                 {% if topics %}
                                     <div class="article-topics__title">Topics</div>
-                                    <ul>
-                                        {% for topic in topics %}
-                                            <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
-                                        {% endfor %}
-                                    </ul>
                                 {% endif %}
+                                {% include "patterns/components/topic_pills.html" with topics=page.topics.all %}
                             {% endwith %}
                         </div>
                         {% if page.author %}

--- a/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
@@ -15,13 +15,7 @@
                         <div class="hero__title">{{ page.hero_title }}</div>
                         <div class="hero__topics">
                             {% with topics=page.topics.all %}
-                                {% if topics %}
-                                    <ul>
-                                        {% for topic in topics %}
-                                            <li><a class="btn-topic" href="{{ topic.get_topic_listing_url }}">{{ topic.name }}</a></li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
+                                {% include "patterns/components/topic_pills.html" with topics=page.topics.all %}
                             {% endwith %}
                         </div>
                         <div class="hero__description lede-text">{{ page.hero_description }}</div>

--- a/foundation_cms/templates/patterns/pages/nothing_personal/product_review_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/product_review_page.html
@@ -13,7 +13,7 @@
                 <div class="grid-x">
                     <div class="cell small-12 medium-7">
                         {% with topics=page.topics.all %}
-                            {% include "patterns/components/topic_pills.html" with topics=page.topics.all %}
+                            {% include "patterns/components/topic_pills.html" with topics=page.topics.all style_variation="loose" %}
                         {% endwith %}
                         <h1>{{ page.title }}</h1>
                         <div>{{ page.updated }} | {{ page.reviewed }} | {{ page.research }}</div>

--- a/foundation_cms/templates/patterns/pages/nothing_personal/product_review_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/product_review_page.html
@@ -12,7 +12,9 @@
             <div class="grid-container">
                 <div class="grid-x">
                     <div class="cell small-12 medium-7">
-                        <div>[Topic Tag Pills]</div>
+                        {% with topics=page.topics.all %}
+                            {% include "patterns/components/topic_pills.html" with topics=page.topics.all %}
+                        {% endwith %}
                         <h1>{{ page.title }}</h1>
                         <div>{{ page.updated }} | {{ page.reviewed }} | {{ page.research }}</div>
                         <div>{{ page.lede_text }}</div>


### PR DESCRIPTION
Refactor topic pill button related code so it's more reusable

- extract the code to its own fragment template and SCSS file
- update existing code to use the new refactored component

--- 
Link to sample test page:
Related PRs/issues: [Jira #TP1-2521 - Topic Tag Pill](https://mozilla-hub.atlassian.net/browse/TP1-2521)

---

## To Review

CMS Login: `admin` / `BM2W*lXgY(ug9b4X`
Pages to review:
- [NP product review page](https://foundation-s-tp1-3159-n-mcsaxj.herokuapp.com/en/nothing-personal/np-product-review/)
- [NP postcast page](https://foundation-s-tp1-3159-n-mcsaxj.herokuapp.com/en/nothing-personal/np-podcast-page/)
- [NP Article Page](https://foundation-s-tp1-3159-n-mcsaxj.herokuapp.com/en/nothing-personal/np-article-page/)
- [Topic listing page](https://foundation-s-tp1-3159-n-mcsaxj.herokuapp.com/en/nothing-personal/topics/test/)
