### PR TITLE
Replace "should_wrap_block" filter with a new block decorator "skip_default_wrapper_on"

### DIFF
--- a/foundation_cms/blocks/callout_block.py
+++ b/foundation_cms/blocks/callout_block.py
@@ -2,10 +2,10 @@ from wagtail.blocks import RichTextBlock
 
 from foundation_cms.base.models.base_block import BaseBlock
 
-from .decorators import full_bleed_on
+from .decorators import skip_default_wrapper_on
 
 
-@full_bleed_on("*")
+@skip_default_wrapper_on("*")
 class CalloutBlock(BaseBlock):
 
     heading = RichTextBlock(required=True, features=["h4", "h5", "h6"], help_text="Callout box title")

--- a/foundation_cms/blocks/callout_block.py
+++ b/foundation_cms/blocks/callout_block.py
@@ -2,7 +2,10 @@ from wagtail.blocks import RichTextBlock
 
 from foundation_cms.base.models.base_block import BaseBlock
 
+from .decorators import full_bleed_on
 
+
+@full_bleed_on("*")
 class CalloutBlock(BaseBlock):
 
     heading = RichTextBlock(required=True, features=["h4", "h5", "h6"], help_text="Callout box title")

--- a/foundation_cms/blocks/decorators.py
+++ b/foundation_cms/blocks/decorators.py
@@ -1,0 +1,47 @@
+def full_bleed_on(*page_types):
+    """
+    Decorator that adds full bleed behavior to blocks.
+    Use "*" to indicate all pages should have full bleed.
+
+    Usage:
+        @full_bleed_on("HomePage", "LandingPage")
+        class MyBlock(BaseBlock):
+            pass
+
+    Side effects:
+        - Adds 'full_bleed_wrapper' to the block's template context
+        - Modifies the class's MRO (Method Resolution Order)
+        - Replaces the original class with an enhanced version. The original class becomes a parent of the new class.
+    """
+
+    def decorator(block_class):
+        # Create a mixin class dynamically inside the decorator
+        # This allows us to inject behavior without modifying the original class
+        class FullBleedMixin:
+            def get_context(self, value, parent_context=None):
+                context = super().get_context(value, parent_context)
+                page = parent_context.get("page") if parent_context else None
+
+                if "*" in page_types:
+                    context["full_bleed_wrapper"] = True
+                elif page:
+                    context["full_bleed_wrapper"] = page.specific_class.__name__ in page_types
+                else:
+                    context["full_bleed_wrapper"] = False
+
+                return context
+
+        # Combine mixin with original block
+        # Mixin goes first so our get_context runs before the block's
+        class DecoratedBlock(FullBleedMixin, block_class):
+            pass
+
+        # Preserve the original class's identity
+        # This prevents issues with Wagtail's registration and Django's introspection
+        DecoratedBlock.__name__ = block_class.__name__
+        DecoratedBlock.__module__ = block_class.__module__
+
+        # Return the enhanced class to replace the original
+        return DecoratedBlock
+
+    return decorator

--- a/foundation_cms/blocks/decorators.py
+++ b/foundation_cms/blocks/decorators.py
@@ -1,7 +1,6 @@
 def skip_default_wrapper_on(*page_types):
     """
     Decorator that adds skip default wrapper behavior to blocks.
-    Use "*" to indicate all pages should have full bleed.
 
     Usage:
         @skip_default_wrapper_on("HomePage", "NothingPersonalHomePage")

--- a/foundation_cms/blocks/decorators.py
+++ b/foundation_cms/blocks/decorators.py
@@ -1,15 +1,15 @@
-def full_bleed_on(*page_types):
+def skip_default_wrapper_on(*page_types):
     """
-    Decorator that adds full bleed behavior to blocks.
+    Decorator that adds skip default wrapper behavior to blocks.
     Use "*" to indicate all pages should have full bleed.
 
     Usage:
-        @full_bleed_on("HomePage", "LandingPage")
+        @skip_default_wrapper_on("HomePage", "LandingPage")
         class MyBlock(BaseBlock):
             pass
 
     Side effects:
-        - Adds 'full_bleed_wrapper' to the block's template context
+        - Adds 'skip_default_wrapper' to the block's template context
         - Modifies the class's MRO (Method Resolution Order)
         - Replaces the original class with an enhanced version. The original class becomes a parent of the new class.
     """
@@ -23,11 +23,11 @@ def full_bleed_on(*page_types):
                 page = parent_context.get("page") if parent_context else None
 
                 if "*" in page_types:
-                    context["full_bleed_wrapper"] = True
+                    context["skip_default_wrapper"] = True
                 elif page:
-                    context["full_bleed_wrapper"] = page.specific_class.__name__ in page_types
+                    context["skip_default_wrapper"] = page.specific_class.__name__ in page_types
                 else:
-                    context["full_bleed_wrapper"] = False
+                    context["skip_default_wrapper"] = False
 
                 return context
 

--- a/foundation_cms/blocks/decorators.py
+++ b/foundation_cms/blocks/decorators.py
@@ -4,7 +4,7 @@ def skip_default_wrapper_on(*page_types):
     Use "*" to indicate all pages should have full bleed.
 
     Usage:
-        @skip_default_wrapper_on("HomePage", "LandingPage")
+        @skip_default_wrapper_on("HomePage", "NothingPersonalHomePage")
         class MyBlock(BaseBlock):
             pass
 
@@ -17,7 +17,7 @@ def skip_default_wrapper_on(*page_types):
     def decorator(block_class):
         # Create a mixin class dynamically inside the decorator
         # This allows us to inject behavior without modifying the original class
-        class FullBleedMixin:
+        class SkipDefaultWrapperMixin:
             def get_context(self, value, parent_context=None):
                 context = super().get_context(value, parent_context)
                 page = parent_context.get("page") if parent_context else None
@@ -33,7 +33,7 @@ def skip_default_wrapper_on(*page_types):
 
         # Combine mixin with original block
         # Mixin goes first so our get_context runs before the block's
-        class DecoratedBlock(FullBleedMixin, block_class):
+        class DecoratedBlock(SkipDefaultWrapperMixin, block_class):
             pass
 
         # Preserve the original class's identity

--- a/foundation_cms/blocks/featured_card_block.py
+++ b/foundation_cms/blocks/featured_card_block.py
@@ -3,9 +3,11 @@ from wagtail.images.blocks import ImageBlock
 
 from foundation_cms.base.models.base_block import BaseBlock
 
+from .decorators import full_bleed_on
 from .link_button_block import LinkButtonBlock
 
 
+@full_bleed_on("*")
 class FeaturedCardBlock(BaseBlock):
     heading = CharBlock(required=True, max_length=50, label="Heading")
     description = RichTextBlock(required=True, max_length=500, label="Description", features=["bold", "italic"])

--- a/foundation_cms/blocks/featured_card_block.py
+++ b/foundation_cms/blocks/featured_card_block.py
@@ -3,11 +3,11 @@ from wagtail.images.blocks import ImageBlock
 
 from foundation_cms.base.models.base_block import BaseBlock
 
-from .decorators import full_bleed_on
+from .decorators import skip_default_wrapper_on
 from .link_button_block import LinkButtonBlock
 
 
-@full_bleed_on("*")
+@skip_default_wrapper_on("*")
 class FeaturedCardBlock(BaseBlock):
     heading = CharBlock(required=True, max_length=50, label="Heading")
     description = RichTextBlock(required=True, max_length=500, label="Description", features=["bold", "italic"])

--- a/foundation_cms/blocks/portrait_card_set_block.py
+++ b/foundation_cms/blocks/portrait_card_set_block.py
@@ -3,10 +3,10 @@ from wagtail import blocks
 from foundation_cms.base.models.base_block import BaseBlock
 
 from . import PortraitCardBlock
-from .decorators import full_bleed_on
+from .decorators import skip_default_wrapper_on
 
 
-@full_bleed_on("*")
+@skip_default_wrapper_on("*")
 class PortraitCardSetBlock(BaseBlock):
 
     cards = blocks.ListBlock(

--- a/foundation_cms/blocks/portrait_card_set_block.py
+++ b/foundation_cms/blocks/portrait_card_set_block.py
@@ -3,8 +3,10 @@ from wagtail import blocks
 from foundation_cms.base.models.base_block import BaseBlock
 
 from . import PortraitCardBlock
+from .decorators import full_bleed_on
 
 
+@full_bleed_on("*")
 class PortraitCardSetBlock(BaseBlock):
 
     cards = blocks.ListBlock(

--- a/foundation_cms/blocks/product_review_carousel_block.py
+++ b/foundation_cms/blocks/product_review_carousel_block.py
@@ -2,7 +2,7 @@ from wagtail import blocks
 
 from foundation_cms.base.models.base_block import BaseBlock
 
-from .decorators import full_bleed_on
+from .decorators import skip_default_wrapper_on
 from .link_block import OptionalLinkBlock
 
 
@@ -33,7 +33,7 @@ class ProductReviewCardBlock(BaseBlock):
         label = "Product Review Card"
 
 
-@full_bleed_on("*")
+@skip_default_wrapper_on("*")
 class ProductReviewCarouselBlock(BaseBlock):
     """
     Block container for displaying product review cards in a carousel.

--- a/foundation_cms/blocks/product_review_carousel_block.py
+++ b/foundation_cms/blocks/product_review_carousel_block.py
@@ -2,6 +2,7 @@ from wagtail import blocks
 
 from foundation_cms.base.models.base_block import BaseBlock
 
+from .decorators import full_bleed_on
 from .link_block import OptionalLinkBlock
 
 
@@ -32,6 +33,7 @@ class ProductReviewCardBlock(BaseBlock):
         label = "Product Review Card"
 
 
+@full_bleed_on("*")
 class ProductReviewCarouselBlock(BaseBlock):
     """
     Block container for displaying product review cards in a carousel.

--- a/foundation_cms/blocks/spotlight_card_set_block.py
+++ b/foundation_cms/blocks/spotlight_card_set_block.py
@@ -3,8 +3,10 @@ from wagtail import blocks
 from foundation_cms.base.models.base_block import BaseBlock
 
 from . import SpotlightCardBlock
+from .decorators import full_bleed_on
 
 
+@full_bleed_on("*")
 class SpotlightCardSetBlock(BaseBlock):
 
     cards = blocks.ListBlock(

--- a/foundation_cms/blocks/spotlight_card_set_block.py
+++ b/foundation_cms/blocks/spotlight_card_set_block.py
@@ -3,10 +3,10 @@ from wagtail import blocks
 from foundation_cms.base.models.base_block import BaseBlock
 
 from . import SpotlightCardBlock
-from .decorators import full_bleed_on
+from .decorators import skip_default_wrapper_on
 
 
-@full_bleed_on("*")
+@skip_default_wrapper_on("*")
 class SpotlightCardSetBlock(BaseBlock):
 
     cards = blocks.ListBlock(

--- a/foundation_cms/templates/patterns/components/streamfield.html
+++ b/foundation_cms/templates/patterns/components/streamfield.html
@@ -7,13 +7,13 @@
     <div class="grid-container">
       <div class="grid-x">
         <div class="cell{% if classnames %} {{ classnames }}{% endif %}">
-          {% include_block block with page_type_bem=page_type_bem %}
+          {% include_block block %}
         </div>
       </div>
     </div>
   {% else %}
     <div class="full-bleed-block-wrapper">
-      {% include_block block with page_type_bem=page_type_bem %}
+      {% include_block block %}
     </div>
   {% endif %}
 

--- a/foundation_cms/templates/patterns/components/streamfield.html
+++ b/foundation_cms/templates/patterns/components/streamfield.html
@@ -1,15 +1,20 @@
 {% load wagtailcore_tags streamfield_tags %}
 
 {% for block in streamfield %}
-  {% if block.block_type|should_wrap_block %}
+  {% get_block_context_value block page 'full_bleed_wrapper' as is_full_bleed %}
+
+  {% if not is_full_bleed %}
     <div class="grid-container">
       <div class="grid-x">
         <div class="cell{% if classnames %} {{ classnames }}{% endif %}">
           {% include_block block with page_type_bem=page_type_bem %}
-        </div>
+        </div>a
       </div>
     </div>
   {% else %}
-    {% include_block block with page_type_bem=page_type_bem %}
+    <div class="full-bleed-block-wrapper">
+      {% include_block block with page_type_bem=page_type_bem %}
+    </div>
   {% endif %}
+
 {% endfor %}

--- a/foundation_cms/templates/patterns/components/streamfield.html
+++ b/foundation_cms/templates/patterns/components/streamfield.html
@@ -8,7 +8,7 @@
       <div class="grid-x">
         <div class="cell{% if classnames %} {{ classnames }}{% endif %}">
           {% include_block block with page_type_bem=page_type_bem %}
-        </div>a
+        </div>
       </div>
     </div>
   {% else %}

--- a/foundation_cms/templates/patterns/components/streamfield.html
+++ b/foundation_cms/templates/patterns/components/streamfield.html
@@ -4,17 +4,17 @@
   {% get_block_context_value block page 'skip_default_wrapper' as skip_default_wrapper %}
 
   <div class="streamfield-block-wrapper" data-block-type="{{ block.block_type }}">
-  {% if not skip_default_wrapper %}
-    <div class="grid-container">
-      <div class="grid-x">
-        <div class="cell{% if classnames %} {{ classnames }}{% endif %}">
-          {% include_block block %}
+    {% if not skip_default_wrapper %}
+      <div class="grid-container">
+        <div class="grid-x">
+          <div class="cell{% if classnames %} {{ classnames }}{% endif %}">
+            {% include_block block %}
+          </div>
         </div>
       </div>
-    </div>
-  {% else %}
-    {% include_block block %}
-  {% endif %}
+    {% else %}
+      {% include_block block %}
+    {% endif %}
   </div>
 
 {% endfor %}

--- a/foundation_cms/templates/patterns/components/streamfield.html
+++ b/foundation_cms/templates/patterns/components/streamfield.html
@@ -1,9 +1,10 @@
 {% load wagtailcore_tags streamfield_tags %}
 
 {% for block in streamfield %}
-  {% get_block_context_value block page 'full_bleed_wrapper' as is_full_bleed %}
+  {% get_block_context_value block page 'skip_default_wrapper' as skip_default_wrapper %}
 
-  {% if not is_full_bleed %}
+  <div class="streamfield-block-wrapper" data-block-type="{{ block.block_type }}">
+  {% if not skip_default_wrapper %}
     <div class="grid-container">
       <div class="grid-x">
         <div class="cell{% if classnames %} {{ classnames }}{% endif %}">
@@ -12,9 +13,8 @@
       </div>
     </div>
   {% else %}
-    <div class="full-bleed-block-wrapper">
-      {% include_block block %}
-    </div>
+    {% include_block block %}
   {% endif %}
+  </div>
 
 {% endfor %}

--- a/foundation_cms/templatetags/streamfield_tags.py
+++ b/foundation_cms/templatetags/streamfield_tags.py
@@ -3,14 +3,10 @@ from django import template
 register = template.Library()
 
 
-@register.filter
-def should_wrap_block(block_type):
-    # This is used in streamfield.html to determine if a block should be pre-wrapped with .grid-container etc
-    NO_WRAP_BLOCKS = {
-        "spotlight_card_set_block",
-        "portrait_card_set_block",
-        "featured_card_block",
-        "callout",
-        "product_review_carousel_block",
-    }
-    return block_type not in NO_WRAP_BLOCKS
+@register.simple_tag
+def get_block_context_value(block, page, key):
+    """Get a value from block's context."""
+    if hasattr(block.block, "get_context"):
+        context = block.block.get_context(block.value, parent_context={"page": page})
+        return context.get(key, False)
+    return False


### PR DESCRIPTION
# Description

In this PR, I have replaced `should_wrap_block` template filter with a new decorator `@skip_default_wrapper_on()`

The previous approach with `should_wrap_block` template filter had a hardcoded list of block types in the template layer. This PR moves that logic to the block definitions themselves using a decorator. This makes it clearer which blocks manage their own wrapper structure. This flexibility will also enable us to apply page-specific layout/style when we need to.


## What changed
- Created `@skip_default_wrapper_on()` decorator
- Applied it to all blocks previously in `NO_WRAP_BLOCKS`
```python
       "spotlight_card_set_block",
        "portrait_card_set_block",
        "featured_card_block",
        "callout",
        "product_review_carousel_block",
 ```
- Updated `streamfield.html` template to use block context
- Added `streamfield-block-wrapper` div with `data-block-type` attribute for better CSS/JS targeting
- Removed the old filter

## To test

- checkout this branch and run it locally as usual
- go to the homepage (there should not be any visual changes)
- inspect the source code of `<main>` and verify each Streamfield block now has a wrapper div like below
<img width="720" height="201" alt="image" src="https://github.com/user-attachments/assets/f10ebf2d-b9d7-451d-88cd-945693cf1cd0" />


---

Related PRs/issues: [Jira TP1-3295](https://mozilla-hub.atlassian.net/browse/TP1-3295) / GitHub #14831