### PR TITLE
Fix webp support in hero media instances

### DIFF
--- a/foundation_cms/static/scss/blocks/themes/default/media_block.scss
+++ b/foundation_cms/static/scss/blocks/themes/default/media_block.scss
@@ -7,8 +7,10 @@
   &__image,
   &__video {
     width: 100%;
+    height: 100%;
     border-bottom-left-radius: 2rem;
     object-fit: cover;
+    object-position: center;
     display: block;
   }
 

--- a/foundation_cms/static/scss/blocks/themes/default/product_review_card_block.scss
+++ b/foundation_cms/static/scss/blocks/themes/default/product_review_card_block.scss
@@ -9,11 +9,16 @@
   }
 
   &__image-container {
+    // Default to 2:3 portrait aspect ratio (matches 192x288 rendition)
+    aspect-ratio: math.div(2, 3);
+    overflow: hidden;
+
     img {
       width: 100%;
-      height: auto;
+      height: 100%;
       display: block;
       object-fit: cover;
+      object-position: center;
     }
   }
 
@@ -25,7 +30,7 @@
   }
 
   &--square {
-    img {
+    .product-review-card__image-container {
       aspect-ratio: math.div(1, 1);
     }
   }

--- a/foundation_cms/static/scss/pages/nothing_personal/home_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/home_page.scss
@@ -53,7 +53,9 @@ body.nothing-personal-home-page {
       img {
         display: block;
         width: 100%;
+        height: 100%;
         object-fit: cover;
+        object-position: center;
       }
     }
 
@@ -158,6 +160,8 @@ body.nothing-personal-home-page {
       img {
         object-fit: cover;
         width: 100%;
+        height: 100%;
+        object-position: center;
       }
 
       video {
@@ -168,6 +172,18 @@ body.nothing-personal-home-page {
       img,
       video {
         transition: transform 0.5s ease;
+      }
+    }
+
+    &__picture {
+      display: contents;
+
+      img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
       }
     }
 

--- a/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/podcast_page.scss
@@ -35,6 +35,16 @@ body.nothing-personal.nothing-personal-podcast-page {
 
     &__image {
       border-radius: 0 100px 0 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+    }
+
+    &__media {
+      aspect-ratio: math.div(1, 1);
+      overflow: hidden;
+      display: flex;
     }
 
     &__divider {

--- a/foundation_cms/static/scss/pages/nothing_personal/product_review_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/product_review_page.scss
@@ -60,14 +60,20 @@ body.nothing-personal.nothing-personal-product-review-page {
     }
 
     &__product-img {
+      aspect-ratio: math.div(2, 3);
+      overflow: hidden;
+      margin-bottom: 4rem;
+
+      @include breakpoint(large up) {
+        margin-bottom: 0;
+      }
+
       img {
         width: 100%;
-        height: auto;
-        margin-bottom: 4rem;
-
-        @include breakpoint(large up) {
-          margin-bottom: 0;
-        }
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+        display: block;
       }
     }
 

--- a/foundation_cms/templates/patterns/blocks/themes/default/media_block.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/media_block.html
@@ -1,18 +1,26 @@
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags responsive_image_tags %}
 {% if value.orientation %}
     <div class="media-block media-block--{{ value.orientation }}">
         {% if link %}
             <a href="{{ link.0.url }}" class="media-block__link" {% if link.0.target %} target="{{ link.0.target }}"{% endif %}>
         {% endif %}
         {% if value.content == "image" and value.image %}
-            {% image value.image width-600 as img_1x %}
-            {% image value.image width-1200 as img_2x %}
-            <img src="{{ img_1x.url }}"
-                 srcset="{{ img_1x.url }} 1x, {{ img_2x.url }} 2x"
-                 alt="{{ img_1x.alt }}"
-                 height="{{ img_1x.height }}"
-                 width="{{ img_1x.width }}"
-                 class="media-block__image">
+            {% if value.image|is_webp %}
+                <img src="{{ value.image.file.url }}"
+                     alt="{{ value.image.title }}"
+                     height="{{ value.image.height }}"
+                     width="{{ value.image.width }}"
+                     class="media-block__image">
+            {% else %}
+                {% image value.image width-600 as img_1x %}
+                {% image value.image width-1200 as img_2x %}
+                <img src="{{ img_1x.url }}"
+                     srcset="{{ img_1x.url }} 1x, {{ img_2x.url }} 2x"
+                     alt="{{ img_1x.alt }}"
+                     height="{{ img_1x.height }}"
+                     width="{{ img_1x.width }}"
+                     class="media-block__image">
+            {% endif %}
 
         {% elif value.content == "video" and value.video_url %}
             <video class="media-block__video" playsinline="" muted="" loop="" preload="" autoplay>

--- a/foundation_cms/templates/patterns/blocks/themes/default/product_review_card_block.html
+++ b/foundation_cms/templates/patterns/blocks/themes/default/product_review_card_block.html
@@ -1,18 +1,26 @@
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags responsive_image_tags %}
 
 {% with page=self.product_review %}
     <div class="product-review-card{% if orientation %} product-review-card--{{ orientation }}{% else %} product-review-card--portrait{% endif %}">
         <a href="{{ page.url }}">
             {% if page.hero_image %}
                 <div class="product-review-card__image-container">
-                    {% image page.hero_image fill-192x288 as img_1x %}
-                    {% image page.hero_image fill-384x576 as img_2x %}
-                    <img src="{{ img_1x.url }}"
-                         srcset="{{ img_1x.url }} 1x, {{ img_2x.url }} 2x"
-                         alt="{{ page.hero_image_alt_text }}"
-                         class="product-review-card__image"
-                         width="{{ img_1x.width }}"
-                         height="{{ img_1x.height }}">
+                    {% if page.hero_image|is_webp %}
+                        <img src="{{ page.hero_image.file.url }}"
+                             alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
+                             class="product-review-card__image"
+                             width="{{ page.hero_image.width }}"
+                             height="{{ page.hero_image.height }}">
+                    {% else %}
+                        {% image page.hero_image fill-192x288 as img_1x %}
+                        {% image page.hero_image fill-384x576 as img_2x %}
+                        <img src="{{ img_1x.url }}"
+                             srcset="{{ img_1x.url }} 1x, {{ img_2x.url }} 2x"
+                             alt="{{ page.hero_image_alt_text }}"
+                             class="product-review-card__image"
+                             width="{{ img_1x.width }}"
+                             height="{{ img_1x.height }}">
+                    {% endif %}
                 </div>
             {% endif %}
             <div class="product-review-card__title">{{ page.title }}</div>

--- a/foundation_cms/templates/patterns/components/hero.html
+++ b/foundation_cms/templates/patterns/components/hero.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags responsive_image_tags %}
 
 <div class="hero__wrapper hero__wrapper--{{ page.hero_variant }} hero__wrapper--{{ page.hero_background_color }}">
 
@@ -26,10 +26,16 @@
         </div>
 
         {% if page.hero_image %}
-          {% image page.hero_image fill-692x692 as img %}
-          <div class="hero__media">
-            <img src="{{ img.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ img.width }}" height="{{ img.height }}" class="hero__media-image">
-          </div>
+          {% if page.hero_image|is_webp %}
+            <div class="hero__media">
+              <img src="{{ page.hero_image.file.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ page.hero_image.width }}" height="{{ page.hero_image.height }}" class="hero__media-image">
+            </div>
+          {% else %}
+            {% image page.hero_image fill-692x692 as img %}
+            <div class="hero__media">
+              <img src="{{ img.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ img.width }}" height="{{ img.height }}" class="hero__media-image">
+            </div>
+          {% endif %}
         {% endif %}
 
       </div>
@@ -58,12 +64,20 @@
       </div>
 
       {% if page.hero_image %}
-        {% image page.hero_image fill-1408x791 as img %}
-        <div class="grid-container">
-          <div class="hero__media">
-            <img src="{{ img.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ img.width }}" height="{{ img.height }}" class="hero__media-image">
+        {% if page.hero_image|is_webp %}
+          <div class="grid-container">
+            <div class="hero__media">
+              <img src="{{ page.hero_image.file.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ page.hero_image.width }}" height="{{ page.hero_image.height }}" class="hero__media-image">
+            </div>
           </div>
-        </div>
+        {% else %}
+          {% image page.hero_image fill-1408x791 as img %}
+          <div class="grid-container">
+            <div class="hero__media">
+              <img src="{{ img.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ img.width }}" height="{{ img.height }}" class="hero__media-image">
+            </div>
+          </div>
+        {% endif %}
       {% endif %}
 
     </div>

--- a/foundation_cms/templates/patterns/components/nothing_personal/article_page_header.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/article_page_header.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags static %}
+{% load wagtailimages_tags static responsive_image_tags %}
 
 <div class="article-header grid-x">
   <header class="article-header__meta cell small-12 medium-10 medium-offset-1 large-8">
@@ -15,24 +15,35 @@
           <source src="{{ page.hero_video_url }}" type="video/mp4">
         </video>
       {% elif page.displayed_hero_content == "image" and page.hero_image %}
-        <picture class="article-header__picture">
-          {% image page.hero_image fill-1172x660 as img_small %}
-          {% image page.hero_image fill-2198x1236 as img_large %}
-          <source
-            media="(max-width: 639px)"
-            srcset="{{ img_small.url }}"
-            width="{{ img_small.width }}"
-            height="{{ img_small.height }}"
-          >
+        {% if page.hero_image|is_webp %}
           <img
             class="article-header__hero-content"
-            src="{{ img_large.url }}"
-            width="{{ img_large.width }}"
-            height="{{ img_large.height }}"
+            src="{{ page.hero_image.file.url }}"
+            width="{{ page.hero_image.width }}"
+            height="{{ page.hero_image.height }}"
             alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
             loading="lazy"
           >
-        </picture>
+        {% else %}
+          <picture class="article-header__picture">
+            {% image page.hero_image fill-1172x660 as img_small %}
+            {% image page.hero_image fill-2198x1236 as img_large %}
+            <source
+              media="(max-width: 639px)"
+              srcset="{{ img_small.url }}"
+              width="{{ img_small.width }}"
+              height="{{ img_small.height }}"
+            >
+            <img
+              class="article-header__hero-content"
+              src="{{ img_large.url }}"
+              width="{{ img_large.width }}"
+              height="{{ img_large.height }}"
+              alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
+              loading="lazy"
+            >
+          </picture>
+        {% endif %}
       {% endif %}
     </figure>
   </div>

--- a/foundation_cms/templates/patterns/components/nothing_personal/home_page/featured_items.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/home_page/featured_items.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags i18n l10n %}
+{% load wagtailimages_tags i18n l10n responsive_image_tags %}
 
 <div class="grid-container">
   <div class="grid-x featured-items grid-margin-x">
@@ -15,13 +15,22 @@
                 </video>
               {% elif featured_item.displayed_hero_content == "image" and featured_item.hero_image %}
                 <picture class="featured-item__picture">
-                  {% image featured_item.hero_image fill-1200x1200 as img %}
-                  <img
-                    src="{{ img.url }}"
-                    width="{{ img.width }}"
-                    height="{{ img.height }}"
-                    alt="{{ featured_item.hero_image_alt_text|default:img.alt }}"
-                  >
+                  {% if featured_item.hero_image|is_webp %}
+                    <img
+                      src="{{ featured_item.hero_image.file.url }}"
+                      width="{{ featured_item.hero_image.width }}"
+                      height="{{ featured_item.hero_image.height }}"
+                      alt="{{ featured_item.hero_image_alt_text|default:featured_item.hero_image.title }}"
+                    >
+                  {% else %}
+                    {% image featured_item.hero_image fill-1200x1200 as img %}
+                    <img
+                      src="{{ img.url }}"
+                      width="{{ img.width }}"
+                      height="{{ img.height }}"
+                      alt="{{ featured_item.hero_image_alt_text|default:img.alt }}"
+                    >
+                  {% endif %}
                 </picture>
               {% endif %}
             </a>

--- a/foundation_cms/templates/patterns/components/nothing_personal/home_page/hero_item.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/home_page/hero_item.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags i18n l10n %}
+{% load wagtailimages_tags i18n l10n responsive_image_tags %}
 
 {% with hero_page=hero_item.specific %}
   <div class="grid-container">
@@ -11,25 +11,34 @@
           </video>
         {% elif hero_page.displayed_hero_content == "image" and hero_page.hero_image %}
           <picture class="featured-hero-item__picture">
-            {% if orientation == "square" %}
-              {% image hero_page.hero_image fill-1172x1172 as img_small %}
-              {% image hero_page.hero_image fill-2198x2198 as img_large %}
-            {% elif orientation == "landscape" %}
-              {% image hero_page.hero_image fill-2198x1238 as img_small %}
-              {% image hero_page.hero_image fill-2198x1238 as img_large %}
+            {% if hero_page.hero_image|is_webp %}
+              <img
+                src="{{ hero_page.hero_image.file.url }}"
+                width="{{ hero_page.hero_image.width }}"
+                height="{{ hero_page.hero_image.height }}"
+                alt="{{ hero_page.hero_image_alt_text|default:hero_page.hero_image.title }}"
+              >
+            {% else %}
+              {% if orientation == "square" %}
+                {% image hero_page.hero_image fill-1172x1172 as img_small %}
+                {% image hero_page.hero_image fill-2198x2198 as img_large %}
+              {% elif orientation == "landscape" %}
+                {% image hero_page.hero_image fill-2198x1238 as img_small %}
+                {% image hero_page.hero_image fill-2198x1238 as img_large %}
+              {% endif %}
+              <source
+                media="(max-width: 639px)"
+                srcset="{{ img_small.url }}"
+                width="{{ img_small.width }}"
+                height="{{ img_small.height }}"
+              >
+              <img
+                src="{{ img_large.url }}"
+                width="{{ img_large.width }}"
+                height="{{ img_large.height }}"
+                alt="{{ hero_page.hero_image_alt_text|default:img_large.alt }}"
+              >
             {% endif %}
-            <source
-              media="(max-width: 639px)"
-              srcset="{{ img_small.url }}"
-              width="{{ img_small.width }}"
-              height="{{ img_small.height }}"
-            >
-            <img
-              src="{{ img_large.url }}"
-              width="{{ img_large.width }}"
-              height="{{ img_large.height }}"
-              alt="{{ hero_page.hero_image_alt_text|default:img_large.alt }}"
-            >
           </picture>
         {% endif %}
       </a>

--- a/foundation_cms/templates/patterns/components/nothing_personal/product_review_page/intro_section.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/product_review_page/intro_section.html
@@ -1,5 +1,5 @@
 
-{% load static wagtailimages_tags wagtailcore_tags i18n l10n %}
+{% load static wagtailimages_tags wagtailcore_tags i18n l10n responsive_image_tags %}
 
 <div class="grid-container intro-section">
     <div class="grid-x">
@@ -56,27 +56,33 @@
         </div>
         <div class="cell small-6 small-offset-3 large-4 large-offset-1">
             {% if page.hero_image %}
-                {% image page.hero_image fill-162x243 as img_mobile %}
-                {% image page.hero_image fill-324x486 as img_mobile_2x %}
-                {% image page.hero_image fill-340x510 as img_tablet %}
-                {% image page.hero_image fill-680x1020 as img_tablet_2x %}
-                {% image page.hero_image fill-380x570 as img_desktop %}
-                {% image page.hero_image fill-760x1140 as img_desktop_2x %}
-
                 <div class="intro-section__product-img">
-                    <img src="{{ img_mobile.url }}"
-                         srcset="{{ img_mobile.url }} 162w,
-                                 {{ img_mobile_2x.url }} 324w,
-                                 {{ img_tablet.url }} 340w,
-                                 {{ img_tablet_2x.url }} 680w,
-                                 {{ img_desktop.url }} 380w,
-                                 {{ img_desktop_2x.url }} 760w"
-                         sizes="(min-width: 1024px) 380px,
-                                (min-width: 640px) 340px,
-                                162px"
-                         alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
-                         width="{{ img_mobile.width }}"
-                         height="{{ img_mobile.height }}">
+                    {% if page.hero_image|is_webp %}
+                        <img src="{{ page.hero_image.file.url }}"
+                             alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
+                             width="{{ page.hero_image.width }}"
+                             height="{{ page.hero_image.height }}">
+                    {% else %}
+                        {% image page.hero_image fill-162x243 as img_mobile %}
+                        {% image page.hero_image fill-324x486 as img_mobile_2x %}
+                        {% image page.hero_image fill-340x510 as img_tablet %}
+                        {% image page.hero_image fill-680x1020 as img_tablet_2x %}
+                        {% image page.hero_image fill-380x570 as img_desktop %}
+                        {% image page.hero_image fill-760x1140 as img_desktop_2x %}
+                        <img src="{{ img_mobile.url }}"
+                             srcset="{{ img_mobile.url }} 162w,
+                                     {{ img_mobile_2x.url }} 324w,
+                                     {{ img_tablet.url }} 340w,
+                                     {{ img_tablet_2x.url }} 680w,
+                                     {{ img_desktop.url }} 380w,
+                                     {{ img_desktop_2x.url }} 760w"
+                             sizes="(min-width: 1024px) 380px,
+                                    (min-width: 640px) 340px,
+                                    162px"
+                             alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}"
+                             width="{{ img_mobile.width }}"
+                             height="{{ img_mobile.height }}">
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/foundation_cms/templates/patterns/components/responsive_image.html
+++ b/foundation_cms/templates/patterns/components/responsive_image.html
@@ -1,4 +1,11 @@
-{% if renditions %}
+{% if is_webp %}
+    <img src="{{ image.file.url }}"
+         width="{{ image.width }}"
+         height="{{ image.height }}"
+         alt="{{ image.title }}"
+         class="{{ classnames }}"
+         loading="lazy">
+{% elif renditions %}
     <img src="{{ primary_rendition.url }}"
          srcset="{% for item in renditions %}{{ item.rendition.url }} {{ item.width }}w{% if not forloop.last %}, {% endif %}{% endfor %}"
          sizes="{{ sizes }}"

--- a/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
+++ b/foundation_cms/templates/patterns/pages/nothing_personal/podcast_page.html
@@ -1,6 +1,6 @@
 {% extends theme_base %}
 
-{% load wagtailimages_tags static %}
+{% load wagtailimages_tags static responsive_image_tags %}
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% static 'foundation_cms/_css/pages/nothing_personal/podcast_page.compiled.css' %}">
@@ -21,9 +21,13 @@
                         <div class="hero__description lede-text">{{ page.hero_description }}</div>
                     </div>
                     {% if page.hero_image %}
-                        {% image page.hero_image fill-692x692 as img %}
                         <div class="hero__media cell small-12 medium-6">
-                            <img src="{{ img.url }}" alt="{{ page.hero_image_alt_text }}" width="{{ img.width }}" height="{{ img.height }}" class="hero__image">
+                            {% if page.hero_image|is_webp %}
+                                <img src="{{ page.hero_image.file.url }}" alt="{{ page.hero_image_alt_text|default:page.hero_image.title }}" width="{{ page.hero_image.width }}" height="{{ page.hero_image.height }}" class="hero__image">
+                            {% else %}
+                                {% image page.hero_image fill-692x692 as img %}
+                                <img src="{{ img.url }}" alt="{{ page.hero_image_alt_text }}" width="{{ img.width }}" height="{{ img.height }}" class="hero__image">
+                            {% endif %}
                         </div>
                     {% endif %}
                     <div class="cell small-12">

--- a/foundation_cms/templatetags/responsive_image_tags.py
+++ b/foundation_cms/templatetags/responsive_image_tags.py
@@ -3,6 +3,14 @@ from django import template
 register = template.Library()
 
 
+@register.filter
+def is_webp(image):
+    """Check if an image file is a WebP format"""
+    if not image or not hasattr(image, 'file') or not hasattr(image.file, 'name'):
+        return False
+    return image.file.name.lower().endswith('.webp')
+
+
 @register.simple_tag
 def colon_to_slash(value):
     """Convert colon-separated ratio to slash format (e.g., '2:3' to '2/3')"""

--- a/foundation_cms/templatetags/responsive_image_tags.py
+++ b/foundation_cms/templatetags/responsive_image_tags.py
@@ -87,6 +87,11 @@ def responsive_image(image, ratio, base_width=300, sizes="(max-width: 639px) 100
             }
         )
 
+    # Check if the image is WebP
+    is_webp_image = (
+        image.file.name.lower().endswith(".webp") if hasattr(image, "file") and hasattr(image.file, "name") else False
+    )
+
     # Use the second rendition (1.5x) as the primary/default src
     # 1.5x provides good quality for most devices while keeping file size reasonable
     # The browser can still choose higher resolutions from srcset when needed
@@ -97,4 +102,6 @@ def responsive_image(image, ratio, base_width=300, sizes="(max-width: 639px) 100
         "sizes": sizes,
         "primary_rendition": primary_rendition,
         "classnames": classnames,
+        "image": image,
+        "is_webp": is_webp_image,
     }

--- a/foundation_cms/templatetags/responsive_image_tags.py
+++ b/foundation_cms/templatetags/responsive_image_tags.py
@@ -6,9 +6,9 @@ register = template.Library()
 @register.filter
 def is_webp(image):
     """Check if an image file is a WebP format"""
-    if not image or not hasattr(image, 'file') or not hasattr(image.file, 'name'):
+    if not image or not hasattr(image, "file") or not hasattr(image.file, "name"):
         return False
-    return image.file.name.lower().endswith('.webp')
+    return image.file.name.lower().endswith(".webp")
 
 
 @register.simple_tag


### PR DESCRIPTION
# Description

This PR implements WebP format detection for hero images across the site, ensuring WebP files are served in their original quality while other image formats continue to use Wagtail's image rendition system for proper responsive behavior.

## Screenshots

![webp-hero](https://github.com/user-attachments/assets/10d68e6c-81f7-4413-bf3c-8b9fbfcd0bc1)

*Nothing personal homepage featured hero/items webp support*

![product-carousel](https://github.com/user-attachments/assets/fa773395-0933-425a-b919-a5e288234a94)

*Nothing personal homepage Product review carousel hero webp support*

![text-media-webp](https://github.com/user-attachments/assets/aa4839fa-79ad-49d4-9f15-bf65e814d765)

*Nothing personal homepage Text/Media block webp image support*

![np-article-page-hero-image-block-webp](https://github.com/user-attachments/assets/3fef2e50-48dc-484f-978e-773382a58a7c)

*Nothing personal article page with hero and image block webp support*

![general-page-hero-webp](https://github.com/user-attachments/assets/3e4cd690-2282-4b47-ab1f-625fea4afc2c)

*General page hero image with webp support*

CMS credentials: `admin` / `(7fY0l7zpODvgdyz`
Link to sample test page:
- NPHP: https://foundation-s-tp1-2995-q-gbvicv.herokuapp.com/en/nothing-personal/
- NP Article: https://foundation-s-tp1-2995-q-gbvicv.herokuapp.com/en/nothing-personal/nothing-personal-article-with-webp-image/
- NP Podcast: https://foundation-s-tp1-2995-q-gbvicv.herokuapp.com/en/nothing-personal/podcast-page-with-webp-hero/
- NP Product review page: https://foundation-s-tp1-2995-q-gbvicv.herokuapp.com/en/nothing-personal/product-review-with-webp-image/
- General Page: https://foundation-s-tp1-2995-q-gbvicv.herokuapp.com/en/general-page-webp-test/
Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-2995)