### PR TITLE
[Do not merge] Bump Wagtail from 6.3.2 to 6.4.2

### DIFF
--- a/foundation_cms/legacy_apps/nav/tests/test_models.py
+++ b/foundation_cms/legacy_apps/nav/tests/test_models.py
@@ -131,11 +131,11 @@ class TestNavMenuFeaturedTopics(test_base.WagtailpagesTestCase):
 
         # Translate topics:
         self.translate_snippet(topic_a, self.fr_locale)
-        topic_a_fr = topic_a.get_translation(self.fr_locale)
+        topic_a_fr = topic_a.get_translation(self.fr_locale)  # type: ignore[attr-defined]
         self.translate_snippet(topic_b, self.fr_locale)
-        topic_b_fr = topic_b.get_translation(self.fr_locale)
+        topic_b_fr = topic_b.get_translation(self.fr_locale)  # type: ignore[attr-defined]
         self.translate_snippet(topic_c, self.fr_locale)
-        topic_c_fr = topic_c.get_translation(self.fr_locale)
+        topic_c_fr = topic_c.get_translation(self.fr_locale)  # type: ignore[attr-defined]
 
         # Translate the menu:
         self.translate_snippet(self.menu, self.fr_locale)
@@ -188,22 +188,22 @@ class TestNavMenuFeaturedTopics(test_base.WagtailpagesTestCase):
 
         # Translate topics a and c (but not b) and associate them with the menu:
         self.translate_snippet(topic_a, self.fr_locale)
-        topic_a_fr = topic_a.get_translation(self.fr_locale)
+        topic_a_fr = topic_a.get_translation(self.fr_locale)  # type: ignore[attr-defined]
         self.translate_snippet(topic_c, self.fr_locale)
-        topic_c_fr = topic_c.get_translation(self.fr_locale)
+        topic_c_fr = topic_c.get_translation(self.fr_locale)  # type: ignore[attr-defined]
 
         nav_factories.NavMenuFeaturedBlogTopicRelationshipFactory(
             menu=menu_fr,
             topic=topic_a_fr,
             sort_order=2,
-            translation_key=rel_a.translation_key,
+            translation_key=rel_a.translation_key,  # type: ignore[attr-defined]
             locale=self.fr_locale,
         )
         nav_factories.NavMenuFeaturedBlogTopicRelationshipFactory(
             menu=menu_fr,
             topic=topic_b,
             sort_order=1,
-            translation_key=rel_b.translation_key,
+            translation_key=rel_b.translation_key,  # type: ignore[attr-defined]
             locale=self.fr_locale,
         )
 
@@ -379,7 +379,7 @@ class TestNavMenuPageReferencesPerDropdown(test_base.WagtailpagesTestCase):
 
         # Get the page links:
         with self.assertNumQueries(1):
-            page_references = menu.page_references_per_dropdown
+            page_references = menu.page_references_per_dropdown  # type: ignore[attr-defined]
             self.assertDictEqual(page_references, expected)
 
         # Get a flat list of page ids:
@@ -424,7 +424,7 @@ class TestNavMenuPageReferences(test_base.WagtailpagesTestCase):
 
         # Get the page links:
         with self.assertNumQueries(1):
-            page_references = menu.page_references
+            page_references = menu.page_references  # type: ignore[attr-defined]
             self.assertDictEqual(page_references, expected)
 
         self.assertIn(page_a.id, page_references.keys())

--- a/foundation_cms/legacy_apps/wagtailpages/tests/blog/test_blog_index.py
+++ b/foundation_cms/legacy_apps/wagtailpages/tests/blog/test_blog_index.py
@@ -520,6 +520,7 @@ class TestBlogIndexSearch(BlogIndexTestCase):
             parent=self.blog_index,
             title=self.search_term,
         )
+        self.update_index()
         url = self.blog_index.get_url() + self.blog_index.reverse_subpage("search") + f"?q={ self.search_term }"
 
         response = self.client.get(path=url)
@@ -619,6 +620,7 @@ class TestBlogIndexSearch(BlogIndexTestCase):
         match_post = blog_factories.BlogPageFactory(parent=self.blog_index, title=self.search_term)
         other_post = blog_factories.BlogPageFactory(parent=self.blog_index)
 
+        self.update_index()
         results = self.blog_index.get_search_entries(query=self.search_term)
 
         self.assertIn(match_post, results)
@@ -749,6 +751,8 @@ class TestBlogIndexSearch(BlogIndexTestCase):
         first_page_of_matches = match_blog_pages[0 : self.page_size]
         second_page_of_matches = match_blog_pages[self.page_size :]
         nonmatch_blog_pages = self.fill_index_pages_with_blog_pages(2, base_title="Othertitle")
+
+        self.update_index()
         url = (
             self.blog_index.get_url()
             + self.blog_index.reverse_subpage("search_entries")
@@ -777,6 +781,8 @@ class TestBlogIndexSearch(BlogIndexTestCase):
         first_page_of_matches = match_blog_pages[0 : self.page_size]
         second_page_of_matches = match_blog_pages[self.page_size :]
         nonmatch_blog_pages = self.fill_index_pages_with_blog_pages(2, base_title="Othertitle")
+
+        self.update_index()
         url = (
             self.blog_index.get_url()
             + self.blog_index.reverse_subpage("search_entries")

--- a/foundation_cms/legacy_apps/wagtailpages/tests/libraries/rcc/test_detail_page.py
+++ b/foundation_cms/legacy_apps/wagtailpages/tests/libraries/rcc/test_detail_page.py
@@ -40,7 +40,7 @@ class TestRCCLibraryDetailPage(rcc_test_base.RCCTestCase):
         page_a_author_profiles = []
         page_a = detail_page_factory.RCCDetailPageFactory(parent=self.library_page, authors=[])
         page_b = detail_page_factory.RCCDetailPageFactory(parent=self.library_page)
-        page_b_author_profile = page_b.authors.first().author_profile
+        page_b_author_profile = page_b.authors.first().author_profile  # type: ignore[attr-defined]
 
         for _ in range(3):
             rcc_author_relation = relations_factory.RCCAuthorRelationFactory(detail_page=page_a)
@@ -60,7 +60,7 @@ class TestRCCLibraryDetailPage(rcc_test_base.RCCTestCase):
         this method should return it in the active locale.
         """
         detail_page = detail_page_factory.RCCDetailPageFactory(parent=self.library_page)
-        profile_en = detail_page.authors.first().author_profile
+        profile_en = detail_page.authors.first().author_profile  # type: ignore[attr-defined]
         self.synchronize_tree()
         # Translating both the page and the rcc author profile
         detail_page_fr = rcc_test_utils.translate_detail_page(detail_page, self.fr_locale)
@@ -111,7 +111,7 @@ class TestRCCLibraryDetailPage(rcc_test_base.RCCTestCase):
         detail_page = detail_page_factory.RCCDetailPageFactory(
             parent=self.library_page,
         )
-        profile_en = detail_page.authors.first().author_profile
+        profile_en = detail_page.authors.first().author_profile  # type: ignore[attr-defined]
         self.synchronize_tree()
 
         translation.activate(self.fr_locale.language_code)

--- a/foundation_cms/legacy_apps/wagtailpages/tests/libraries/rcc/test_library_page.py
+++ b/foundation_cms/legacy_apps/wagtailpages/tests/libraries/rcc/test_library_page.py
@@ -200,6 +200,7 @@ class TestRCCLibraryPageSearch(TestRCCLibraryPage):
             collaborators="",
         )
 
+        self.update_index()
         rcc_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
         self.assertEqual(len(rcc_detail_pages), 1)
         self.assertIn(apple_page, rcc_detail_pages)
@@ -221,6 +222,7 @@ class TestRCCLibraryPageSearch(TestRCCLibraryPage):
             collaborators="",
         )
 
+        self.update_index()
         rcc_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
 
         self.assertEqual(len(rcc_detail_pages), 1)
@@ -243,6 +245,7 @@ class TestRCCLibraryPageSearch(TestRCCLibraryPage):
             collaborators="",
         )
 
+        self.update_index()
         rcc_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
 
         self.assertEqual(len(rcc_detail_pages), 1)
@@ -265,6 +268,7 @@ class TestRCCLibraryPageSearch(TestRCCLibraryPage):
             collaborators="Banana",
         )
 
+        self.update_index()
         rcc_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
 
         self.assertEqual(len(rcc_detail_pages), 1)

--- a/foundation_cms/legacy_apps/wagtailpages/tests/libraries/research_hub/test_detail_page.py
+++ b/foundation_cms/legacy_apps/wagtailpages/tests/libraries/research_hub/test_detail_page.py
@@ -38,7 +38,7 @@ class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
         page_a_author_profiles = []
         page_a = detail_page_factory.ResearchDetailPageFactory(parent=self.library_page, authors=[])
         page_b = detail_page_factory.ResearchDetailPageFactory(parent=self.library_page)
-        page_b_author_profile = page_b.authors.first().author_profile
+        page_b_author_profile = page_b.authors.first().author_profile  # type: ignore[attr-defined]
 
         for _ in range(3):
             research_author_relation = relations_factory.ResearchAuthorRelationFactory(detail_page=page_a)
@@ -58,7 +58,7 @@ class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
         this method should return it in the active locale.
         """
         detail_page = detail_page_factory.ResearchDetailPageFactory(parent=self.library_page)
-        profile_en = detail_page.authors.first().author_profile
+        profile_en = detail_page.authors.first().author_profile  # type: ignore[attr-defined]
         self.synchronize_tree()
         # Translating both the page and the research author profile
         detail_page_fr = research_test_utils.translate_detail_page(detail_page, self.fr_locale)
@@ -109,7 +109,7 @@ class TestResearchLibraryDetailPage(research_test_base.ResearchHubTestCase):
         detail_page = detail_page_factory.ResearchDetailPageFactory(
             parent=self.library_page,
         )
-        profile_en = detail_page.authors.first().author_profile
+        profile_en = detail_page.authors.first().author_profile  # type: ignore[attr-defined]
         self.synchronize_tree()
 
         translation.activate(self.fr_locale.language_code)

--- a/foundation_cms/legacy_apps/wagtailpages/tests/libraries/research_hub/test_library_page.py
+++ b/foundation_cms/legacy_apps/wagtailpages/tests/libraries/research_hub/test_library_page.py
@@ -207,6 +207,7 @@ class TestResearchLibraryPageSearch(TestResearchLibraryPage):
             collaborators="",
         )
 
+        self.update_index()
         research_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
         self.assertEqual(len(research_detail_pages), 1)
         self.assertIn(apple_page, research_detail_pages)
@@ -228,6 +229,7 @@ class TestResearchLibraryPageSearch(TestResearchLibraryPage):
             collaborators="",
         )
 
+        self.update_index()
         research_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
 
         self.assertEqual(len(research_detail_pages), 1)
@@ -250,6 +252,7 @@ class TestResearchLibraryPageSearch(TestResearchLibraryPage):
             collaborators="",
         )
 
+        self.update_index()
         research_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
 
         self.assertEqual(len(research_detail_pages), 1)
@@ -272,6 +275,7 @@ class TestResearchLibraryPageSearch(TestResearchLibraryPage):
             collaborators="Banana",
         )
 
+        self.update_index()
         research_detail_pages = self.library_page.get_sorted_filtered_detail_pages(search_query="Apple")
 
         self.assertEqual(len(research_detail_pages), 1)

--- a/foundation_cms/legacy_apps/wagtailpages/utils.py
+++ b/foundation_cms/legacy_apps/wagtailpages/utils.py
@@ -231,7 +231,9 @@ def insert_panels_after(panels, after_label, additional_panels):
     """
     Insert wagtail panels somewhere in another set of panels
     """
-    position = next((i for i, item in enumerate(panels) if item.heading == after_label), None)
+    position = next(
+        (i for i, item in enumerate(panels) if hasattr(item, "heading") and item.heading == after_label), None
+    )
 
     if position is not None:
         cut = position + 1

--- a/frontend/legacy/tests/integration/pni/search.spec.js
+++ b/frontend/legacy/tests/integration/pni/search.spec.js
@@ -16,9 +16,9 @@ test.describe("PNI search", () => {
     // provided RANDOM_SEED=530910203 was used!
     total: 47,
     health: 16,
-    smart: 4,
+    smart: 6,
     percy: 1,
-    searchTerm: 4,
+    searchTerm: 3,
     searchTermWithDing: 1,
   };
 

--- a/frontend/legacy/tests/integration/pni/search.spec.js
+++ b/frontend/legacy/tests/integration/pni/search.spec.js
@@ -14,12 +14,12 @@ test.describe("PNI search", () => {
 
   const counts = {
     // provided RANDOM_SEED=530910203 was used!
-    total: 38,
-    health: 11,
+    total: 47,
+    health: 16,
     smart: 4,
     percy: 1,
     searchTerm: 4,
-    searchTermWithDing: 2,
+    searchTermWithDing: 1,
   };
 
   const qs = {

--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ pygit2==1.14.0
 python-slugify
 requests
 social-auth-app-django
-wagtail==6.3.2
+wagtail==6.4.2
 wagtail-ab-testing
 wagtail-color-panel
 wagtail-factories

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt.tmp requirements.in
 #
-anyascii==0.3.0
+anyascii==0.3.3
     # via wagtail
 asgiref==3.7.2
     # via
@@ -12,41 +12,39 @@ asgiref==3.7.2
     #   django-cors-headers
     #   django-htmx
     #   scout-apm
-async-timeout==4.0.2
-    # via redis
-basket-client==1.0.0
+basket-client==1.2.0
     # via -r requirements.in
-beautifulsoup4==4.9.3
+beautifulsoup4==4.14.3
     # via
     #   -r requirements.in
     #   wagtail
-boto3==1.34.158
+boto3==1.42.30
     # via -r requirements.in
-botocore==1.34.158
+botocore==1.42.30
     # via
     #   boto3
     #   s3transfer
 cached-property==2.0.1
     # via -r requirements.in
-certifi==2024.7.4
+certifi==2026.1.4
     # via
     #   requests
     #   scout-apm
     #   sentry-sdk
-cffi==1.16.0
+cffi==2.0.0
     # via
     #   cryptography
     #   pygit2
-charset-normalizer==2.0.12
+charset-normalizer==3.4.4
     # via requests
-cryptography==43.0.1
-    # via social-auth-core
+cryptography==46.0.3
+    # via pyjwt
 defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
     #   willow
-dj-database-url==2.3.0
+dj-database-url==3.1.0
     # via -r requirements.in
 django==4.2.27
     # via
@@ -63,7 +61,9 @@ django==4.2.27
     #   django-querystring-tag
     #   django-redis
     #   django-storages
+    #   django-stubs-ext
     #   django-taggit
+    #   django-tasks
     #   django-treebeard
     #   djangorestframework
     #   laces
@@ -75,19 +75,19 @@ django==4.2.27
     #   wagtailmedia
 django-admin-sortable==2.3
     # via -r requirements.in
-django-cors-headers==4.3.1
+django-cors-headers==4.9.0
     # via -r requirements.in
-django-csp==3.8
+django-csp==4.0
     # via -r requirements.in
 django-environ==0.12.0
     # via -r requirements.in
-django-filter==23.5
+django-filter==25.1
     # via
     #   -r requirements.in
     #   wagtail
-django-htmx==1.23.0
+django-htmx==1.27.0
     # via -r requirements.in
-django-modelcluster==6.2.1
+django-modelcluster==6.4.1
     # via wagtail
 django-pattern-library==1.5.0
     # via -r requirements.in
@@ -95,29 +95,33 @@ django-permissionedforms==0.1
     # via wagtail
 django-querystring-tag==1.0.3
     # via -r requirements.in
-django-redis==5.4.0
+django-redis==6.0.0
     # via -r requirements.in
-django-storages==1.14.5
+django-storages==1.14.6
     # via -r requirements.in
+django-stubs-ext==5.2.8
+    # via django-tasks
 django-taggit==6.1.0
     # via wagtail
-django-treebeard==4.5.1
+django-tasks==0.6.1
     # via wagtail
-djangorestframework==3.15.2
+django-treebeard==4.8.0
+    # via wagtail
+djangorestframework==3.16.1
     # via
     #   -r requirements.in
     #   wagtail
-draftjs-exporter==2.1.7
+draftjs-exporter==5.2.0
     # via wagtail
 ecdsa==0.19.1
     # via python-jose
-et-xmlfile==1.1.0
+et-xmlfile==2.0.0
     # via openpyxl
-factory-boy==3.3.1
+factory-boy==3.3.3
     # via
     #   -r requirements.in
     #   wagtail-factories
-faker==26.3.0
+faker==40.1.2
     # via
     #   -r requirements.in
     #   factory-boy
@@ -125,47 +129,47 @@ filetype==1.2.0
     # via willow
 future==1.0.0
     # via -r requirements.in
-gitdb==4.0.9
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.41
+gitpython==3.1.46
     # via wagtail-localize-git
 gunicorn==23.0.0
     # via -r requirements.in
 heroku3==5.2.1
     # via -r requirements.in
-idna==3.7
+idna==3.11
     # via requests
-jmespath==0.10.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-l18n==2021.3
-    # via wagtail
 laces==0.1.2
     # via wagtail
-markdown==3.4.4
+markdown==3.10
     # via django-pattern-library
-numpy==1.24.4
+numpy==1.26.4
     # via
     #   scipy
     #   wagtail-ab-testing
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   requests-oauthlib
     #   social-auth-core
-openpyxl==3.1.0
+openpyxl==3.1.5
     # via wagtail
 packaging==23.1
-    # via gunicorn
-pillow==10.3.0
+    # via
+    #   django-csp
+    #   gunicorn
+pillow==11.3.0
     # via
     #   pillow-heif
     #   wagtail
-pillow-heif==0.14.0
+pillow-heif==1.1.1
     # via willow
-polib==1.1.1
+polib==1.2.0
     # via wagtail-localize
-psutil==5.9.0
+psutil==7.2.1
     # via scout-apm
 psycopg2-binary==2.9.11
     # via -r requirements.in
@@ -173,18 +177,19 @@ pyasn1==0.6.2
     # via
     #   python-jose
     #   rsa
-pycparser==2.21
+pycparser==2.23
     # via cffi
 pygit2==1.14.0
     # via
     #   -r requirements.in
     #   wagtail-localize-git
-pyjwt==2.4.0
-    # via social-auth-core
-python-dateutil==2.8.2
+pyjwt[crypto]==2.10.1
+    # via
+    #   pyjwt
+    #   social-auth-core
+python-dateutil==2.9.0.post0
     # via
     #   botocore
-    #   faker
     #   heroku3
 python-jose==3.5.0
     # via -r requirements.in
@@ -192,15 +197,11 @@ python-slugify==8.0.4
     # via -r requirements.in
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2023.3.post1
-    # via
-    #   django-modelcluster
-    #   l18n
 pyyaml==6.0.1
     # via django-pattern-library
-redis==4.5.4
+redis==7.1.0
     # via django-redis
-requests==2.32.3
+requests==2.32.5
     # via
     #   -r requirements.in
     #   basket-client
@@ -208,31 +209,29 @@ requests==2.32.3
     #   requests-oauthlib
     #   social-auth-core
     #   wagtail
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via social-auth-core
-rsa==4.9
+rsa==4.9.1
     # via python-jose
-s3transfer==0.10.0
+s3transfer==0.16.0
     # via boto3
-scipy==1.10.0
+scipy==1.17.0
     # via wagtail-ab-testing
-scout-apm==3.2.1
+scout-apm==3.5.2
     # via -r requirements.in
-sentry-sdk==2.25.0
+sentry-sdk==2.49.0
     # via -r requirements.in
 six==1.16.0
     # via
-    #   basket-client
     #   ecdsa
-    #   l18n
     #   python-dateutil
-smmap==5.0.0
+smmap==5.0.2
     # via gitdb
 social-auth-app-django==5.4.3
     # via -r requirements.in
-social-auth-core==4.4.1
+social-auth-core==4.8.3
     # via social-auth-app-django
-soupsieve==2.3.1
+soupsieve==2.8.2
     # via beautifulsoup4
 sqlparse==0.5.0
     # via django
@@ -246,10 +245,14 @@ tqdm==4.63.0
     # via wagtail-inventory
 typing-extensions==4.4.0
     # via
-    #   dj-database-url
+    #   beautifulsoup4
+    #   django-stubs-ext
+    #   django-tasks
     #   wagtail-localize
-ua-parser==0.18.0
+ua-parser==1.0.1
     # via user-agents
+ua-parser-builtins==202601
+    # via ua-parser
 urllib3==2.6.3
     # via
     #   botocore
@@ -258,7 +261,7 @@ urllib3==2.6.3
     #   sentry-sdk
 user-agents==2.2.0
     # via wagtail-ab-testing
-wagtail==6.3.2
+wagtail==6.4.2
     # via
     #   -r requirements.in
     #   wagtail-ab-testing
@@ -272,13 +275,13 @@ wagtail==6.3.2
     #   wagtailmedia
 wagtail-ab-testing==0.12
     # via -r requirements.in
-wagtail-color-panel==1.6.0
+wagtail-color-panel==1.7.1
     # via -r requirements.in
-wagtail-factories==4.2.1
+wagtail-factories==4.3.0
     # via -r requirements.in
-wagtail-footnotes==0.13.0
+wagtail-footnotes==0.14.0
     # via -r requirements.in
-wagtail-inventory==3.1
+wagtail-inventory==3.2
     # via -r requirements.in
 wagtail-localize==1.12.2
     # via
@@ -288,15 +291,15 @@ wagtail-localize-git==0.15.0
     # via -r requirements.in
 wagtail-metadata==5.0.0
     # via -r requirements.in
-wagtailmedia==0.15.2
+wagtailmedia==0.17.2
     # via -r requirements.in
 wand==0.6.13
     # via -r requirements.in
-whitenoise==6.9.0
+whitenoise==6.11.0
     # via -r requirements.in
-willow[heif]==1.8.0
+willow[heif]==1.12.0
     # via
     #   wagtail
     #   willow
-wrapt==1.16.0
+wrapt==1.17.3
     # via scout-apm


### PR DESCRIPTION
# Description

This PR bumps Wagtail from 6.3.2 to 6.4.2

Related PRs: [dependabot/15029](https://github.com/MozillaFoundation/foundation.mozilla.org/pull/15029)
`The upgrade to Wagtail 7.2 will be done gradually for the reasons discussed` [here](https://mozilla-hub.atlassian.net/browse/TP1-3505).

Related issue: https://mozilla-hub.atlassian.net/browse/TP1-3549

### Main changes
- Include `Type Ignore` in legacy tests, tests did not change, but after upgrading to `Wagtail 6.4.2`, **_pip-tools_** also upgraded **factory-boy** from 3.3.1 to 3.3.3 (via wagtail-factories).
This version [exposes stricter typing](https://factoryboy.readthedocs.io/en/3.3.3/changelog.html#id3:~:text=%EF%83%81-,3%2E3%2E3%20%282025%2D02%2D03) which caused mypy to start flagging dynamic factory attributes. 

