### PR TITLE
[DO NOT MERGE] (For Test Only) verify visual regression workflow triggers on legacy changes

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -15,12 +15,42 @@ on:
       - 'foundation_cms/legacy_apps/**'
       - 'frontend/legacy/**'
 jobs:
+  # GitHub Actions does not support paths filtering on pull_request_review events natively.
+  # This job runs on PR approval and uses the GitHub API to check if any legacy files changed.
+  # The result is passed as an output to the visual_regression_tests job.
+  check-changes:
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    outputs:
+      legacy: ${{ steps.check.outputs.legacy }}
+    steps:
+      - uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const legacyChanged = files.some(f =>
+              f.filename.startsWith('foundation_cms/legacy_apps/') ||
+              f.filename.startsWith('frontend/legacy/')
+            );
+            core.setOutput('legacy', legacyChanged ? 'true' : 'false');
+
   visual_regression_tests:
     name: Percy CI - Legacy
+    needs: [check-changes]
+    # always() prevents this job from being skipped when check-changes is skipped
+    # (i.e. on push and labeled events, check-changes does not run).
+    # For pull_request_review, we additionally gate on the legacy output from check-changes.
     if: |
-      (github.event_name == 'push' && github.event.ref == 'refs/heads/main' ) ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'run:visual-regression:legacy') ||
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+      always() && (
+        (github.event_name == 'push' && github.event.ref == 'refs/heads/main') ||
+        (github.event_name == 'pull_request' && github.event.label.name == 'run:visual-regression:legacy') ||
+        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && needs.check-changes.outputs.legacy == 'true')
+      )
     runs-on: ubuntu-22.04
     services:
       postgres:

--- a/foundation_cms/legacy_apps/static/sass/main.scss
+++ b/foundation_cms/legacy_apps/static/sass/main.scss
@@ -1,3 +1,5 @@
+// test
+
 // mofo-bootstrap
 @import "./mofo-bootstrap/mofo-bootstrap.scss";
 


### PR DESCRIPTION
This is a throwaway PR to validate the workflow changes in PR #15484 . It adds a dummy comment to a legacy SCSS file so that the path filters match and all three trigger scenarios can be tested:

- Label `run:visual-regression:legacy` triggers tests
- PR approval triggers tests