### PR TITLE
Update podcast page to match Simplecast embed width(desktop and tablet)

### DIFF
--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -11,6 +11,13 @@ body.nothing-personal.nothing-personal-podcast-page {
     }
   }
 
+  a {
+    @include link-text-color(
+      map.get($mofo-colors, black),
+      color(orange, "600")
+    );
+  }
+
   .hero {
     margin: 2rem 0;
 

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -11,13 +11,6 @@ body.nothing-personal.nothing-personal-podcast-page {
     }
   }
 
-  main a {
-    @include link-text-color(
-      map.get($mofo-colors, black),
-      color(orange, "600")
-    );
-  }
-
   .hero {
     margin: 2rem 0;
 
@@ -65,6 +58,14 @@ body.nothing-personal.nothing-personal-podcast-page {
         gap: 0;
       }
     }
+  }
+
+  .rich-text-block a,
+  .podcast-block a {
+    @include link-text-color(
+      map.get($mofo-colors, black),
+      color(orange, "600")
+    );
   }
 
   .podcast-block {

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -63,9 +63,6 @@ body.nothing-personal.nothing-personal-podcast-page {
   .podcast-block {
     margin-bottom: 1.5rem;
 
-    @include breakpoint(medium up) {
-    }
-
     iframe {
       display: block;
     }

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -80,4 +80,10 @@ body.nothing-personal.nothing-personal-podcast-page {
       margin-bottom: 0;
     }
   }
+
+  .cell.large-8:has(.two-column-container) {
+    @include breakpoint(large up) {
+      width: 100%;
+    }
+  }
 }

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -64,7 +64,6 @@ body.nothing-personal.nothing-personal-podcast-page {
     margin-bottom: 1.5rem;
 
     @include breakpoint(medium up) {
-      width: math.div(2, 3) * 100%;
     }
 
     iframe {

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -11,7 +11,7 @@ body.nothing-personal.nothing-personal-podcast-page {
     }
   }
 
-  a {
+  main a {
     @include link-text-color(
       map.get($mofo-colors, black),
       color(orange, "600")

--- a/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
@@ -33,7 +33,7 @@
             </div>
         </div>
         {% if page.body %}
-            {% include "patterns/components/streamfield.html" with streamfield=page.body %}
+            {% include "patterns/components/streamfield.html" with streamfield=page.body classnames="small-12 large-8"%}
         {% endif %}
     </main>
 {% endblock content %}

--- a/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
@@ -33,7 +33,7 @@
             </div>
         </div>
         {% if page.body %}
-            {% include "patterns/components/streamfield.html" with streamfield=page.body classnames="small-12 large-8"%}
+            {% include "patterns/components/streamfield.html" with streamfield=page.body classnames="small-12 large-8" %}
         {% endif %}
     </main>
 {% endblock content %}


### PR DESCRIPTION
# Description

This PR is to update the Podcast page so that the content has the same width for desktop, tablet, and mobile.

Main changes:
- Adjust the streamblock limit in the grid
- Update block styles

<img width="1121" height="2000" alt="image" src="https://github.com/user-attachments/assets/8c8229c8-9a2b-405e-9606-7acf8eade958" />

Podcast Page - Test: https://foundation-s-tp1-3255-c-dy9oke.herokuapp.com/en/nothing-personal/irl-podcast-season-8/
Review app: https://foundation-s-tp1-3255-c-dy9oke.herokuapp.com/cms/pages/450/edit/
CMS credentials: 
```
Login: admin
Password: i%Xwn1cj&y1l6sAG
```

Related PRs/issues: https://mozilla-hub.atlassian.net/browse/TP1-3255