### PR TITLE
test(vitest): add Vitest coverage for newsletter components

### DIFF
--- a/foundation_cms/static/js/components/newsletter_signup/newsletter_signup.test.js
+++ b/foundation_cms/static/js/components/newsletter_signup/newsletter_signup.test.js
@@ -1,0 +1,245 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+vi.mock("../../utils/csrf.js", () => ({
+  ensureCsrfToken: vi.fn().mockResolvedValue("test-csrf-token"),
+}));
+
+let injectNewsletterSignups;
+
+beforeAll(async () => {
+  window.gettext = (message) => message;
+  ({ default: injectNewsletterSignups } =
+    await import("./newsletter_signup.js"));
+});
+
+function buildSignupMarkup({
+  layout = "default",
+  currentLanguage = "en",
+  signupId = "footer",
+} = {}) {
+  document.body.innerHTML = `
+    <div
+      class="newsletter-signup__container"
+      data-signup-id="${signupId}"
+      data-layout="${layout}"
+      data-current-language="${currentLanguage}"
+    >
+      <form class="newsletter-signup__form">
+        <input name="email" type="email" value="" />
+        <select name="country"></select>
+        <select name="language"></select>
+        <input name="privacy" type="checkbox" />
+        <p class="email-error-message newsletter-signup__field-error--hidden"></p>
+        <p class="privacy-error-message newsletter-signup__field-error--hidden"></p>
+        <button class="newsletter-signup__button" type="submit">
+          <span class="loading-message" style="display: none">Loading</span>
+          <span class="btn-primary__rolltext">Sign up</span>
+        </button>
+        <div class="newsletter-signup__field newsletter-signup__field--hidden">
+          Extra field
+        </div>
+      </form>
+      <p class="newsletter-signup__success-message newsletter-signup__success-message--hidden">
+        Thanks for signing up
+      </p>
+      <p class="newsletter-signup__error-message newsletter-signup__error-message--hidden">
+        Something went wrong
+      </p>
+    </div>
+  `;
+}
+
+describe("injectNewsletterSignups", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    delete window.wagtailAbTesting;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 201,
+        ok: true,
+        json: vi.fn().mockResolvedValue({}),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does nothing when no signup containers are present", () => {
+    document.body.innerHTML = "";
+
+    expect(() =>
+      injectNewsletterSignups("https://foundation.test"),
+    ).not.toThrow();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("populates country and language selects and defaults unsupported languages to en", () => {
+    buildSignupMarkup({ currentLanguage: "unsupported" });
+    const countryInput = document.querySelector("select[name='country']");
+    const languageInput = document.querySelector("select[name='language']");
+
+    injectNewsletterSignups("https://foundation.test");
+
+    expect(countryInput.options.length).toBeGreaterThan(0);
+    expect(languageInput.options.length).toBeGreaterThan(0);
+    expect(languageInput.value).toBe("en");
+  });
+
+  it("reveals hidden fields immediately for expanded layouts", () => {
+    buildSignupMarkup({ layout: "expanded" });
+    const hiddenField = document.querySelector(".newsletter-signup__field");
+
+    injectNewsletterSignups("https://foundation.test");
+
+    expect(
+      hiddenField.classList.contains("newsletter-signup__field--hidden"),
+    ).toBe(false);
+  });
+
+  it("reveals hidden fields when the email input receives focus in default layouts", () => {
+    buildSignupMarkup({ layout: "default" });
+    const emailInput = document.querySelector("input[name='email']");
+    const hiddenField = document.querySelector(".newsletter-signup__field");
+
+    injectNewsletterSignups("https://foundation.test");
+    expect(
+      hiddenField.classList.contains("newsletter-signup__field--hidden"),
+    ).toBe(true);
+
+    emailInput.dispatchEvent(new Event("focus"));
+
+    expect(
+      hiddenField.classList.contains("newsletter-signup__field--hidden"),
+    ).toBe(false);
+  });
+
+  it("shows validation errors and skips the API call for invalid submissions", () => {
+    buildSignupMarkup();
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailError = document.querySelector(".email-error-message");
+    const privacyError = document.querySelector(".privacy-error-message");
+
+    injectNewsletterSignups("https://foundation.test");
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    expect(
+      emailError.classList.contains("newsletter-signup__field-error--hidden"),
+    ).toBe(false);
+    expect(
+      privacyError.classList.contains("newsletter-signup__field-error--hidden"),
+    ).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("submits valid signup data and shows the success message", async () => {
+    buildSignupMarkup({ signupId: "footer" });
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailInput = document.querySelector("input[name='email']");
+    const countryInput = document.querySelector("select[name='country']");
+    const languageInput = document.querySelector("select[name='language']");
+    const privacyCheckbox = document.querySelector("input[name='privacy']");
+    const successMessage = document.querySelector(
+      ".newsletter-signup__success-message",
+    );
+
+    injectNewsletterSignups("https://foundation.test");
+
+    emailInput.value = "person@example.com";
+    countryInput.value = countryInput.options[0].value;
+    languageInput.value = "en";
+    privacyCheckbox.checked = true;
+
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "https://foundation.test/newsletter-signup/footer/",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            email: "person@example.com",
+            country: countryInput.options[0].value,
+            lang: "en",
+            source: window.location.href,
+          }),
+        }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(form.classList.contains("newsletter-signup__form--hidden")).toBe(
+        true,
+      );
+      expect(
+        successMessage.classList.contains(
+          "newsletter-signup__success-message--hidden",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it("shows the error message when the API request fails", async () => {
+    buildSignupMarkup();
+    fetch.mockResolvedValueOnce({ status: 500, ok: false });
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailInput = document.querySelector("input[name='email']");
+    const privacyCheckbox = document.querySelector("input[name='privacy']");
+    const errorMessage = document.querySelector(
+      ".newsletter-signup__error-message",
+    );
+
+    injectNewsletterSignups("https://foundation.test");
+
+    emailInput.value = "person@example.com";
+    privacyCheckbox.checked = true;
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        errorMessage.classList.contains(
+          "newsletter-signup__error-message--hidden",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it("tracks footer newsletter submissions when wagtail A/B testing is enabled", async () => {
+    buildSignupMarkup();
+    window.wagtailAbTesting = { triggerEvent: vi.fn() };
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailInput = document.querySelector("input[name='email']");
+    const privacyCheckbox = document.querySelector("input[name='privacy']");
+
+    injectNewsletterSignups("https://foundation.test");
+
+    emailInput.value = "person@example.com";
+    privacyCheckbox.checked = true;
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(window.wagtailAbTesting.triggerEvent).toHaveBeenCalledWith(
+        "footer-newsletter-signup-submission",
+      );
+    });
+  });
+});

--- a/foundation_cms/static/js/components/newsletter_unsubscribe.js
+++ b/foundation_cms/static/js/components/newsletter_unsubscribe.js
@@ -8,6 +8,7 @@ const SELECTORS = {
   form: ".newsletter-signup__form",
   emailInput: "input[name='email']",
   emailErrorMessage: ".email-error-message",
+  successMessage: ".newsletter-signup__success-message",
   errorMessage: ".newsletter-signup__error-message",
   submitButton: ".newsletter-signup__button",
   loadingMessage: ".loading-message",
@@ -18,7 +19,10 @@ const SELECTORS = {
  * CSS class names used to toggle visibility or styling of DOM elements.
  */
 const CLASSNAMES = {
+  formHidden: "newsletter-signup__form--hidden",
+  successHidden: "newsletter-signup__success-message--hidden",
   errorHidden: "newsletter-signup__error-message--hidden",
+  fieldErrorHidden: "newsletter-signup__field-error--hidden",
 };
 
 /**
@@ -89,6 +93,7 @@ export default function injectNewsletterSignups(foundationSiteURL) {
     const emailInput = form.querySelector(SELECTORS.emailInput);
 
     const emailErrorMessage = form.querySelector(SELECTORS.emailErrorMessage);
+    const successMessage = container.querySelector(SELECTORS.successMessage);
     const errorMessage = container.querySelector(SELECTORS.errorMessage);
 
     const unsubscribeUrl = `${foundationSiteURL}/newsletter-unsubscribe/`;

--- a/foundation_cms/static/js/components/newsletter_unsubscribe.test.js
+++ b/foundation_cms/static/js/components/newsletter_unsubscribe.test.js
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../utils/csrf.js", () => ({
+vi.mock("../utils/csrf.js", () => ({
   ensureCsrfToken: vi.fn().mockResolvedValue("test-csrf-token"),
 }));
 
+import { ensureCsrfToken } from "../utils/csrf.js";
 import injectNewsletterSignups from "./newsletter_unsubscribe.js";
 
 let fetchMock;
@@ -19,6 +20,9 @@ function buildUnsubscribeMarkup() {
           <span class="btn-primary__rolltext">Unsubscribe</span>
         </button>
       </form>
+      <p class="newsletter-signup__success-message newsletter-signup__success-message--hidden">
+        You have been unsubscribed
+      </p>
       <p class="newsletter-signup__error-message newsletter-signup__error-message--hidden">
         Something went wrong
       </p>
@@ -34,11 +38,30 @@ function mockFetchResponse({ status, ok, body }) {
   }));
 }
 
+function mockLocationAssign() {
+  const assign = vi.fn();
+  const originalLocation = window.location;
+
+  delete window.location;
+  window.location = {
+    href: "https://foundation.test/current-page/",
+    assign,
+  };
+
+  return {
+    assign,
+    restore: () => {
+      window.location = originalLocation;
+    },
+  };
+}
+
 describe("injectNewsletterSignups (unsubscribe)", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
+    ensureCsrfToken.mockClear();
   });
 
   afterEach(() => {
@@ -52,32 +75,79 @@ describe("injectNewsletterSignups (unsubscribe)", () => {
       injectNewsletterSignups("https://foundation.test"),
     ).not.toThrow();
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(ensureCsrfToken).not.toHaveBeenCalled();
   });
 
   it("shows a validation error and skips the API call for invalid email addresses", () => {
     buildUnsubscribeMarkup();
     const form = document.querySelector(".newsletter-signup__form");
+    const emailError = document.querySelector(".email-error-message");
 
     injectNewsletterSignups("https://foundation.test");
     form.dispatchEvent(
       new Event("submit", { bubbles: true, cancelable: true }),
     );
 
+    expect(
+      emailError.classList.contains("newsletter-signup__field-error--hidden"),
+    ).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(ensureCsrfToken).not.toHaveBeenCalled();
   });
 
-  it("submits valid unsubscribe data to the API endpoint", async () => {
+  it("follows a server-directed redirect after a successful unsubscribe", async () => {
     buildUnsubscribeMarkup();
     mockFetchResponse({
       status: 200,
       ok: true,
       body: { redirect: "https://foundation.test/unsubscribed/" },
     });
+    const { assign, restore } = mockLocationAssign();
     const form = document.querySelector(".newsletter-signup__form");
     const emailInput = document.querySelector("input[name='email']");
-    const submitButton = document.querySelector(".newsletter-signup__button");
-    const errorMessage = document.querySelector(
-      ".newsletter-signup__error-message",
+
+    injectNewsletterSignups("https://foundation.test");
+
+    emailInput.value = "person@example.com";
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(ensureCsrfToken).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://foundation.test/newsletter-unsubscribe/",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "X-CSRFToken": "test-csrf-token",
+          }),
+          body: JSON.stringify({
+            email: "person@example.com",
+            source: window.location.href,
+          }),
+        }),
+      );
+      expect(assign).toHaveBeenCalledWith(
+        "https://foundation.test/unsubscribed/",
+      );
+    });
+
+    restore();
+  });
+
+  it("shows the success message for a non-redirect unsubscribe response", async () => {
+    buildUnsubscribeMarkup();
+    mockFetchResponse({
+      status: 201,
+      ok: true,
+      body: { status: "ok" },
+    });
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailInput = document.querySelector("input[name='email']");
+    const successMessage = document.querySelector(
+      ".newsletter-signup__success-message",
     );
 
     injectNewsletterSignups("https://foundation.test");
@@ -88,26 +158,15 @@ describe("injectNewsletterSignups (unsubscribe)", () => {
     );
 
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(
-        "https://foundation.test/newsletter-unsubscribe/",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({
-            email: "person@example.com",
-            source: window.location.href,
-          }),
-        }),
+      expect(ensureCsrfToken).toHaveBeenCalledTimes(1);
+      expect(form.classList.contains("newsletter-signup__form--hidden")).toBe(
+        true,
       );
-    });
-
-    await vi.waitFor(() => {
-      expect(submitButton.disabled).toBe(false);
-      expect(submitButton.getAttribute("aria-busy")).toBeNull();
       expect(
-        errorMessage.classList.contains(
-          "newsletter-signup__error-message--hidden",
+        successMessage.classList.contains(
+          "newsletter-signup__success-message--hidden",
         ),
-      ).toBe(true);
+      ).toBe(false);
     });
   });
 

--- a/foundation_cms/static/js/components/newsletter_unsubscribe.test.js
+++ b/foundation_cms/static/js/components/newsletter_unsubscribe.test.js
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../utils/csrf.js", () => ({
+  ensureCsrfToken: vi.fn().mockResolvedValue("test-csrf-token"),
+}));
+
+import injectNewsletterSignups from "./newsletter_unsubscribe.js";
+
+let fetchMock;
+
+function buildUnsubscribeMarkup() {
+  document.body.innerHTML = `
+    <div class="newsletter-unsubscribe__container">
+      <form class="newsletter-signup__form">
+        <input name="email" type="email" value="" />
+        <p class="email-error-message newsletter-signup__field-error--hidden"></p>
+        <button class="newsletter-signup__button" type="submit">
+          <span class="loading-message" style="display: none">Loading</span>
+          <span class="btn-primary__rolltext">Unsubscribe</span>
+        </button>
+      </form>
+      <p class="newsletter-signup__error-message newsletter-signup__error-message--hidden">
+        Something went wrong
+      </p>
+    </div>
+  `;
+}
+
+function mockFetchResponse({ status, ok, body }) {
+  fetchMock.mockImplementation(async () => ({
+    status,
+    ok,
+    json: async () => body,
+  }));
+}
+
+describe("injectNewsletterSignups (unsubscribe)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does nothing when no unsubscribe containers are present", () => {
+    document.body.innerHTML = "";
+
+    expect(() =>
+      injectNewsletterSignups("https://foundation.test"),
+    ).not.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a validation error and skips the API call for invalid email addresses", () => {
+    buildUnsubscribeMarkup();
+    const form = document.querySelector(".newsletter-signup__form");
+
+    injectNewsletterSignups("https://foundation.test");
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("submits valid unsubscribe data to the API endpoint", async () => {
+    buildUnsubscribeMarkup();
+    mockFetchResponse({
+      status: 200,
+      ok: true,
+      body: { redirect: "https://foundation.test/unsubscribed/" },
+    });
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailInput = document.querySelector("input[name='email']");
+    const submitButton = document.querySelector(".newsletter-signup__button");
+    const errorMessage = document.querySelector(
+      ".newsletter-signup__error-message",
+    );
+
+    injectNewsletterSignups("https://foundation.test");
+
+    emailInput.value = "person@example.com";
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://foundation.test/newsletter-unsubscribe/",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            email: "person@example.com",
+            source: window.location.href,
+          }),
+        }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(submitButton.disabled).toBe(false);
+      expect(submitButton.getAttribute("aria-busy")).toBeNull();
+      expect(
+        errorMessage.classList.contains(
+          "newsletter-signup__error-message--hidden",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("shows the error message when the API request fails", async () => {
+    buildUnsubscribeMarkup();
+    mockFetchResponse({
+      status: 500,
+      ok: false,
+      body: { status: "error" },
+    });
+    const form = document.querySelector(".newsletter-signup__form");
+    const emailInput = document.querySelector("input[name='email']");
+    const errorMessage = document.querySelector(
+      ".newsletter-signup__error-message",
+    );
+
+    injectNewsletterSignups("https://foundation.test");
+
+    emailInput.value = "person@example.com";
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        errorMessage.classList.contains(
+          "newsletter-signup__error-message--hidden",
+        ),
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds Vitest unit tests for the newsletter JavaScript modules under `foundation_cms/static/js/components/` and fixes unsubscribe form runtime states.

- `newsletter_signup/newsletter_signup.test.js`: select population, layout expansion, validation, successful/failed API submission, loading state, and wagtail A/B testing tracking with mocked `fetch` and CSRF helpers
- `newsletter_unsubscribe.test.js`: validation, API submission, error handling, and redirect responses with mocked `fetch` and CSRF helpers
- `newsletter_unsubscribe.js`: adds the missing success-message selector and visibility classes so invalid-email errors and successful submissions without a redirect display correctly

## Ticket

https://mozilla-hub.atlassian.net/browse/TP1-4149

Related GitHub issue: #16393

## Heroku preview app
N/A

## How to test locally

From the repo root:

```sh
yarn install
yarn workspace redesign test
```

Expected result: all tests pass, including the new newsletter test files.

Optional watch mode while iterating:

```sh
yarn workspace redesign test:watch
```

## Checklist

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~Did I update or add new fake data?~~
- ~~Did I squash my migration?~~
- ~~Are my changes backward-compatible. If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~
