### PR TITLE
Change database engine version references

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -133,7 +133,7 @@ jobs:
     needs: preroll
     services:
       postgres:
-        image: postgres:15
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -204,7 +204,7 @@ jobs:
     needs: preroll
     services:
       postgres:
-        image: postgres:15
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/visual-regression-testing-legacy.yml
+++ b/.github/workflows/visual-regression-testing-legacy.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/visual-regression-testing-redesign.yml
+++ b/.github/workflows/visual-regression-testing-redesign.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgres:14
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Mozilla Foundation site",
   "description": "Mozilla Foundation site",
   "stack": "heroku-24",
-  "addons": ["heroku-postgresql:basic --version=15"],
+  "addons": ["heroku-postgresql:essential-0 --version=18"],
   "formation": {
     "web": {
       "quantity": 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:15
+    image: postgres:18
     ports:
       - "5678:5432"
     environment:


### PR DESCRIPTION
# Description

This PR intends to upgrade all references of our current PostgreSQL db in version 15 to Heroku's latest available engine version, v18.

Preview apps have already been running on v18 for months now, and staging is going in first for at least a week before prod is ready to upgrade. These changes are mostly for local development and keep code documented and reflecting the current state of our stack. 

Link to sample test page:
Related PRs/issues: #

# Checklist

<!-- Check off items with `[x]` or cross out items that don't apply with `~~The description~~` -->

**Tests**
- [ ] Is the code I'm adding covered by tests?

**Changes in Models:**
- [ ] Did I update or add new fake data?
- [ ] Did I squash my migration?
- [ ] Are my changes [backward-compatible](https://github.com/mozilla/foundation.mozilla.org/blob/main/docs/workflow.md#django-migrations-what-to-do-when-working-on-backward-incompatible-migrations). If not, did I schedule a deploy with the rest of the team?

**Documentation:**
- [ ] Is my code documented?
- [ ] Did I update the READMEs or wagtail documentation?

**Merge Method**
**💡❗Remember to use squash merge when merging non-feature branches into `main`**
