### PR TITLE
Fix localized Expert profile links on Expert Hub page

### DIFF
--- a/foundation_cms/profiles/models/expert_hub_page.py
+++ b/foundation_cms/profiles/models/expert_hub_page.py
@@ -96,8 +96,9 @@ class ExpertHubPage(AbstractBasePage):
             .select_related("expert", "expert__image")
             .prefetch_related("expert__topics")
         ):
+            expert = fe.expert.localized
             topic = fe.expert.topics.first()
-            featured_experts.append({"expert": fe.expert, "topic": topic})
+            featured_experts.append({"expert": expert, "topic": topic})
 
         context["featured_experts"] = featured_experts
 


### PR DESCRIPTION
# Description

<!-- Describe the PR here -->
This PR fixes expert profile links on translated Expert Hub pages always pointing to the English version of the expert's profile, regardless of the active locale.
Adding `.localized` resolves this by returning the active-locale translation if it exists, falling back to the English version  if no translation is available.

Link to sample test page: https://foundation-s-tp1-4173-f-82wwww.mofostaging.net/en/mozilla-expert-hub/
Related PRs/issues: [TP1-4173](https://mozilla-hub.atlassian.net/browse/TP1-4173)

#### How to Test (Review App)

1. Open the Review App and navigate to the Expert Hub page in a non-English locale (e.g. [/fr/mozilla-expert-hub/](https://foundation-s-tp1-4173-f-82wwww.mofostaging.net/fr/mozilla-expert-hub/))
2. Click any expert bubble
    - Expected: redirects to the French version of the expert profile (e.g [/fr/mozilla-expert-hub/expert-2/](https://foundation-s-tp1-4173-f-82wwww.mofostaging.net/fr/mozilla-expert-hub/expert-2/))

### Images
<img width="1453" height="986" alt="image" src="https://github.com/user-attachments/assets/20e81490-ef51-42cc-830c-9d546c240261" />
<img width="1398" height="971" alt="image" src="https://github.com/user-attachments/assets/dd761f16-c69c-4a96-8348-be4d3da05805" />
