### PR TITLE
Upgrade numpy and scipy transitive deps via wagtail-ab-testing

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -25,7 +25,7 @@ python-slugify
 requests
 social-auth-app-django
 wagtail==7.4.2
-wagtail-ab-testing
+wagtail-ab-testing==0.14.0
 wagtail-color-panel
 wagtail-factories
 wagtail-footnotes

--- a/requirements.txt
+++ b/requirements.txt
@@ -152,7 +152,7 @@ markdown==3.8.1
     # via django-pattern-library
 modelsearch==1.3.1
     # via wagtail
-numpy==1.24.4
+numpy==2.4.6
     # via
     #   scipy
     #   wagtail-ab-testing
@@ -217,7 +217,7 @@ rsa==4.9
     # via python-jose
 s3transfer==0.10.0
     # via boto3
-scipy==1.10.0
+scipy==1.17.1
     # via wagtail-ab-testing
 scout-apm==3.5.3
     # via -r requirements.in
@@ -275,7 +275,7 @@ wagtail==7.4.2
     #   wagtail-localize-git
     #   wagtail-metadata
     #   wagtailmedia
-wagtail-ab-testing==0.12
+wagtail-ab-testing==0.14
     # via -r requirements.in
 wagtail-color-panel==1.8.1
     # via -r requirements.in


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
Bumps [wagtail-ab-testing](https://github.com/wagtail-nest/wagtail-ab-testing) from 0.12 to 0.14 to upgrade `numpy` and `scipy`.
Related dependabot PR https://github.com/MozillaFoundation/foundation.mozilla.org/pull/16071

Link to sample test page: https://foundation-s-tp1-4134-u-lwtc3z.mofostaging.net/en/
Related PRs/issues: [TP1-4134](https://mozilla-hub.atlassian.net/browse/TP1-4134)

----

- Release notes
Sourced from <a href="https://github.com/wagtail-nest/wagtail-ab-testing/releases">wagtail-ab-testing's releases</a>