### PR TITLE
Center Nothing Personal hero titles and expand article media

### DIFF
--- a/foundation_cms/nothing_personal/tests/test_templates.py
+++ b/foundation_cms/nothing_personal/tests/test_templates.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+
+
+class HomePageHeroItemTemplateTests(SimpleTestCase):
+    def render_hero(self, orientation, **overrides):
+        context = {
+            "author": None,
+            "displayed_hero_content": "video",
+            "hero_video_url": "https://example.com/hero.mp4",
+            "hero_image": None,
+            "hero_image_alt_text": "Hero artwork",
+            "title": "A prominent hero headline",
+            "url": "/nothing-personal/hero/",
+        }
+        context.update(overrides)
+
+        return render_to_string(
+            "patterns/components/nothing_personal/home_page/_hero_item.html",
+            {"hero_item": SimpleNamespace(**context), "orientation": orientation},
+        )
+
+    def test_square_and_landscape_titles_use_centered_eight_column_span(self):
+        expected_title_class = 'class="featured-hero-item__text cell small-12 large-8 large-offset-2"'
+
+        for orientation in ("square", "landscape"):
+            with self.subTest(orientation=orientation):
+                self.assertIn(expected_title_class, self.render_hero(orientation))
+
+    def test_square_and_landscape_media_classes_are_preserved(self):
+        expected_media_classes = {
+            "square": (
+                "featured-hero-item__media featured-hero-item__media--square " "cell small-12 large-6 large-offset-3"
+            ),
+            "landscape": (
+                "featured-hero-item__media featured-hero-item__media--landscape "
+                "cell small-12 large-8 large-offset-2"
+            ),
+        }
+
+        for orientation, classes in expected_media_classes.items():
+            with self.subTest(orientation=orientation):
+                html = self.render_hero(orientation)
+                self.assertIn(f'class="{classes}"', html)
+                self.assertIn('href="/nothing-personal/hero/"', html)
+                self.assertIn(
+                    '<source src="https://example.com/hero.mp4" type="video/mp4">',
+                    html,
+                )
+
+    def test_webp_image_and_author_are_preserved(self):
+        image = SimpleNamespace(
+            file=SimpleNamespace(name="hero.webp", url="/media/hero.webp"),
+            height=900,
+            title="Hero image title",
+            width=1600,
+        )
+
+        html = self.render_hero(
+            "landscape",
+            author=SimpleNamespace(name="Hero Author"),
+            displayed_hero_content="image",
+            hero_image=image,
+            hero_video_url="",
+        )
+
+        self.assertIn('src="/media/hero.webp"', html)
+        self.assertIn('alt="Hero artwork"', html)
+        self.assertIn("Hero Author", html)
+
+
+class ArticlePageHeaderTemplateTests(SimpleTestCase):
+    def render_header(self, **overrides):
+        context = {
+            "author": SimpleNamespace(name="Article Author"),
+            "displayed_hero_content": "video",
+            "hero_caption": "Hero caption",
+            "hero_image": None,
+            "hero_image_alt_text": "Article hero artwork",
+            "hero_video_url": "https://example.com/article.mp4",
+            "title": "A centered article headline",
+        }
+        context.update(overrides)
+
+        return render_to_string(
+            "patterns/components/nothing_personal/_article_page_header.html",
+            {"page": SimpleNamespace(**context)},
+        )
+
+    def test_meta_and_media_use_confirmed_grid_spans(self):
+        html = self.render_header()
+
+        self.assertIn(
+            'class="article-header__meta cell small-12 medium-10 medium-offset-1 ' 'large-8 large-offset-2"',
+            html,
+        )
+        self.assertIn('class="article-header__hero cell small-12"', html)
+
+    def test_video_author_and_caption_are_preserved(self):
+        html = self.render_header()
+
+        self.assertIn("A centered article headline", html)
+        self.assertIn("Article Author", html)
+        self.assertIn(
+            '<source src="https://example.com/article.mp4" type="video/mp4">',
+            html,
+        )
+        self.assertIn('<p class="article-header__hero-caption">Hero caption</p>', html)
+
+    def test_webp_image_attributes_and_caption_are_preserved(self):
+        image = SimpleNamespace(
+            file=SimpleNamespace(name="article.webp", url="/media/article.webp"),
+            height=900,
+            title="Article image title",
+            width=1600,
+        )
+
+        html = self.render_header(
+            displayed_hero_content="image",
+            hero_image=image,
+            hero_video_url="",
+        )
+
+        self.assertIn('src="/media/article.webp"', html)
+        self.assertIn('width="1600"', html)
+        self.assertIn('height="900"', html)
+        self.assertIn('alt="Article hero artwork"', html)
+        self.assertIn('loading="lazy"', html)
+        self.assertIn('<p class="article-header__hero-caption">Hero caption</p>', html)

--- a/foundation_cms/nothing_personal/tests/test_templates.py
+++ b/foundation_cms/nothing_personal/tests/test_templates.py
@@ -98,6 +98,16 @@ class ArticlePageHeaderTemplateTests(SimpleTestCase):
         )
         self.assertIn('class="article-header__hero cell small-12"', html)
 
+    def test_parent_tagline_is_not_rendered(self):
+        html = self.render_header(
+            get_parent=lambda: SimpleNamespace(
+                specific=SimpleNamespace(tagline="<p>A visible Nothing Personal tagline</p>")
+            )
+        )
+
+        self.assertNotIn("article-header__tagline", html)
+        self.assertNotIn("A visible Nothing Personal tagline", html)
+
     def test_video_author_and_caption_are_preserved(self):
         html = self.render_header()
 

--- a/foundation_cms/static/scss/components/nothing_personal/article_page_header.scss
+++ b/foundation_cms/static/scss/components/nothing_personal/article_page_header.scss
@@ -5,9 +5,9 @@ body.nothing-personal.nothing-personal-article-page .article-header {
   &__meta {
     z-index: 1;
     position: relative;
-    margin-left: rem-calc(-6);
     margin-bottom: rem-calc(-54);
     height: fit-content;
+    text-align: center;
 
     @include breakpoint(large up) {
       margin-bottom: -100%;

--- a/foundation_cms/static/scss/components/nothing_personal/article_page_header.scss
+++ b/foundation_cms/static/scss/components/nothing_personal/article_page_header.scss
@@ -10,8 +10,7 @@ body.nothing-personal.nothing-personal-article-page .article-header {
     text-align: center;
 
     @include breakpoint(large up) {
-      margin-bottom: -100%;
-      margin-top: rem-calc(60);
+      margin-bottom: rem-calc(-70);
     }
   }
 

--- a/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/article_page.scss
@@ -38,6 +38,8 @@ body.nothing-personal.nothing-personal-article-page {
   }
 
   .brand-banner {
+    margin-bottom: $block-spacing-large;
+
     @include breakpoint(medium up) {
       margin-top: 1rem;
     }

--- a/foundation_cms/static/scss/pages/nothing_personal/home_page.scss
+++ b/foundation_cms/static/scss/pages/nothing_personal/home_page.scss
@@ -81,7 +81,7 @@ body.nothing-personal-home-page {
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
-      margin-left: rem-calc(-8);
+      text-align: center;
       text-decoration: none;
       color: map.get($mofo-colors, black);
     }

--- a/foundation_cms/templates/patterns/components/nothing_personal/_article_page_header.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/_article_page_header.html
@@ -1,14 +1,14 @@
 {% load wagtailimages_tags static responsive_image_tags %}
 
 <div class="article-header grid-x">
-  <header class="article-header__meta cell small-12 medium-10 medium-offset-1 large-8">
+  <header class="article-header__meta cell small-12 medium-10 medium-offset-1 large-8 large-offset-2">
     <h1 class="article-header__title">{{ page.title }}</h1>
     <span class="article-header__author-wrapper">
       <span class="article-header__author">{{ page.author.name }}</span>
     </span>
   </header>
 
-  <div class="article-header__hero cell small-12 medium-10 medium-offset-2 large-11 large-offset-1">
+  <div class="article-header__hero cell small-12">
     <figure class="article-header__hero-figure">
       <div class="article-header__hero-media">
         {% if page.displayed_hero_content == "video" and page.hero_video_url %}

--- a/foundation_cms/templates/patterns/components/nothing_personal/home_page/_hero_item.html
+++ b/foundation_cms/templates/patterns/components/nothing_personal/home_page/_hero_item.html
@@ -43,7 +43,7 @@
         {% endif %}
       </a>
 
-      <a class="featured-hero-item__text cell small-12 {% if orientation == "square" %}large-8 large-offset-2{% elif orientation == "landscape" %}large-10 large-offset-1{% endif %}" href="{{ hero_page.url }}">
+      <a class="featured-hero-item__text cell small-12 large-8 large-offset-2" href="{{ hero_page.url }}">
         <h1 class="featured-hero-item__title">{{ hero_page.title }}</h1>
         {% if hero_page.author %}
           <div class="featured-hero-item__author-wrapper">


### PR DESCRIPTION
## Description

Centers Nothing Personal hero headlines in predictable grid spans, removes the inherited homepage tagline from article pages, and gives article hero media the full content width. The article header keeps a consistent 4rem gap below the NP logo while preserving image, video, caption, author, responsive, and accessibility behavior.

## What Changed

- Centers the homepage featured hero title in an eight-column span for square and landscape variants while preserving the established overlay composition.
- Centers the article hero title and author metadata within eight columns on desktop and keeps them centered on mobile.
- Expands article hero media from its constrained offset layout to all 12 columns.
- Adds focused template coverage for the structural classes and preserved image, video, author, link, alt-text, and caption variants.

## QA

Review app:

- [Nothing Personal homepage](https://foundation-s-tp1-3660-p-brfjxy.mofostaging.net/en/nothing-personal/)
- [Two-line video article](https://foundation-s-tp1-3660-p-brfjxy.mofostaging.net/en/nothing-personal/qa-tp1-3660-long-title-image-hero/)
- [CMS homepage fixture (page 26)](https://foundation-s-tp1-3660-p-brfjxy.mofostaging.net/cms/pages/26/edit/)
- [CMS article fixture (page 27)](https://foundation-s-tp1-3660-p-brfjxy.mofostaging.net/cms/pages/27/edit/)

Verify that:

- On the homepage, the featured headline is centered in an eight-column span. The persistent fixture is currently landscape; square and landscape variants were both exercised.
- On the article, the homepage tagline is absent and the centered title begins 4rem below the NP logo on desktop and mobile.
- The title’s final-line midpoint meets the full-width hero’s top edge, the author remains fully over the media, and the two-line title stays centered without clipping.
- The production-matched video crop, persistent caption, lede, publication metadata, author section, topics, and More Stories content remain present and aligned.

## Screenshots

<table width="100%">
  <thead>
    <tr>
      <th width="50%">Before</th>
      <th width="50%">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td width="50%"><img width="100%" alt="Nothing Personal homepage — production before with the featured headline aligned left across a wider span" src="https://github.com/user-attachments/assets/64498810-61dc-40ef-8ca2-e20b9ade9b56" /></td>
      <td width="50%"><img width="100%" alt="Nothing Personal homepage — review-app after showing the production tagline, the copied two-line featured article title and video, and the same three secondary articles in production order" src="https://github.com/user-attachments/assets/5afd050a-0b73-4af4-a070-f1127687914e" /></td>
    </tr>
    <tr>
      <td width="50%"><em>Nothing Personal homepage — before (production): The featured headline uses the wider left-aligned treatment.</em></td>
      <td width="50%"><em>Nothing Personal homepage — after (review app): The production tagline is visible, the copied two-line featured article is centered in the predictable text-safe area, and the same three secondary articles appear in production order.</em></td>
    </tr>
  </tbody>
</table>

<table width="100%">
  <thead>
    <tr>
      <th width="50%">Before (recreated)</th>
      <th width="50%">Deployed after</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td width="50%"><img width="100%" alt="Nothing Personal article — browser-side recreation of the pre-change desktop layout using the How to Disappear: Shopping Online QA article and production hero video" src="https://github.com/user-attachments/assets/bd472ce2-3d83-41e9-bc3e-3a8828ffdb4d" /></td>
      <td width="50%"><img width="100%" alt="Nothing Personal article — deployed desktop review-app layout with a centered two-line title straddling the full-width production hero video" src="https://github.com/user-attachments/assets/6054fc7e-c3cf-4448-8c7c-12dbfa017c70" /></td>
    </tr>
    <tr>
      <td width="50%"><em>Nothing Personal article — before (browser-side recreation): The same QA article uses the prior left-aligned overlay and inset desktop hero.</em></td>
      <td width="50%"><em>Nothing Personal article — deployed after: The centered two-line title meets the full-width hero at its final-line midpoint; the author remains over the video.</em></td>
    </tr>
  </tbody>
</table>

<table width="100%">
  <thead>
    <tr>
      <th width="50%">Before (recreated)</th>
      <th width="50%">Deployed after</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td width="50%"><img width="100%" alt="Nothing Personal article — browser-side recreation of the pre-change mobile layout using the How to Disappear: Shopping Online QA article and production hero video" src="https://github.com/user-attachments/assets/e5d714c0-92f7-467c-a04b-953c6243ed48" /></td>
      <td width="50%"><img width="100%" alt="Nothing Personal article — deployed mobile review-app layout with a centered two-line title and full-width production hero video" src="https://github.com/user-attachments/assets/8bcb39f5-2d57-4de0-8326-fbdf8ed61a86" /></td>
    </tr>
    <tr>
      <td width="50%"><em>Nothing Personal article — before (browser-side recreation): The same QA article’s title is left-aligned on mobile.</em></td>
      <td width="50%"><em>Nothing Personal article — deployed after: The same two-line title is centered on mobile while preserving the author and hero relationship.</em></td>
    </tr>
  </tbody>
</table>

Related PRs/issues: [TP1-3660](https://mozilla-hub.atlassian.net/browse/TP1-3660), [GitHub issue #15404](https://github.com/MozillaFoundation/foundation.mozilla.org/issues/15404)