### PR TITLE
Updated abstract pages `translatablefields`

### DIFF
--- a/foundation_cms/base/models/abstract_article_page.py
+++ b/foundation_cms/base/models/abstract_article_page.py
@@ -31,7 +31,6 @@ class AbstractArticlePage(AbstractBasePage):
     translatable_fields = AbstractBasePage.translatable_fields + [
         # Content tab fields
         TranslatableField("lede_text"),
-        TranslatableField("body"),
     ]
 
     class Meta:

--- a/foundation_cms/base/models/abstract_base_page.py
+++ b/foundation_cms/base/models/abstract_base_page.py
@@ -165,7 +165,6 @@ class AbstractBasePage(FoundationMetadataPageMixin, Page):
         SynchronizedField("author"),
         SynchronizedField("topics"),
         # Content tab fields
-        TranslatableField("body"),
         TranslatableField("title"),
         # Settings tab fields
         SynchronizedField("theme"),


### PR DESCRIPTION
# Description

The field `body` used to be set as a translatable field on the abstract page models, however, this is not best practice. The reason being is that sometimes pages can overwrite the body field to be `None`, a good example would be the `NothingPersonalProductReview` page. When that is done, an attempt to translate a product review page will be met with a 500 error saying that the page model has no field `body`, yet, since this has been assigned as a translatable field on the models that it inherits from, it is still looking for it! 

Ive removed the field from the abstract page models, as more concrete models such as `ArticlePage`, etc, should be defining it in their translatable fields anyways. 