### PR TITLE
test(vitest): add Vitest coverage for donate components

### DIFF
--- a/foundation_cms/static/js/components/donate_banner.test.js
+++ b/foundation_cms/static/js/components/donate_banner.test.js
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initDonateBanner } from "./donate_banner.js";
+
+const DISMISS_KEY = "donate banner dismiss day";
+
+function buildBannerMarkup({
+  bannerStyle = "pushdown",
+  siteType = "redesign",
+} = {}) {
+  document.body.innerHTML = `
+    <nav class="primary-nav-ns"></nav>
+    <main></main>
+    <div class="primary-nav-container-wrapper"></div>
+    <div class="donate-banner" data-banner-style="${bannerStyle}">
+      <button data-donate-banner-close-button type="button">Close</button>
+      <button data-donate-banner-skip-button type="button">Skip</button>
+      <a data-donate-banner-cta-button href="#">Donate</a>
+      <a class="donate-banner__cta-button" href="#">Legacy donate</a>
+    </div>
+  `;
+  document.body.dataset.siteType = siteType;
+}
+
+describe("initDonateBanner", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+    });
+    delete window.wagtailAbTesting;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when the donate banner is missing", () => {
+    document.body.innerHTML = "";
+    document.body.dataset.siteType = "redesign";
+
+    expect(() => initDonateBanner()).not.toThrow();
+  });
+
+  it("removes a legacy banner that was dismissed today", () => {
+    buildBannerMarkup({ bannerStyle: "legacy" });
+    const today = new Date().toDateString();
+    localStorage.getItem.mockReturnValue(today);
+
+    initDonateBanner();
+
+    expect(document.querySelector(".donate-banner")).toBeNull();
+  });
+
+  it("shows a legacy banner that has not been dismissed today", () => {
+    buildBannerMarkup({ bannerStyle: "legacy" });
+    localStorage.getItem.mockReturnValue(null);
+    const banner = document.querySelector(".donate-banner");
+
+    initDonateBanner();
+
+    expect(banner.classList.contains("donate-banner--visible")).toBe(true);
+  });
+
+  it("persists dismissal and removes a legacy banner when closed", () => {
+    buildBannerMarkup({ bannerStyle: "legacy" });
+    localStorage.getItem.mockReturnValue(null);
+    const banner = document.querySelector(".donate-banner");
+    const closeButton = banner.querySelector(
+      "[data-donate-banner-close-button]",
+    );
+
+    initDonateBanner();
+    closeButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      DISMISS_KEY,
+      new Date().toDateString(),
+    );
+    expect(document.querySelector(".donate-banner")).toBeNull();
+  });
+
+  it("removes non-legacy banners without persisting dismissal", () => {
+    buildBannerMarkup({ bannerStyle: "pushdown" });
+    const banner = document.querySelector(".donate-banner");
+    const closeButton = banner.querySelector(
+      "[data-donate-banner-close-button]",
+    );
+
+    initDonateBanner();
+    closeButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+    expect(document.querySelector(".donate-banner")).toBeNull();
+  });
+
+  it("scrolls to the redesign skip target for pushdown banners", () => {
+    buildBannerMarkup({ bannerStyle: "pushdown", siteType: "redesign" });
+    const skipTarget = document.querySelector("nav.primary-nav-ns");
+    skipTarget.scrollIntoView = vi.fn();
+
+    initDonateBanner();
+    document
+      .querySelector("[data-donate-banner-skip-button]")
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(skipTarget.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+    });
+  });
+
+  it("uses legacy selectors when the site type is legacy", () => {
+    buildBannerMarkup({ bannerStyle: "pushdown", siteType: "legacy" });
+    const skipTarget = document.querySelector("main");
+    skipTarget.scrollIntoView = vi.fn();
+
+    initDonateBanner();
+    document
+      .querySelector("[data-donate-banner-skip-button]")
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(skipTarget.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+    });
+  });
+
+  it("tracks donate CTA clicks when wagtail A/B testing is enabled", () => {
+    buildBannerMarkup();
+    window.wagtailAbTesting = {
+      triggerEvent: vi.fn(),
+    };
+    const ctaButton = document.querySelector("[data-donate-banner-cta-button]");
+
+    initDonateBanner();
+    ctaButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(window.wagtailAbTesting.triggerEvent).toHaveBeenCalledWith(
+      "donate-banner-link-click",
+    );
+  });
+});

--- a/foundation_cms/static/js/components/donate_banner.test.js
+++ b/foundation_cms/static/js/components/donate_banner.test.js
@@ -139,4 +139,21 @@ describe("initDonateBanner", () => {
       "donate-banner-link-click",
     );
   });
+
+  it("tracks legacy donate CTA clicks when wagtail A/B testing is enabled", () => {
+    buildBannerMarkup({ siteType: "legacy" });
+    window.wagtailAbTesting = {
+      triggerEvent: vi.fn(),
+    };
+    const legacyCtaButton = document.querySelector(
+      ".donate-banner__cta-button",
+    );
+
+    initDonateBanner();
+    legacyCtaButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(window.wagtailAbTesting.triggerEvent).toHaveBeenCalledWith(
+      "donate-banner-link-click",
+    );
+  });
 });

--- a/foundation_cms/static/js/components/donate_lightbox.test.js
+++ b/foundation_cms/static/js/components/donate_lightbox.test.js
@@ -12,42 +12,60 @@ function buildLightboxMarkup() {
 }
 
 describe("initDonateLightbox", () => {
+  let showModalSpy;
+  let closeSpy;
+  let originalShowModal;
+  let originalClose;
+
   beforeEach(() => {
     document.body.innerHTML = "";
     delete window.wagtailAbTesting;
-    HTMLDialogElement.prototype.showModal = vi.fn();
-    HTMLDialogElement.prototype.close = vi.fn();
+    originalShowModal = HTMLDialogElement.prototype.showModal;
+    originalClose = HTMLDialogElement.prototype.close;
+    showModalSpy = vi.fn();
+    closeSpy = vi.fn();
+    HTMLDialogElement.prototype.showModal = showModalSpy;
+    HTMLDialogElement.prototype.close = closeSpy;
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    if (originalShowModal) {
+      HTMLDialogElement.prototype.showModal = originalShowModal;
+    } else {
+      delete HTMLDialogElement.prototype.showModal;
+    }
+
+    if (originalClose) {
+      HTMLDialogElement.prototype.close = originalClose;
+    } else {
+      delete HTMLDialogElement.prototype.close;
+    }
   });
 
   it("does nothing when the lightbox is missing", () => {
     document.body.innerHTML = "";
 
     expect(() => initDonateLightbox()).not.toThrow();
+    expect(showModalSpy).not.toHaveBeenCalled();
   });
 
   it("opens the lightbox on initialization", () => {
     buildLightboxMarkup();
-    const lightbox = document.querySelector("dialog.donate-lightbox");
 
     initDonateLightbox();
 
-    expect(lightbox.showModal).toHaveBeenCalledTimes(1);
+    expect(showModalSpy).toHaveBeenCalledTimes(1);
   });
 
   it("closes the lightbox when the close button is clicked", () => {
     buildLightboxMarkup();
-    const lightbox = document.querySelector("dialog.donate-lightbox");
 
     initDonateLightbox();
     document
       .querySelector("[data-donate-lightbox-close-button]")
       .dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    expect(lightbox.close).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("closes the lightbox when clicking the backdrop", () => {
@@ -59,12 +77,23 @@ describe("initDonateLightbox", () => {
       new MouseEvent("click", { bubbles: false, cancelable: true }),
     );
 
-    expect(lightbox.close).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close the lightbox when clicking inside the modal content", () => {
+    buildLightboxMarkup();
+
+    initDonateLightbox();
+    document
+      .querySelector(".donate-lightbox__content")
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(closeSpy).not.toHaveBeenCalled();
   });
 
   it("tracks donate CTA clicks and closes the lightbox", () => {
     buildLightboxMarkup();
-    const lightbox = document.querySelector("dialog.donate-lightbox");
+
     window.wagtailAbTesting = {
       triggerEvent: vi.fn(),
     };
@@ -77,6 +106,6 @@ describe("initDonateLightbox", () => {
     expect(window.wagtailAbTesting.triggerEvent).toHaveBeenCalledWith(
       "donate-banner-link-click",
     );
-    expect(lightbox.close).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/foundation_cms/static/js/components/donate_lightbox.test.js
+++ b/foundation_cms/static/js/components/donate_lightbox.test.js
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initDonateLightbox } from "./donate_lightbox.js";
+
+function buildLightboxMarkup() {
+  document.body.innerHTML = `
+    <dialog class="donate-lightbox">
+      <button data-donate-lightbox-close-button type="button">Close</button>
+      <a data-donate-banner-cta-button href="#">Donate</a>
+      <div class="donate-lightbox__content">Support Mozilla</div>
+    </dialog>
+  `;
+}
+
+describe("initDonateLightbox", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete window.wagtailAbTesting;
+    HTMLDialogElement.prototype.showModal = vi.fn();
+    HTMLDialogElement.prototype.close = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when the lightbox is missing", () => {
+    document.body.innerHTML = "";
+
+    expect(() => initDonateLightbox()).not.toThrow();
+  });
+
+  it("opens the lightbox on initialization", () => {
+    buildLightboxMarkup();
+    const lightbox = document.querySelector("dialog.donate-lightbox");
+
+    initDonateLightbox();
+
+    expect(lightbox.showModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the lightbox when the close button is clicked", () => {
+    buildLightboxMarkup();
+    const lightbox = document.querySelector("dialog.donate-lightbox");
+
+    initDonateLightbox();
+    document
+      .querySelector("[data-donate-lightbox-close-button]")
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(lightbox.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the lightbox when clicking the backdrop", () => {
+    buildLightboxMarkup();
+    const lightbox = document.querySelector("dialog.donate-lightbox");
+
+    initDonateLightbox();
+    lightbox.dispatchEvent(
+      new MouseEvent("click", { bubbles: false, cancelable: true }),
+    );
+
+    expect(lightbox.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks donate CTA clicks and closes the lightbox", () => {
+    buildLightboxMarkup();
+    const lightbox = document.querySelector("dialog.donate-lightbox");
+    window.wagtailAbTesting = {
+      triggerEvent: vi.fn(),
+    };
+
+    initDonateLightbox();
+    document
+      .querySelector("[data-donate-banner-cta-button]")
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(window.wagtailAbTesting.triggerEvent).toHaveBeenCalledWith(
+      "donate-banner-link-click",
+    );
+    expect(lightbox.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Vitest unit tests for the donate JavaScript modules under `foundation_cms/static/js/components/`.

- `donate_banner.test.js`: legacy dismissal via `localStorage`, banner visibility, close behavior, pushdown skip scrolling, site-type selector switching, and wagtail A/B testing CTA tracking
- `donate_lightbox.test.js`: modal open/close behavior, backdrop dismissal, and wagtail A/B testing CTA tracking

## Ticket

https://mozilla-hub.atlassian.net/browse/TP1-4148

Related GitHub issue: #16392

## Heroku preview app
N/A

## How to test locally

From the repo root:

```sh
yarn install
yarn workspace redesign test
```

Expected result: all tests pass, including the new donate component test files.

Optional watch mode while iterating:

```sh
yarn workspace redesign test:watch
```

## Checklist

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~Did I update or add new fake data?~~
- ~~Did I squash my migration?~~
- ~~Are my changes backward-compatible. If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~