### PR TITLE
Remove rich-text block horizontal padding

### DIFF
--- a/foundation_cms/static/scss/blocks/themes/default/rich_text_block.scss
+++ b/foundation_cms/static/scss/blocks/themes/default/rich_text_block.scss
@@ -4,7 +4,7 @@
 @include block-wrapper("rich_text") {
   .rich-text-block {
     @include breakpoint(large up) {
-      @include grid-column(8);
+      @include grid-column(8, 0);
     }
   }
 
@@ -13,7 +13,7 @@
     .large-#{$i} {
       .rich-text-block {
         @include breakpoint(large up) {
-          @include grid-column(12);
+          @include grid-column(12, 0);
         }
       }
     }


### PR DESCRIPTION
## Description

Removes Foundation’s unintended 15px horizontal padding from default rich-text blocks while preserving the intended 8/12 desktop width and 12/12 width inside constrained layouts.

## What Changed

- Passes explicit zero-gutter arguments to both existing Foundation grid-column width calls.
- Preserves the default rich-text block’s responsive widths and stacking behavior.
- Keeps the change scoped to the default rich-text block SCSS.

## Screenshots

The **Before** images use the exact historical SCSS calls and a real watcher rebuild; the **After** images use the restored zero-gutter fix. Each overlay is measured from the live DOM and actual Foundation grid container. The six retained desktop pairs are the cases with a measured layout change.

Mobile layouts across all eight page types, plus the desktop Campaign Page and Nothing Personal Home Page regression cases, were verified unchanged.

<details>
<summary><strong>General Page</strong> — affected page-level rich text</summary>

Review app: [Open General Page in the review app](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/tp1-3879-rich-text-layout-qa/)

| Before | After |
| --- | --- |
| [![TP1-3879-01-general-page-desktop-before-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/74b0dcb1-b1a9-4dc1-b9c8-0749e71ee637)](https://github.com/user-attachments/assets/74b0dcb1-b1a9-4dc1-b9c8-0749e71ee637) | [![TP1-3879-01-general-page-desktop-after-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/c7f1f945-ea94-4a44-a4d0-225a7b4e8548)](https://github.com/user-attachments/assets/c7f1f945-ea94-4a44-a4d0-225a7b4e8548) |
| *Before: The historical Foundation gutter creates a measured 15px inner offset.* | *After: The intended and actual rich-text edges coincide at 0px.* |

</details>

<details>
<summary><strong>Home Page</strong> — affected page-level rich text</summary>

Review app: [Open Home Page in the review app](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/tp1-3879-core-home-page-qa/)

| Before | After |
| --- | --- |
| [![TP1-3879-02-home-page-desktop-before-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/87e54514-6315-4311-ab03-43455302b166)](https://github.com/user-attachments/assets/87e54514-6315-4311-ab03-43455302b166) | [![TP1-3879-02-home-page-desktop-after-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/5242d50a-f369-4913-8bff-79e65ec762c5)](https://github.com/user-attachments/assets/5242d50a-f369-4913-8bff-79e65ec762c5) |
| *Before: The historical Foundation gutter creates a measured 15px inner offset.* | *After: The intended and actual rich-text edges coincide at 0px.* |

</details>

<details>
<summary><strong>Project Page</strong> — affected page-level rich text</summary>

Review app: [Open Project Page in the review app](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/gallery/gallery-project-1/)

| Before | After |
| --- | --- |
| [![TP1-3879-03-project-page-desktop-before-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/ee127ac2-ce8a-4540-983c-d9465ed3d6be)](https://github.com/user-attachments/assets/ee127ac2-ce8a-4540-983c-d9465ed3d6be) | [![TP1-3879-03-project-page-desktop-after-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/f11b0016-b979-4e01-b29c-cec13c7a5bd7)](https://github.com/user-attachments/assets/f11b0016-b979-4e01-b29c-cec13c7a5bd7) |
| *Before: The historical Foundation gutter creates a measured 15px inner offset.* | *After: The intended and actual rich-text edges coincide at 0px.* |

</details>

<details>
<summary><strong>Nothing Personal Article Page</strong> — affected page-level rich text</summary>

Review app: [Open Nothing Personal Article Page in the review app](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/nothing-personal/expert-profile-article-1/)

| Before | After |
| --- | --- |
| [![TP1-3879-04-nothing-personal-article-page-desktop-before-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/4d28dada-6e36-4f7d-b010-43f29a1f0814)](https://github.com/user-attachments/assets/4d28dada-6e36-4f7d-b010-43f29a1f0814) | [![TP1-3879-04-nothing-personal-article-page-desktop-after-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/c5e3fdd9-55b6-42b9-8fe4-bcd401862c5f)](https://github.com/user-attachments/assets/c5e3fdd9-55b6-42b9-8fe4-bcd401862c5f) |
| *Before: The historical Foundation gutter creates a measured 15px inner offset.* | *After: The intended and actual rich-text edges coincide at 0px.* |

</details>

<details>
<summary><strong>Nothing Personal Podcast Page</strong> — affected page-level rich text</summary>

Review app: [Open Nothing Personal Podcast Page in the review app](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/nothing-personal/tp1-3879-podcast-page-qa/)

| Before | After |
| --- | --- |
| [![TP1-3879-05-nothing-personal-podcast-page-desktop-before-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/8edefebe-7ed4-4350-93a2-c3820cd3353c)](https://github.com/user-attachments/assets/8edefebe-7ed4-4350-93a2-c3820cd3353c) | [![TP1-3879-05-nothing-personal-podcast-page-desktop-after-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/7382f1e1-76b9-4180-b779-1a5c4bc9e280)](https://github.com/user-attachments/assets/7382f1e1-76b9-4180-b779-1a5c4bc9e280) |
| *Before: The historical Foundation gutter creates a measured 15px inner offset.* | *After: The intended and actual rich-text edges coincide at 0px.* |

</details>

<details>
<summary><strong>Expert Hub Page</strong> — affected page-level rich text</summary>

Review app: [Open Expert Hub Page in the review app](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/mozilla-expert-hub/)

| Before | After |
| --- | --- |
| [![TP1-3879-06-expert-hub-page-desktop-before-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/e6f076c6-fa4e-43e8-ba83-f3091d9267e2)](https://github.com/user-attachments/assets/e6f076c6-fa4e-43e8-ba83-f3091d9267e2) | [![TP1-3879-06-expert-hub-page-desktop-after-overlay-2040x1319-1x-fullpage](https://github.com/user-attachments/assets/1b1ecdc0-ba61-4ded-8973-3ac2aa81d065)](https://github.com/user-attachments/assets/1b1ecdc0-ba61-4ded-8973-3ac2aa81d065) |
| *Before: The historical Foundation gutter creates a measured 15px inner offset.* | *After: The intended and actual rich-text edges coincide at 0px.* |

</details>

## Review app / QA links

Primary affected page types:

- [General Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/tp1-3879-rich-text-layout-qa/)
- [Home Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/tp1-3879-core-home-page-qa/)
- [Project Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/gallery/gallery-project-1/)
- [Nothing Personal Article Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/nothing-personal/expert-profile-article-1/)
- [Nothing Personal Podcast Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/nothing-personal/tp1-3879-podcast-page-qa/)
- [Expert Hub Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/mozilla-expert-hub/)

Regression checks:

- [Campaign Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/tp1-3879-campaign-page-qa/)
- [Nothing Personal Home Page](https://foundation-s-tp1-3879-r-rfa3dp.mofostaging.net/en/nothing-personal/)

Related PRs/issues: [TP1-3879](https://mozilla-hub.atlassian.net/browse/TP1-3879), [#15830](https://github.com/MozillaFoundation/foundation.mozilla.org/issues/15830)