### PR TITLE
Add link color styling for rich text in NP article pages and product review sections

### DIFF
--- a/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
@@ -218,7 +218,8 @@ body.nothing-personal.nothing-personal-article-page {
   }
 
   .rich-text-block a,
-  .podcast-block a {
+  .podcast-block a,
+  .callout-box a {
     @include link-text-color(
       map.get($mofo-colors, black),
       color(orange, "600")

--- a/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
@@ -216,4 +216,12 @@ body.nothing-personal.nothing-personal-article-page {
       font-size: get-text-property($body-text-styles, "small", font-size);
     }
   }
+
+  .rich-text-block a,
+  .podcast-block a {
+    @include link-text-color(
+      map.get($mofo-colors, black),
+      color(orange, "600")
+    );
+  }
 }

--- a/foundation_cms/static/scss/pages/nothing_personal/product_review_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/product_review_page.scss
@@ -234,6 +234,13 @@ body.nothing-personal.nothing-personal-product-review-page {
     }
   }
 
+  .product-review-section a {
+    @include link-text-color(
+      map.get($mofo-colors, black),
+      color(orange, "600")
+    );
+  }
+
   .products-mentioned {
     &__heading {
       @include mofo-text-style($header-styles, "h6", $header-font-family);


### PR DESCRIPTION
# Description

This PR adds consistent link styling to rich text, podcast and callout box blocks inside Article pages and product review sections on Product Review pages.

Current state
<img width="300" alt="image-20251013-202531" src="https://github.com/user-attachments/assets/8ce8a0b5-624c-47a7-ab2e-8411310c95d5" /> <img width="300" alt="image-20251013-202515" src="https://github.com/user-attachments/assets/9fc54e84-b14f-485b-8664-c60f01c25abc" /> 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/85c26bbb-6ca8-48d3-bcf7-4f2ba32632fa" />


Updated state
<img width="300" alt="image" src="https://github.com/user-attachments/assets/993726f9-df6b-4ae2-ac43-eae2e5fe4cee" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/03ee23fb-16b5-45b5-b95e-d58ba55e3204" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/8865430e-61f4-4918-8249-45d91532023f" />


Link to sample test page:
- Article: https://foundation-s-tp1-3258-u-zmacq4.herokuapp.com/en/nothing-personal/nothing-personal-article-page/
- Product review: https://foundation-s-tp1-3258-u-zmacq4.herokuapp.com/en/nothing-personal/imessage/

Related PRs/issues: [Jira ticket](https://mozilla-hub.atlassian.net/browse/TP1-3257)