### PR TITLE
Restore Nothing Personal homepage blocks in the editor

### DIFF
--- a/foundation_cms/blocks/tests/test_text_image_block.py
+++ b/foundation_cms/blocks/tests/test_text_image_block.py
@@ -1,0 +1,11 @@
+from django.test import SimpleTestCase
+
+from foundation_cms.blocks.text_image_block import TextMediaBlock
+
+
+class TextMediaBlockTests(SimpleTestCase):
+    def test_form_layout_only_references_defined_child_blocks(self):
+        block = TextMediaBlock()
+
+        self.assertNotIn("image", block.child_blocks)
+        self.assertEqual(block.meta.form_layout.children, list(block.child_blocks))

--- a/foundation_cms/blocks/text_image_block.py
+++ b/foundation_cms/blocks/text_image_block.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from wagtail import blocks
 
 from foundation_cms.base.models.base_block import BaseBlock
@@ -37,7 +39,7 @@ class TextMediaBlock(TextImageBlock):
           TextImageBlock with a `ChoiceBlock` for style/variant selection.
     """
 
-    image = None
+    image: Any = None
 
     background_color = blocks.ChoiceBlock(
         choices=[

--- a/foundation_cms/blocks/text_image_block.py
+++ b/foundation_cms/blocks/text_image_block.py
@@ -37,6 +37,8 @@ class TextMediaBlock(TextImageBlock):
           TextImageBlock with a `ChoiceBlock` for style/variant selection.
     """
 
+    image = None
+
     background_color = blocks.ChoiceBlock(
         choices=[
             ("white", "White"),
@@ -59,10 +61,6 @@ class TextMediaBlock(TextImageBlock):
         default="white",
     )
     media = CustomMediaBlock(required=False)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.child_blocks.pop("image", None)
 
     class Meta:
         icon = "image"


### PR DESCRIPTION
## Description

Restores all persisted Nothing Personal homepage blocks in Wagtail's editor by keeping the Text & Media block's form layout aligned with its Telepath child definitions.

## What Changed

- Removes the inherited image field through Wagtail's declarative field-shadowing pattern.
- Prevents StreamField initialization from stopping at the first Text & Media block.
- Adds regression coverage for Text & Media form-layout and child-block parity.

## QA

Review app:

- [Nothing Personal homepage](https://foundation-s-tp1-4192-f-dajkah.mofostaging.net/en/nothing-personal/)
- [CMS test page](https://foundation-s-tp1-4192-f-dajkah.mofostaging.net/cms/pages/26/edit/)

Verify that:

- The editor displays these blocks in order: Product Review Carousel, video-backed Humor, image-backed How to Disappear, image-backed Our Podcast, and Two Column Who We Are.
- Reloading the editor keeps all five blocks visible without a StreamField initializer error.
- The public homepage renders the fixture headings and images.

## Screenshots

| Before | After |
| --- | --- |
| ![Wagtail editor preview stops after Product Reviews and jumps to the site footer](https://github.com/user-attachments/assets/bfbf0be6-d0b2-44fe-810e-212cdfb1dfc2) | ![Wagtail editor preview continues from Product Reviews to Humor and How to Disappear](https://github.com/user-attachments/assets/0017ff77-7a7a-4f78-a439-be2d286f1b3b) |
| *Before: The editor preview stops after Product Reviews; persisted later homepage blocks are absent.* | *After: Humor and How to Disappear remain visible, with the remaining persisted blocks continuing below.* |

Related PRs/issues: [TP1-4192](https://mozilla-hub.atlassian.net/browse/TP1-4192)