### PR TITLE
ci: fix -cov typo so backend test coverage is actually collected

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -137,7 +137,7 @@ jobs:
           python ./manage.py block_inventory
           python ./manage.py compilemessages
       - name: Run Tests
-        run: cd foundation_cms && pytest -n auto -v --ds=foundation_cms.settings.base -cov=foundation_cms --cov-report=term-missing
+        run: cd foundation_cms && pytest -n auto -v --ds=foundation_cms.settings.base --cov=foundation_cms --cov-report=term-missing
 
   test_integration:
     name: Integration testing

--- a/foundation_cms/legacy_apps/events/tests.py
+++ b/foundation_cms/legacy_apps/events/tests.py
@@ -105,7 +105,7 @@ class TitoTicketCompletedTest(TestCase):
         with self.assertLogs(logger="foundation_cms.legacy_apps.events.views", level="ERROR") as cm:
             response = tito_ticket_completed(request)
             self.assertEqual(response.status_code, 202)
-            self.assertIn("Basket subscription from Tito webhook failed", cm.output[0])
+            self.assertIn("Subscription from Tito webhook failed", cm.output[0])
 
 
 class TitoWidgetBlockLocalizationTest(TestCase):


### PR DESCRIPTION
# Description

`.github/workflows/continous-integration.yml:140` has` -cov=foundation_cms` instead of `--cov=foundation_cms`. Single dash gets misparsed as `pytest`'s -c (config-file) flag (see [doc](https://docs.pytest.org/en/stable/reference/reference.html#complete-help-output)), so coverage is never actually turned on.

This PR fixes the typo by adding the missing `-` (see pytest-cov [doc](https://pytest-cov.readthedocs.io/en/latest/config.html))

Related PRs/issues: [Jira TP1-4170](https://mozilla-hub.atlassian.net/browse/TP1-4170) / #16414 

## Unrelated CI failure uncovered by this fix

(See [CI error uncovered](https://github.com/MozillaFoundation/foundation.mozilla.org/actions/runs/31563257163/job/94009793490?pr=16415#step:10:3232) from my first commit in this PR)

The same `-c` misparse was also blocking `pyproject.toml`'s `python_files = "tests.py test_*.py *_tests.py"` setting from loading, so `legacy_apps/events/tests.py` was never being collected by CI at all. Fixing the typo let it run for the first time and surfaced a stale assertion: `test_logs_basket_exception` expected `"Basket subscription from Tito webhook failed"` in the log, but `views.py` actually logs `"Subscription from Tito webhook failed"` (no "Basket"). Updated the assertion to match.


# To Test
- Verify that CI log in this PR shows coverage result (https://github.com/MozillaFoundation/foundation.mozilla.org/actions/runs/31563257163/job/94009793490?pr=16415#step:10:2054)
- Verify [CI is green](https://github.com/MozillaFoundation/foundation.mozilla.org/actions/runs/31566069548/job/94018008573?pr=16415#step:10:172), including `legacy_apps/events/tests.py::TitoTicketCompletedTest::test_logs_basket_exception` (the test newly surfaced and fixed above)

