### PR TITLE
Bump django-redis from 5.4.0 to 7.0.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -124,7 +124,7 @@ types-python-slugify==8.0.2.20240310
     # via -r dev-requirements.in
 types-requests==2.33.0.20260712
     # via -r dev-requirements.in
-typing-extensions==4.4.0
+typing-extensions==4.16.0
     # via
     #   -c requirements.txt
     #   mypy

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ django-environ
 django-filter
 django-htmx
 django-pattern-library
-django-redis
+django-redis==7.0.0
 django-storages
 django-querystring-tag
 python-jose>=3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ django-permissionedforms==0.1
     # via wagtail
 django-querystring-tag==1.0.3
     # via -r requirements.in
-django-redis==5.4.0
+django-redis==7.0.0
     # via -r requirements.in
 django-storages==1.14.5
     # via -r requirements.in
@@ -246,10 +246,11 @@ toml==0.10.2
     # via wagtail-localize-git
 tqdm==4.63.0
     # via wagtail-inventory
-typing-extensions==4.4.0
+typing-extensions==4.16.0
     # via
     #   beautifulsoup4
     #   django-countries
+    #   django-redis
     #   django-stubs-ext
     #   django-tasks
     #   wagtail-localize


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
Bumps [django-redis](https://github.com/jazzband/django-redis) from 5.4.0 to 7.0.0.
Related dependabot PR https://github.com/MozillaFoundation/foundation.mozilla.org/pull/16038

Link to sample test page: https://foundation-s-tp1-4131-b-hqht1u.mofostaging.net/en/
Related PRs/issues: [TP1-4131](https://mozilla-hub.atlassian.net/browse/TP1-4131)

----

- Release notes
Sourced from <a href="https://github.com/jazzband/django-redis/releases">django-redis's releases</a>