### PR TITLE
ci add a language reset fixture

### DIFF
--- a/foundation_cms/conftest.py
+++ b/foundation_cms/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from django.utils import translation
+
+
+@pytest.fixture(autouse=True)
+def reset_active_language():
+    """Reset the thread-local active language after every test."""
+    # Tests call translation.activate() without ever undoing it, so the language
+    # otherwise leaks into later tests sharing the worker process.
+    yield
+    translation.deactivate()


### PR DESCRIPTION
# Description

Our CI sharding has revealed a leak in how our tests handle locale testing. Django keeps the active language in a process-wide thread-local and resets it only once per test run, so any test that calls `translation.activate()` without undoing it leaves that language active for every later test in the same pytest-xdist worker process. Sharding changed which tests share a worker, and shard 4 now happens to run a leaking test immediately before one that asserts English copy, so that test fails.
  
This PR adds an autouse fixture in `foundation_cms/conftest.py` that calls `translation.deactivate()` after every test, returning the language to the `settings.LANGUAGE_CODE` fallback that Django establishes at the start of a run.

The test case is that CI should now pass with this and fix #16294 ci testing once merged.