### PR TITLE
test(vitest): add Vitest coverage for primary nav components

### DIFF
--- a/foundation_cms/static/js/components/primary_nav/config.test.js
+++ b/foundation_cms/static/js/components/primary_nav/config.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLASSNAMES,
+  DESKTOP_BREAKPOINT,
+  DROPDOWN_DELAY,
+  EVENTS,
+  SELECTORS,
+  TRANSITION_DURATION,
+} from "./config.js";
+
+describe("primary nav config", () => {
+  it("exports stable selectors for nav elements", () => {
+    expect(SELECTORS.primaryNav).toBe(".primary-nav-ns");
+    expect(SELECTORS.hamburger).toBe(".primary-nav-ns .hamburger");
+    expect(SELECTORS.dropdown).toBe(".primary-nav-ns__dropdown");
+    expect(SELECTORS.searchToggle).toBe(
+      ".primary-nav-ns__search-icon .search-toggle",
+    );
+  });
+
+  it("exports class names and timing constants used by nav behavior", () => {
+    expect(CLASSNAMES.open).toBe("open");
+    expect(CLASSNAMES.searchOpen).toBe("search-open");
+    expect(CLASSNAMES.navOpen).toBe("primary-nav-ns-open");
+    expect(TRANSITION_DURATION).toBe(300);
+    expect(DROPDOWN_DELAY).toBe(200);
+    expect(DESKTOP_BREAKPOINT).toBe(1024);
+  });
+
+  it("exports cross-module coordination events", () => {
+    expect(EVENTS.primaryNavWillOpen).toBe("primaryNav:willOpen");
+    expect(EVENTS.searchWillOpen).toBe("primaryNav:searchWillOpen");
+  });
+});

--- a/foundation_cms/static/js/components/primary_nav/index.test.js
+++ b/foundation_cms/static/js/components/primary_nav/index.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import * as primaryNav from "./index.js";
+
+describe("primary nav index", () => {
+  it("re-exports the primary nav entry points", () => {
+    expect(typeof primaryNav.initPrimaryNav).toBe("function");
+    expect(typeof primaryNav.initWordmarkVisibilityOnScroll).toBe("function");
+    expect(typeof primaryNav.initSearchToggle).toBe("function");
+  });
+});

--- a/foundation_cms/static/js/components/primary_nav/primary_nav.test.js
+++ b/foundation_cms/static/js/components/primary_nav/primary_nav.test.js
@@ -3,7 +3,33 @@ import {
   initPrimaryNav,
   initWordmarkVisibilityOnScroll,
 } from "./primary_nav.js";
-import { CLASSNAMES, DROPDOWN_DELAY, EVENTS } from "./config.js";
+import {
+  CLASSNAMES,
+  DESKTOP_BREAKPOINT,
+  DROPDOWN_DELAY,
+  EVENTS,
+} from "./config.js";
+
+let eventListenerCleanups;
+
+/**
+ * Tracks listeners added to shared event targets so tests can remove them.
+ *
+ * @param {EventTarget[]} targets
+ */
+function trackEventListeners(targets) {
+  targets.forEach((target) => {
+    const addEventListener = target.addEventListener.bind(target);
+    vi.spyOn(target, "addEventListener").mockImplementation(
+      (type, listener, options) => {
+        addEventListener(type, listener, options);
+        eventListenerCleanups.push(() =>
+          target.removeEventListener(type, listener, options),
+        );
+      },
+    );
+  });
+}
 
 function buildPrimaryNavMarkup() {
   document.body.innerHTML = `
@@ -26,11 +52,16 @@ function buildPrimaryNavMarkup() {
 
 describe("initPrimaryNav", () => {
   beforeEach(() => {
-    document.body.innerHTML = "";
+    document.body.replaceWith(document.createElement("body"));
+    document.documentElement.style.removeProperty("--primary-nav-search-top");
+    eventListenerCleanups = [];
+    trackEventListeners([document, document.body]);
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    eventListenerCleanups.reverse().forEach((cleanup) => cleanup());
+    document.documentElement.style.removeProperty("--primary-nav-search-top");
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -133,6 +164,62 @@ describe("initPrimaryNav", () => {
     expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
   });
 
+  it("closes an open dropdown on desktop mouseleave", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(1200);
+
+    initPrimaryNav();
+
+    menu.dispatchEvent(new MouseEvent("mouseenter"));
+    vi.advanceTimersByTime(DROPDOWN_DELAY);
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
+
+    menu.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
+
+    vi.advanceTimersByTime(DROPDOWN_DELAY);
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(false);
+  });
+
+  it("cancels a pending desktop hover opening on mouseleave", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(1200);
+
+    initPrimaryNav();
+
+    menu.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(vi.getTimerCount()).toBe(1);
+
+    menu.dispatchEvent(new MouseEvent("mouseleave"));
+    vi.advanceTimersByTime(DROPDOWN_DELAY);
+
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(false);
+  });
+
+  it("ignores hover events below the desktop breakpoint", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(
+      DESKTOP_BREAKPOINT - 1,
+    );
+
+    initPrimaryNav();
+    const timerCountBeforeHover = vi.getTimerCount();
+
+    menu.dispatchEvent(new MouseEvent("mouseenter"));
+    menu.dispatchEvent(new MouseEvent("mouseleave"));
+
+    expect(vi.getTimerCount()).toBe(timerCountBeforeHover);
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(false);
+    expect(
+      menu
+        .querySelector(".primary-nav-ns__dropdown-toggle")
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
   it("closes open dropdowns when Escape is pressed", () => {
     buildPrimaryNavMarkup();
     const menu = document.querySelector(".primary-nav-ns__menu-item");
@@ -153,7 +240,8 @@ describe("initWordmarkVisibilityOnScroll", () => {
   let observerCallback;
 
   beforeEach(() => {
-    document.body.innerHTML = "";
+    document.body.replaceWith(document.createElement("body"));
+    document.documentElement.style.removeProperty("--primary-nav-search-top");
     observerCallback = null;
     vi.stubGlobal(
       "IntersectionObserver",
@@ -168,6 +256,7 @@ describe("initWordmarkVisibilityOnScroll", () => {
   });
 
   afterEach(() => {
+    document.documentElement.style.removeProperty("--primary-nav-search-top");
     vi.unstubAllGlobals();
   });
 

--- a/foundation_cms/static/js/components/primary_nav/primary_nav.test.js
+++ b/foundation_cms/static/js/components/primary_nav/primary_nav.test.js
@@ -1,0 +1,220 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  initPrimaryNav,
+  initWordmarkVisibilityOnScroll,
+} from "./primary_nav.js";
+import { CLASSNAMES, DROPDOWN_DELAY, EVENTS } from "./config.js";
+
+function buildPrimaryNavMarkup() {
+  document.body.innerHTML = `
+    <nav class="primary-nav-ns">
+      <button class="hamburger" type="button"></button>
+      <div class="primary-nav-ns__grid">
+        <div class="primary-nav-ns__wordmark"></div>
+      </div>
+      <ul>
+        <li class="primary-nav-ns__menu-item">
+          <a href="/topics">Topics</a>
+          <div class="primary-nav-ns__dropdown">
+            <a href="/topic-one">Topic one</a>
+          </div>
+        </li>
+      </ul>
+    </nav>
+  `;
+}
+
+describe("initPrimaryNav", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when required nav elements are missing", () => {
+    document.body.innerHTML = `<nav class="primary-nav-ns"></nav>`;
+
+    expect(() => initPrimaryNav()).not.toThrow();
+    expect(document.querySelector(".hamburger")).toBeNull();
+  });
+
+  it("toggles the mobile nav drawer when the hamburger is clicked", () => {
+    buildPrimaryNavMarkup();
+    const nav = document.querySelector(".primary-nav-ns");
+    const hamburger = document.querySelector(".hamburger");
+
+    initPrimaryNav();
+
+    hamburger.click();
+    expect(nav.classList.contains(CLASSNAMES.open)).toBe(true);
+    expect(hamburger.classList.contains(CLASSNAMES.active)).toBe(true);
+    expect(document.body.classList.contains(CLASSNAMES.navOpen)).toBe(true);
+
+    hamburger.click();
+    expect(nav.classList.contains(CLASSNAMES.open)).toBe(false);
+    expect(hamburger.classList.contains(CLASSNAMES.active)).toBe(false);
+
+    vi.advanceTimersByTime(300);
+    expect(document.body.classList.contains(CLASSNAMES.navOpen)).toBe(false);
+  });
+
+  it("closes the mobile nav drawer when search is about to open", () => {
+    buildPrimaryNavMarkup();
+    const nav = document.querySelector(".primary-nav-ns");
+    const hamburger = document.querySelector(".hamburger");
+
+    initPrimaryNav();
+    hamburger.click();
+    expect(nav.classList.contains(CLASSNAMES.open)).toBe(true);
+
+    document.dispatchEvent(new CustomEvent(EVENTS.searchWillOpen));
+
+    expect(nav.classList.contains(CLASSNAMES.open)).toBe(false);
+    vi.advanceTimersByTime(300);
+    expect(document.body.classList.contains(CLASSNAMES.navOpen)).toBe(false);
+  });
+
+  it("creates a mobile dropdown toggle and opens it on click", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+    const dropdown = document.querySelector(".primary-nav-ns__dropdown");
+
+    initPrimaryNav();
+
+    const toggle = menu.querySelector(".primary-nav-ns__dropdown-toggle");
+    expect(toggle).not.toBeNull();
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(dropdown.getAttribute("aria-hidden")).toBe("true");
+    expect(dropdown.hasAttribute("inert")).toBe(true);
+
+    toggle.click();
+
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
+    expect(dropdown.style.maxHeight).toBe(`${dropdown.scrollHeight}px`);
+    expect(dropdown.getAttribute("aria-hidden")).toBe("false");
+    expect(dropdown.hasAttribute("inert")).toBe(false);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("toggles dropdowns with Enter and Space keyboard events", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+
+    initPrimaryNav();
+
+    const toggle = menu.querySelector(".primary-nav-ns__dropdown-toggle");
+
+    toggle.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
+
+    toggle.dispatchEvent(
+      new KeyboardEvent("keydown", { key: " ", bubbles: true }),
+    );
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(false);
+  });
+
+  it("opens dropdowns on desktop hover after the configured delay", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(1200);
+
+    initPrimaryNav();
+
+    menu.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(false);
+
+    vi.advanceTimersByTime(DROPDOWN_DELAY);
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
+  });
+
+  it("closes open dropdowns when Escape is pressed", () => {
+    buildPrimaryNavMarkup();
+    const menu = document.querySelector(".primary-nav-ns__menu-item");
+
+    initPrimaryNav();
+    menu.querySelector(".primary-nav-ns__dropdown-toggle").click();
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(true);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+
+    expect(menu.classList.contains(CLASSNAMES.open)).toBe(false);
+  });
+});
+
+describe("initWordmarkVisibilityOnScroll", () => {
+  let observerCallback;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    observerCallback = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      vi.fn((callback) => {
+        observerCallback = callback;
+        return {
+          observe: vi.fn(),
+          disconnect: vi.fn(),
+        };
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the wordmark when the kinetic type wordmark is absent", () => {
+    document.body.innerHTML = `
+      <nav class="primary-nav-ns">
+        <div class="primary-nav-ns__grid"></div>
+        <div class="primary-nav-ns__wordmark hidden"></div>
+      </nav>
+    `;
+    const wordmark = document.querySelector(".primary-nav-ns__wordmark");
+    const grid = document.querySelector(".primary-nav-ns__grid");
+
+    initWordmarkVisibilityOnScroll();
+
+    expect(wordmark.classList.contains(CLASSNAMES.hidden)).toBe(false);
+    expect(grid.classList.contains(CLASSNAMES.hiddenWordmark)).toBe(false);
+    expect(IntersectionObserver).not.toHaveBeenCalled();
+  });
+
+  it("hides the nav wordmark when the kinetic type wordmark intersects", () => {
+    document.body.innerHTML = `
+      <nav class="primary-nav-ns">
+        <div class="primary-nav-ns__grid"></div>
+        <div class="primary-nav-ns__wordmark"></div>
+      </nav>
+      <div class="kinetic-type-wordmark"></div>
+    `;
+    const wordmark = document.querySelector(".primary-nav-ns__wordmark");
+    const grid = document.querySelector(".primary-nav-ns__grid");
+
+    initWordmarkVisibilityOnScroll();
+
+    expect(IntersectionObserver).toHaveBeenCalledTimes(1);
+    observerCallback([{ isIntersecting: true }]);
+    expect(wordmark.classList.contains(CLASSNAMES.hidden)).toBe(true);
+    expect(grid.classList.contains(CLASSNAMES.hiddenWordmark)).toBe(true);
+
+    observerCallback([{ isIntersecting: false }]);
+    expect(wordmark.classList.contains(CLASSNAMES.hidden)).toBe(false);
+    expect(grid.classList.contains(CLASSNAMES.hiddenWordmark)).toBe(false);
+  });
+});

--- a/foundation_cms/static/js/components/primary_nav/primary_nav.test.js
+++ b/foundation_cms/static/js/components/primary_nav/primary_nav.test.js
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   initPrimaryNav,
   initWordmarkVisibilityOnScroll,

--- a/foundation_cms/static/js/components/primary_nav/search.test.js
+++ b/foundation_cms/static/js/components/primary_nav/search.test.js
@@ -1,0 +1,173 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { initSearchToggle } from "./search.js";
+import { CLASSNAMES, EVENTS } from "./config.js";
+
+function buildSearchMarkup() {
+  document.body.innerHTML = `
+    <nav class="primary-nav-ns"></nav>
+    <div class="primary-nav-ns__search-icon">
+      <button class="search-toggle" type="button">Search</button>
+    </div>
+    <div class="search-input-container" aria-hidden="true" inert>
+      <input type="search" />
+    </div>
+  `;
+}
+
+describe("initSearchToggle", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when required search elements are missing", () => {
+    document.body.innerHTML = `<button class="search-toggle"></button>`;
+
+    expect(() => initSearchToggle()).not.toThrow();
+  });
+
+  it("opens and closes the search drawer when the toggle is clicked", () => {
+    buildSearchMarkup();
+    const searchToggle = document.querySelector(".search-toggle");
+    const searchInputContainer = document.querySelector(
+      ".search-input-container",
+    );
+    const searchInput = document.querySelector(".search-input-container input");
+    const focusSpy = vi.spyOn(searchInput, "focus");
+
+    initSearchToggle();
+
+    searchToggle.click();
+
+    expect(searchToggle.classList.contains(CLASSNAMES.searchOpen)).toBe(true);
+    expect(searchInputContainer.classList.contains(CLASSNAMES.searchOpen)).toBe(
+      true,
+    );
+    expect(searchInputContainer.getAttribute("aria-expanded")).toBe("true");
+    expect(searchInputContainer.getAttribute("aria-hidden")).toBe("false");
+    expect(searchInputContainer.hasAttribute("inert")).toBe(false);
+    expect(searchToggle.getAttribute("aria-expanded")).toBe("true");
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    expect(
+      document.querySelector(`.${CLASSNAMES.searchOpenBackdrop}`),
+    ).not.toBeNull();
+
+    searchToggle.click();
+
+    expect(searchToggle.classList.contains(CLASSNAMES.searchOpen)).toBe(false);
+    expect(searchInputContainer.classList.contains(CLASSNAMES.searchOpen)).toBe(
+      false,
+    );
+    expect(searchInputContainer.getAttribute("aria-expanded")).toBe("false");
+    expect(searchInputContainer.getAttribute("aria-hidden")).toBe("true");
+    expect(searchInputContainer.hasAttribute("inert")).toBe(true);
+  });
+
+  it("dispatches searchWillOpen before opening the drawer", () => {
+    buildSearchMarkup();
+    const searchToggle = document.querySelector(".search-toggle");
+    const listener = vi.fn();
+
+    document.addEventListener(EVENTS.searchWillOpen, listener);
+    initSearchToggle();
+    searchToggle.click();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the search drawer when the primary nav is about to open", () => {
+    buildSearchMarkup();
+    const searchToggle = document.querySelector(".search-toggle");
+    const searchInputContainer = document.querySelector(
+      ".search-input-container",
+    );
+
+    initSearchToggle();
+    searchToggle.click();
+    expect(searchInputContainer.classList.contains(CLASSNAMES.searchOpen)).toBe(
+      true,
+    );
+
+    document.dispatchEvent(new CustomEvent(EVENTS.primaryNavWillOpen));
+
+    expect(searchInputContainer.classList.contains(CLASSNAMES.searchOpen)).toBe(
+      false,
+    );
+  });
+
+  it("positions the search drawer below the primary nav", () => {
+    buildSearchMarkup();
+    const primaryNav = document.querySelector(".primary-nav-ns");
+    const searchToggle = document.querySelector(".search-toggle");
+
+    vi.spyOn(primaryNav, "getBoundingClientRect").mockReturnValue({
+      bottom: 88.4,
+    });
+
+    initSearchToggle();
+    searchToggle.click();
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--primary-nav-search-top",
+      ),
+    ).toBe("88px");
+  });
+
+  it("closes the search drawer when Escape is pressed in the input", () => {
+    buildSearchMarkup();
+    const searchToggle = document.querySelector(".search-toggle");
+    const searchInput = document.querySelector(".search-input-container input");
+    const searchInputContainer = document.querySelector(
+      ".search-input-container",
+    );
+    const focusSpy = vi.spyOn(searchToggle, "focus");
+
+    initSearchToggle();
+    searchToggle.click();
+
+    searchInput.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+
+    expect(searchInputContainer.classList.contains(CLASSNAMES.searchOpen)).toBe(
+      false,
+    );
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it("closes the search drawer when the backdrop is clicked", () => {
+    buildSearchMarkup();
+    const searchToggle = document.querySelector(".search-toggle");
+    const searchInputContainer = document.querySelector(
+      ".search-input-container",
+    );
+    const focusSpy = vi.spyOn(searchToggle, "focus");
+
+    initSearchToggle();
+    searchToggle.click();
+
+    document
+      .querySelector(`.${CLASSNAMES.searchOpenBackdrop}`)
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(searchInputContainer.classList.contains(CLASSNAMES.searchOpen)).toBe(
+      false,
+    );
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  });
+});

--- a/foundation_cms/static/js/components/primary_nav/search.test.js
+++ b/foundation_cms/static/js/components/primary_nav/search.test.js
@@ -2,6 +2,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initSearchToggle } from "./search.js";
 import { CLASSNAMES, EVENTS } from "./config.js";
 
+let eventListenerCleanups;
+
+/**
+ * Tracks listeners added to shared event targets so tests can remove them.
+ *
+ * @param {EventTarget[]} targets
+ */
+function trackEventListeners(targets) {
+  targets.forEach((target) => {
+    const addEventListener = target.addEventListener.bind(target);
+    vi.spyOn(target, "addEventListener").mockImplementation(
+      (type, listener, options) => {
+        addEventListener(type, listener, options);
+        eventListenerCleanups.push(() =>
+          target.removeEventListener(type, listener, options),
+        );
+      },
+    );
+  });
+}
+
 function buildSearchMarkup() {
   document.body.innerHTML = `
     <nav class="primary-nav-ns"></nav>
@@ -16,7 +37,10 @@ function buildSearchMarkup() {
 
 describe("initSearchToggle", () => {
   beforeEach(() => {
-    document.body.innerHTML = "";
+    document.body.replaceWith(document.createElement("body"));
+    document.documentElement.style.removeProperty("--primary-nav-search-top");
+    eventListenerCleanups = [];
+    trackEventListeners([document, document.body, window]);
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       callback(0);
       return 1;
@@ -24,6 +48,8 @@ describe("initSearchToggle", () => {
   });
 
   afterEach(() => {
+    eventListenerCleanups.reverse().forEach((cleanup) => cleanup());
+    document.documentElement.style.removeProperty("--primary-nav-search-top");
     vi.restoreAllMocks();
   });
 
@@ -102,14 +128,15 @@ describe("initSearchToggle", () => {
     );
   });
 
-  it("positions the search drawer below the primary nav", () => {
+  it("repositions the search drawer on resize and scroll", () => {
     buildSearchMarkup();
     const primaryNav = document.querySelector(".primary-nav-ns");
     const searchToggle = document.querySelector(".search-toggle");
+    let navBottom = 88.4;
 
-    vi.spyOn(primaryNav, "getBoundingClientRect").mockReturnValue({
-      bottom: 88.4,
-    });
+    vi.spyOn(primaryNav, "getBoundingClientRect").mockImplementation(() => ({
+      bottom: navBottom,
+    }));
 
     initSearchToggle();
     searchToggle.click();
@@ -119,6 +146,24 @@ describe("initSearchToggle", () => {
         "--primary-nav-search-top",
       ),
     ).toBe("88px");
+
+    navBottom = 121.6;
+    window.dispatchEvent(new Event("resize"));
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--primary-nav-search-top",
+      ),
+    ).toBe("122px");
+
+    navBottom = 43.2;
+    window.dispatchEvent(new Event("scroll"));
+
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--primary-nav-search-top",
+      ),
+    ).toBe("43px");
   });
 
   it("closes the search drawer when Escape is pressed in the input", () => {

--- a/foundation_cms/static/js/components/primary_nav/search.test.js
+++ b/foundation_cms/static/js/components/primary_nav/search.test.js
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initSearchToggle } from "./search.js";
 import { CLASSNAMES, EVENTS } from "./config.js";
 


### PR DESCRIPTION
## Summary

Adds Vitest unit tests for the primary nav JavaScript modules under `foundation_cms/static/js/components/primary_nav/`.

- `config.test.js`: exported selectors, class names, timing constants, and coordination events
- `index.test.js`: re-exported entry points
- `primary_nav.test.js`: mobile drawer, dropdown toggles, desktop hover open/close delays, pending hover cancellation, mobile hover behavior, Escape handling, and wordmark visibility via mocked `IntersectionObserver`
- `search.test.js`: search drawer open/close, cross-module events, positioning updates on resize and scroll, Escape/backdrop handling, and mocked `requestAnimationFrame`
- Improves test isolation by cleaning up global listeners, replacing the document body, and resetting `--primary-nav-search-top` between tests

## Ticket

https://mozilla-hub.atlassian.net/browse/TP1-4147

Related GitHub issue: #16391

## Heroku preview app
N/A

## How to test locally

From the repo root:

```sh
yarn install
yarn workspace redesign test
```

Expected result: all tests pass, including the new primary nav test files.

Optional watch mode while iterating:

```sh
yarn workspace redesign test:watch
```

## Checklist

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~Did I update or add new fake data?~~
- ~~Did I squash my migration?~~
- ~~Are my changes backward-compatible. If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~
