### PR TITLE
[WIP] Pushdown donate banner fix

### DIFF
--- a/foundation_cms/static/scss/_layout.scss
+++ b/foundation_cms/static/scss/_layout.scss
@@ -2,4 +2,10 @@
 
 .main-content-wrapper {
   background-color: map.get($mofo-colors, white);
+  // Fix for Safari: proper layer stacking with sticky elements because z-index alone doesn''t work with position: sticky
+  position: relative;
+  z-index: z("main-content-wrapper");
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
+  isolation: isolate;
 }

--- a/foundation_cms/static/scss/_layout.scss
+++ b/foundation_cms/static/scss/_layout.scss
@@ -2,6 +2,7 @@
 
 .main-content-wrapper {
   background-color: map.get($mofo-colors, white);
+
   // Fix for Safari: proper layer stacking with sticky elements because z-index alone doesn''t work with position: sticky
   position: relative;
   z-index: z("main-content-wrapper");

--- a/foundation_cms/static/scss/_redesign_base.scss
+++ b/foundation_cms/static/scss/_redesign_base.scss
@@ -3,6 +3,7 @@
 
 // Our custom variables and base styles
 @import "../scss/colors";
+@import "../scss/z_index";
 @import "../scss/type";
 @import "../scss/mixins";
 @import "../scss/buttons";

--- a/foundation_cms/static/scss/_z_index.scss
+++ b/foundation_cms/static/scss/_z_index.scss
@@ -1,0 +1,17 @@
+$z-layers: (
+  // Sticky/fixed elements that should be below main content when scrolling
+  "pushdown-donate-banner": 1,
+
+  // Main site navigation and primary UI elements
+  "primary-nav-ns": 10,
+  "main-content-wrapper": 10,
+);
+
+// Helper function to get z-index values
+// Example usage: z("main-content-wrapper");
+@function z($layer) {
+  @if not map-has-key($z-layers, $layer) {
+    @error "No z-index defined for layer: #{$layer}";
+  }
+  @return map-get($z-layers, $layer);
+}

--- a/foundation_cms/static/scss/_z_index.scss
+++ b/foundation_cms/static/scss/_z_index.scss
@@ -4,7 +4,7 @@ $z-layers: (
 
   // Main site navigation and primary UI elements
   "primary-nav-ns": 10,
-  "main-content-wrapper": 10,
+  "main-content-wrapper": 10
 );
 
 // Helper function to get z-index values

--- a/foundation_cms/static/scss/components/donate_banner/donate_banner.scss
+++ b/foundation_cms/static/scss/components/donate_banner/donate_banner.scss
@@ -33,10 +33,10 @@
   &[data-banner-style="pushdown"] {
     position: sticky;
     top: 0;
-
-    ~ .main-content-wrapper {
-      position: relative;
-    }
+    // Fix for Safari: proper layer stacking with sticky elements because z-index alone doesn't work with position: sticky
+    z-index: z("pushdown-donate-banner");
+    transform: translate3d(0, 0, 0);
+    backface-visibility: hidden;
   }
 
   &__inner-wrapper {

--- a/foundation_cms/static/scss/components/donate_banner/donate_banner.scss
+++ b/foundation_cms/static/scss/components/donate_banner/donate_banner.scss
@@ -33,6 +33,7 @@
   &[data-banner-style="pushdown"] {
     position: sticky;
     top: 0;
+
     // Fix for Safari: proper layer stacking with sticky elements because z-index alone doesn't work with position: sticky
     z-index: z("pushdown-donate-banner");
     transform: translate3d(0, 0, 0);

--- a/foundation_cms/static/scss/components/primary_nav.scss
+++ b/foundation_cms/static/scss/components/primary_nav.scss
@@ -20,6 +20,7 @@ $primary-nav-margin: 0.7rem;
   overflow: hidden;
   will-change: height;
   transition: height 0.3s ease-in-out;
+
   // Fix for Safari: proper layer stacking with sticky elements because z-index alone doesn't work with position: sticky
   transform: translate3d(0, 0, 0);
   backface-visibility: hidden;

--- a/foundation_cms/static/scss/components/primary_nav.scss
+++ b/foundation_cms/static/scss/components/primary_nav.scss
@@ -14,12 +14,15 @@ $primary-nav-margin: 0.7rem;
   margin: 0;
   max-width: 100vw;
   top: 0;
-  z-index: 10;
+  z-index: z("primary-nav-ns");
   background-color: $white;
   height: $primary-nav-height;
   overflow: hidden;
   will-change: height;
   transition: height 0.3s ease-in-out;
+  // Fix for Safari: proper layer stacking with sticky elements because z-index alone doesn't work with position: sticky
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
 
   @include breakpoint(large up) {
     overflow: visible;

--- a/foundation_cms/static/scss/redesign_migrated_content.scss
+++ b/foundation_cms/static/scss/redesign_migrated_content.scss
@@ -3,6 +3,7 @@
 
 // Our custom variables and base styles
 @import "../scss/colors";
+@import "../scss/z_index";
 @import "../scss/type";
 @import "../scss/buttons";
 @import "../scss/layout";


### PR DESCRIPTION
# Description

**Problem**: a Safari-specific bug where the sticky donate banner (i.e., the "pushdown" version of banner) was not properly covered by scrolling content (nav and main content). Safari doesn't respect z-index values on sticky positioned elements unless we force proper layering.

**Solution**: added `transform: translate3d(0, 0, 0)` and `backface-visibility: hidden` to force Safari to create proper composite layers
  - fixes are applied to
     - `.donate-banner[data-banner-style="pushdown"]` (z-index: 1)
     - `.primary-nav-ns` (z-index: 10)
     - `.main-content-wrapper` (z-index: 10)

I also create a `_z_index.scss` to systematically organize special `z-index` used in the codebase

---

Related PRs/issues: [Jira TP1-3345](https://mozilla-hub.atlassian.net/browse/TP1-3345) / https://github.com/MozillaFoundation/foundation.mozilla.org/issues/14928

# To Test

1. Check out this branch and run it
2. Set up a Pushdown Donate Banner
3. Test on Safari to see the bug mentioned in the Jira ticket is resolved.
