### PR TITLE
Add Vitest coverage for shared JavaScript utilities

### DIFF
--- a/foundation_cms/static/js/blocks/util/carousel.test.js
+++ b/foundation_cms/static/js/blocks/util/carousel.test.js
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RESIZE_DEBOUNCE_MS,
+  SWIPE_THRESHOLD,
+  debounce,
+  getLogicalIndex,
+  tripleCards,
+  updateIndicators,
+} from "./carousel.js";
+
+describe("carousel utilities", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("exports the shared interaction timings", () => {
+    expect(SWIPE_THRESHOLD).toBe(50);
+    expect(RESIZE_DEBOUNCE_MS).toBe(200);
+  });
+
+  it.each([
+    [0, 3, 0],
+    [4, 3, 1],
+    [-1, 3, 2],
+    [-4, 3, 2],
+  ])(
+    "maps track index %s into a %s-item carousel",
+    (index, total, expected) => {
+      expect(getLogicalIndex(index, total)).toBe(expected);
+    },
+  );
+
+  it("triples cards while retaining the originals in the middle set", () => {
+    const cards = ["One", "Two"].map((label) => {
+      const card = document.createElement("article");
+      card.textContent = label;
+      return card;
+    });
+
+    const nodes = Array.from(tripleCards(cards).childNodes);
+
+    expect(nodes).toHaveLength(6);
+    expect(nodes.map((node) => node.textContent)).toEqual([
+      "One",
+      "Two",
+      "One",
+      "Two",
+      "One",
+      "Two",
+    ]);
+    expect(nodes[2]).toBe(cards[0]);
+    expect(nodes[3]).toBe(cards[1]);
+    expect(nodes[0]).not.toBe(cards[0]);
+    expect(nodes[4]).not.toBe(cards[0]);
+  });
+
+  it("updates indicator classes and aria state", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <button class="carousel-indicators__item carousel-indicators__item--active"></button>
+      <button class="carousel-indicators__item"></button>
+      <button class="carousel-indicators__item"></button>
+    `;
+
+    updateIndicators(root, 1);
+
+    const indicators = root.querySelectorAll(".carousel-indicators__item");
+    expect(indicators[0].classList).not.toContain(
+      "carousel-indicators__item--active",
+    );
+    expect(indicators[0].getAttribute("aria-current")).toBe("false");
+    expect(indicators[1].classList).toContain(
+      "carousel-indicators__item--active",
+    );
+    expect(indicators[1].getAttribute("aria-current")).toBe("true");
+    expect(indicators[2].getAttribute("aria-current")).toBe("false");
+  });
+
+  it("debounces calls and forwards the latest arguments", () => {
+    vi.useFakeTimers();
+    const callback = vi.fn();
+    const debounced = debounce(callback, 100);
+
+    debounced("first");
+    vi.advanceTimersByTime(50);
+    debounced("latest", 2);
+    vi.advanceTimersByTime(99);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith("latest", 2);
+  });
+});

--- a/foundation_cms/static/js/blocks/util/sliding_carousel.test.js
+++ b/foundation_cms/static/js/blocks/util/sliding_carousel.test.js
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SlidingCarousel } from "./sliding_carousel.js";
+
+const SELECTORS = {
+  viewport: ".viewport",
+  track: ".track",
+  item: ".item",
+};
+
+function createCarousel({ isCarousel = false, withCounter = true } = {}) {
+  document.body.innerHTML = `
+    <section class="carousel ${isCarousel ? "is-carousel" : ""}">
+      <div class="viewport">
+        <div class="track" style="column-gap: 8px; --carousel-transition: transform 200ms ease;">
+          <article class="item">One</article>
+          <article class="item">Two</article>
+          <article class="item">Three</article>
+        </div>
+      </div>
+      <button class="pagination-controls__prev">Previous</button>
+      <button class="pagination-controls__next">Next</button>
+      ${withCounter ? "<span data-active-index></span>" : ""}
+      <button class="carousel-indicators__item"></button>
+      <button class="carousel-indicators__item"></button>
+      <button class="carousel-indicators__item"></button>
+    </section>
+  `;
+
+  return new SlidingCarousel(document.querySelector(".carousel"), SELECTORS);
+}
+
+describe("SlidingCarousel", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (callback) => callback());
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: 100,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 768,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("initializes a tripled track at the first logical item", () => {
+    const carousel = createCarousel();
+
+    carousel.init();
+
+    expect(carousel.items).toHaveLength(9);
+    expect(carousel.index).toBe(3);
+    expect(carousel.slideOffset).toBe(108);
+    expect(carousel.track.style.transform).toBe("translateX(-324px)");
+    expect(carousel.track.style.transition).toBe("none");
+    expect(carousel.counterEl.textContent).toBe("1");
+    expect(carousel.root.getAttribute("tabindex")).toBe("0");
+    expect(
+      carousel.root.querySelector(".carousel-indicators__item--active"),
+    ).toBe(carousel.root.querySelector(".carousel-indicators__item"));
+  });
+
+  it("does not slide a non-carousel at the desktop breakpoint", () => {
+    const carousel = createCarousel();
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
+    const transformSpy = vi.spyOn(carousel, "updateTransform");
+
+    carousel.slideTo(4);
+
+    expect(carousel.index).toBe(3);
+    expect(transformSpy).not.toHaveBeenCalled();
+  });
+
+  it("slides an explicit carousel on wide viewports and updates its status", () => {
+    const carousel = createCarousel({ isCarousel: true });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1280,
+    });
+    carousel.slideOffset = 100;
+    carousel.carouselTransition = "transform 200ms ease";
+
+    carousel.slideTo(4);
+
+    expect(carousel.index).toBe(4);
+    expect(carousel.track.style.transform).toBe("translateX(-400px)");
+    expect(carousel.track.style.transition).toBe("transform 200ms ease");
+    expect(carousel.counterEl.textContent).toBe("2");
+    expect(
+      carousel.root
+        .querySelectorAll(".carousel-indicators__item")[1]
+        .getAttribute("aria-current"),
+    ).toBe("true");
+  });
+
+  it("loops forward from the next clone set", () => {
+    const carousel = createCarousel();
+    const transformSpy = vi.spyOn(carousel, "updateTransform");
+    const counterSpy = vi.spyOn(carousel, "updateCounter");
+
+    expect(carousel.handleLoop(carousel.nextCloneTrackStart)).toBe(true);
+
+    expect(carousel.index).toBe(4);
+    expect(transformSpy).toHaveBeenNthCalledWith(1, 3, false);
+    expect(transformSpy).toHaveBeenNthCalledWith(2, 4, true);
+    expect(counterSpy).toHaveBeenCalledOnce();
+  });
+
+  it("loops backward from the previous clone set", () => {
+    const carousel = createCarousel();
+    const transformSpy = vi.spyOn(carousel, "updateTransform");
+
+    expect(carousel.handleLoop(carousel.prevCloneTrackEnd)).toBe(true);
+
+    expect(carousel.index).toBe(5);
+    expect(transformSpy).toHaveBeenNthCalledWith(1, 6, false);
+    expect(transformSpy).toHaveBeenNthCalledWith(2, 5, true);
+  });
+
+  it("leaves ordinary indices for slideTo to handle", () => {
+    const carousel = createCarousel();
+
+    expect(carousel.handleLoop(4)).toBe(false);
+    expect(carousel.index).toBe(3);
+  });
+
+  it("only navigates for swipes beyond the threshold", () => {
+    const carousel = createCarousel();
+    const slideSpy = vi.spyOn(carousel, "slideTo").mockImplementation(() => {});
+
+    carousel.handleSwipe(50);
+    carousel.handleSwipe(-51);
+    carousel.handleSwipe(51);
+
+    expect(slideSpy).toHaveBeenCalledTimes(2);
+    expect(slideSpy).toHaveBeenNthCalledWith(1, 4);
+    expect(slideSpy).toHaveBeenNthCalledWith(2, 2);
+  });
+
+  it("binds pagination, keyboard, and drag interactions", () => {
+    const carousel = createCarousel();
+    const slideSpy = vi.spyOn(carousel, "slideTo").mockImplementation(() => {});
+    const swipeSpy = vi
+      .spyOn(carousel, "handleSwipe")
+      .mockImplementation(() => {});
+
+    carousel.bindEvents();
+    carousel.nextBtn.click();
+    carousel.prevBtn.click();
+    carousel.root.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight" }),
+    );
+    carousel.root.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowLeft" }),
+    );
+    carousel.viewport.dispatchEvent(
+      new MouseEvent("mousedown", { clientX: 100 }),
+    );
+    carousel.viewport.dispatchEvent(new MouseEvent("mouseup", { clientX: 20 }));
+
+    expect(slideSpy.mock.calls).toEqual([[4], [2], [4], [2]]);
+    expect(swipeSpy).toHaveBeenCalledWith(-80);
+  });
+
+  it("updates indicators even when the optional counter is absent", () => {
+    const carousel = createCarousel({ withCounter: false });
+    carousel.index = 5;
+
+    carousel.updateCounter();
+
+    expect(carousel.counterEl).toBeNull();
+    expect(
+      carousel.root
+        .querySelectorAll(".carousel-indicators__item")[2]
+        .getAttribute("aria-current"),
+    ).toBe("true");
+  });
+});

--- a/foundation_cms/static/js/utils/csrf.test.js
+++ b/foundation_cms/static/js/utils/csrf.test.js
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureCsrfToken, getCookie, initCsrfForms } from "./csrf.js";
+
+function clearCsrfCookie() {
+  document.cookie = "csrftoken=; Max-Age=0; path=/";
+}
+
+describe("CSRF utilities", () => {
+  beforeEach(() => {
+    clearCsrfCookie();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    clearCsrfCookie();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reads and decodes a named cookie", () => {
+    document.cookie = "other=value; path=/";
+    document.cookie = "csrftoken=token%20value; path=/";
+
+    expect(getCookie("csrftoken")).toBe("token value");
+    expect(getCookie("missing")).toBe("");
+  });
+
+  it("returns an existing token without fetching", async () => {
+    document.cookie = "csrftoken=existing; path=/";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(ensureCsrfToken()).resolves.toBe("existing");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("mints and returns a token when the cookie is absent", async () => {
+    const fetchMock = vi.fn(async () => {
+      document.cookie = "csrftoken=minted; path=/";
+      return { ok: true };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(ensureCsrfToken()).resolves.toBe("minted");
+    expect(fetchMock).toHaveBeenCalledWith("/api/csrf/", {
+      credentials: "same-origin",
+    });
+  });
+
+  it.each([
+    ["an unsuccessful response", vi.fn().mockResolvedValue({ ok: false })],
+    ["a network failure", vi.fn().mockRejectedValue(new Error("offline"))],
+  ])("returns an empty token after %s", async (_label, fetchMock) => {
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(ensureCsrfToken()).resolves.toBe("");
+  });
+
+  it("populates a form token and preserves the clicked submitter", async () => {
+    document.cookie = "csrftoken=form-token; path=/";
+    document.body.innerHTML = `
+      <form data-csrf-form>
+        <input type="hidden" data-csrf-field name="csrfmiddlewaretoken">
+        <button name="action" value="share">Share</button>
+      </form>
+    `;
+    const form = document.querySelector("form");
+    const submitter = form.querySelector("button");
+    const submitSpy = vi.spyOn(form, "submit").mockImplementation(() => {});
+    initCsrfForms();
+    const event = new SubmitEvent("submit", {
+      bubbles: true,
+      cancelable: true,
+      submitter,
+    });
+
+    form.dispatchEvent(event);
+
+    await vi.waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
+    expect(event.defaultPrevented).toBe(true);
+    expect(form.querySelector("[data-csrf-field]").value).toBe("form-token");
+    const mirror = form.querySelector("[data-csrf-submitter]");
+    expect(mirror.type).toBe("hidden");
+    expect(mirror.name).toBe("action");
+    expect(mirror.value).toBe("share");
+  });
+
+  it("allows a form with an existing token to submit normally", () => {
+    document.body.innerHTML = `
+      <form data-csrf-form>
+        <input data-csrf-field value="existing">
+      </form>
+    `;
+    const form = document.querySelector("form");
+    const submitSpy = vi.spyOn(form, "submit").mockImplementation(() => {});
+    initCsrfForms();
+    const event = new SubmitEvent("submit", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    form.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(submitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/foundation_cms/static/js/utils/csrf.test.js
+++ b/foundation_cms/static/js/utils/csrf.test.js
@@ -54,12 +54,20 @@ describe("CSRF utilities", () => {
   });
 
   it.each([
-    ["an unsuccessful response", vi.fn().mockResolvedValue({ ok: false })],
-    ["a network failure", vi.fn().mockRejectedValue(new Error("offline"))],
-  ])("returns an empty token after %s", async (_label, fetchMock) => {
+    [
+      "an unsuccessful response",
+      () => vi.fn().mockResolvedValue({ ok: false }),
+    ],
+    [
+      "a network failure",
+      () => vi.fn().mockRejectedValue(new Error("offline")),
+    ],
+  ])("returns an empty token after %s", async (_label, createFetchMock) => {
+    const fetchMock = createFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(ensureCsrfToken()).resolves.toBe("");
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("populates a form token and preserves the clicked submitter", async () => {

--- a/foundation_cms/static/js/utils/csrf.test.js
+++ b/foundation_cms/static/js/utils/csrf.test.js
@@ -47,6 +47,12 @@ describe("CSRF utilities", () => {
     });
   });
 
+  it("returns an empty token when minting succeeds without setting a cookie", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+
+    await expect(ensureCsrfToken()).resolves.toBe("");
+  });
+
   it.each([
     ["an unsuccessful response", vi.fn().mockResolvedValue({ ok: false })],
     ["a network failure", vi.fn().mockRejectedValue(new Error("offline"))],
@@ -83,6 +89,29 @@ describe("CSRF utilities", () => {
     expect(mirror.type).toBe("hidden");
     expect(mirror.name).toBe("action");
     expect(mirror.value).toBe("share");
+  });
+
+  it("submits the form with an empty token when token minting fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    document.body.innerHTML = `
+      <form data-csrf-form>
+        <input type="hidden" data-csrf-field name="csrfmiddlewaretoken">
+      </form>
+    `;
+    const form = document.querySelector("form");
+    const field = form.querySelector("[data-csrf-field]");
+    const submitSpy = vi.spyOn(form, "submit").mockImplementation(() => {});
+    initCsrfForms();
+    const event = new SubmitEvent("submit", {
+      bubbles: true,
+      cancelable: true,
+    });
+
+    form.dispatchEvent(event);
+
+    await vi.waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
+    expect(event.defaultPrevented).toBe(true);
+    expect(field.value).toBe("");
   });
 
   it("allows a form with an existing token to submit normally", () => {

--- a/foundation_cms/static/js/utils/csrf_global.test.js
+++ b/foundation_cms/static/js/utils/csrf_global.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { ensureCsrfToken, getCookie } from "./csrf.js";
+import "./csrf_global.js";
+
+describe("CSRF global entry point", () => {
+  it("exposes the shared helpers on window.FoundationCSRF", () => {
+    expect(window.FoundationCSRF).toEqual({ getCookie, ensureCsrfToken });
+  });
+});

--- a/foundation_cms/static/js/utils/csrf_global.test.js
+++ b/foundation_cms/static/js/utils/csrf_global.test.js
@@ -4,6 +4,7 @@ import "./csrf_global.js";
 
 describe("CSRF global entry point", () => {
   it("exposes the shared helpers on window.FoundationCSRF", () => {
-    expect(window.FoundationCSRF).toEqual({ getCookie, ensureCsrfToken });
+    expect(window.FoundationCSRF.getCookie).toBe(getCookie);
+    expect(window.FoundationCSRF.ensureCsrfToken).toBe(ensureCsrfToken);
   });
 });


### PR DESCRIPTION
## Description

Adds focused Vitest coverage for the shared redesign carousel and CSRF utilities, including the standalone global CSRF entry point.

## What Changed

- Covers carousel indexing, card cloning, indicator state, debouncing, responsive navigation, loop boundaries, and pointer and keyboard interactions.
- Covers CSRF cookie lookup, token minting and failure handling, native form submission, submitter preservation, and global helper exposure.

Related PRs/issues: [TP1-4150](https://mozilla-hub.atlassian.net/browse/TP1-4150), [GitHub issue #16394](https://github.com/MozillaFoundation/foundation.mozilla.org/issues/16394)