### PR TITLE
fix(api): standardize error-response shape across newsletter/webhook endpoints

### DIFF
--- a/foundation_cms/legacy_apps/events/tests.py
+++ b/foundation_cms/legacy_apps/events/tests.py
@@ -29,7 +29,7 @@ class TitoTicketCompletedTest(TestCase):
             self.url, data=self._webhook_data(), content_type="application/json", headers={"x-webhook-name": "invalid"}
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), "Not a ticket completed request")
+        self.assertEqual(json.loads(response.content)["error"], "Not a ticket completed request")
 
     def test_missing_tito_signature(self):
         response = self.client.post(
@@ -39,7 +39,7 @@ class TitoTicketCompletedTest(TestCase):
             headers={"x-webhook-name": "ticket.completed"},
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), "Payload verification failed")
+        self.assertEqual(json.loads(response.content)["error"], "Payload verification failed")
 
     def test_invalid_tito_signature(self):
         response = self.client.post(
@@ -49,7 +49,7 @@ class TitoTicketCompletedTest(TestCase):
             headers={"x-webhook-name": "ticket.completed", "tito-signature": "invalid"},
         )
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content.decode(), "Payload verification failed")
+        self.assertEqual(json.loads(response.content)["error"], "Payload verification failed")
 
     @mock.patch("foundation_cms.legacy_apps.events.views.basket")
     def test_calls_basket_api(self, mock_basket):

--- a/foundation_cms/legacy_apps/events/views.py
+++ b/foundation_cms/legacy_apps/events/views.py
@@ -8,7 +8,11 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from rest_framework import status
 
-from foundation_cms.views import error_json_response, process_lang_code, subscribe_to_camo_newsletter
+from foundation_cms.views import (
+    error_json_response,
+    process_lang_code,
+    subscribe_to_camo_newsletter,
+)
 
 from .utils import has_signed_up_to_newsletter, is_valid_tito_request
 

--- a/foundation_cms/legacy_apps/events/views.py
+++ b/foundation_cms/legacy_apps/events/views.py
@@ -3,11 +3,12 @@ import logging
 
 import basket
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from rest_framework import status
 
-from foundation_cms.views import process_lang_code, subscribe_to_camo_newsletter
+from foundation_cms.views import error_json_response, process_lang_code, subscribe_to_camo_newsletter
 
 from .utils import has_signed_up_to_newsletter, is_valid_tito_request
 
@@ -23,12 +24,12 @@ def tito_ticket_completed(request):
     # is it the correct webhook trigger?
     # https://ti.to/docs/api/admin#webhooks-triggers
     if not request.headers.get("x-webhook-name", "") == "ticket.completed":
-        return HttpResponseBadRequest("Not a ticket completed request")
+        return error_json_response("Not a ticket completed request", status.HTTP_400_BAD_REQUEST)
 
     # does the payload hash signature match
     tito_signature = request.headers.get("tito-signature", "")
     if not is_valid_tito_request(tito_signature, request.body):
-        return HttpResponseBadRequest("Payload verification failed")
+        return error_json_response("Payload verification failed", status.HTTP_400_BAD_REQUEST)
 
     # have they signed up to the newsletter?
     data = json.loads(request.body.decode())

--- a/foundation_cms/views.py
+++ b/foundation_cms/views.py
@@ -173,7 +173,7 @@ def subscribe_to_basket_newsletter(data):
 
     if response["status"] == "ok":
         return JsonResponse(data, status=status.HTTP_201_CREATED)
-    return JsonResponse(data, status=status.HTTP_400_BAD_REQUEST)
+    return error_json_response("There was an error subscribing to the newsletter", status.HTTP_400_BAD_REQUEST)
 
 
 def subscribe_to_camo_newsletter(data):
@@ -192,7 +192,7 @@ def subscribe_to_camo_newsletter(data):
     if resp.status_code == 200:
         return JsonResponse(data, status=status.HTTP_201_CREATED)
 
-    return JsonResponse(data, status=status.HTTP_400_BAD_REQUEST)
+    return error_json_response("There was an error subscribing to the newsletter", status.HTTP_400_BAD_REQUEST)
 
 
 @require_http_methods(["POST"])

--- a/foundation_cms/views.py
+++ b/foundation_cms/views.py
@@ -22,6 +22,11 @@ from foundation_cms.snippets.models.newsletter_signup import NewsletterSignup
 logger = logging.getLogger(__name__)
 
 
+def error_json_response(message, status_code):
+    """Standard JSON shape for API error responses: {"error": <message>}."""
+    return JsonResponse({"error": message}, status=status_code)
+
+
 class EnvVariablesView(View):
     """
     A view that permits a GET to expose allowlisted environment
@@ -90,12 +95,7 @@ def newsletter_signup_submission_view(request, pk):
     try:
         request.data = json.loads(new_body)
     except ValueError:
-        return JsonResponse(
-            {
-                "error": "Could not validate incoming data",
-            },
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return error_json_response("Could not validate incoming data", status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     try:
         signup = NewsletterSignup.objects.get(id=pk)
@@ -115,20 +115,12 @@ def illustrated_newsletter_signup_submission_view(request, pk):
     try:
         request.data = json.loads(new_body)
     except ValueError:
-        return JsonResponse(
-            {
-                "error": "Could not validate incoming data",
-            },
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        )
+        return error_json_response("Could not validate incoming data", status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     try:
         signup = IllustratedNewsletterSignup.objects.get(id=pk)
     except ObjectDoesNotExist:
-        return JsonResponse(
-            {"error": "Newsletter signup not found"},
-            status=status.HTTP_404_NOT_FOUND,
-        )
+        return error_json_response("Newsletter signup not found", status.HTTP_404_NOT_FOUND)
 
     return newsletter_signup_submission(request, signup.newsletter)
 
@@ -140,17 +132,11 @@ def newsletter_signup_submission(request, newsletter):
     # payload validation
     email = rq.get("email")
     if email is None:
-        return JsonResponse(
-            {"error": "Signup requires an email address"},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+        return error_json_response("Signup requires an email address", status.HTTP_400_BAD_REQUEST)
 
     source = rq.get("source")
     if source is None:
-        return JsonResponse(
-            {"error": "Unknown source"},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+        return error_json_response("Unknown source", status.HTTP_400_BAD_REQUEST)
 
     newsletter = newsletter.strip().lower()
 
@@ -217,10 +203,7 @@ def newsletter_unsubscribe_view(request):
     # payload validation
     email = data.get("email")
     if email is None:
-        return JsonResponse(
-            {"error": "Signup requires an email address"},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+        return error_json_response("Signup requires an email address", status.HTTP_400_BAD_REQUEST)
 
     unsubscribe_request = requests.post(
         settings.UNSUBSCRIBE_NEWSLETTER_ENDPOINT,
@@ -233,4 +216,4 @@ def newsletter_unsubscribe_view(request):
             {"status": "ok", "redirect": settings.SUCCESSFUL_UNSUBSCRIBE_REDIRECT_URL}, status=status.HTTP_200_OK
         )
     else:
-        return JsonResponse({"error": "There was an error unsubscribing"}, status=status.HTTP_400_BAD_REQUEST)
+        return error_json_response("There was an error unsubscribing", status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
# Description

- Adds a shared `error_json_response()` helper and adopts it across `views.py` (pure refactor).
- Fixes `subscribe_to_basket_newsletter`/`subscribe_to_camo_newsletter`, which echoed the submitted payload with no error message on failure.
- Fixes the Tito webhook, which returned plain text instead of JSON on validation failure.

Link to sample test page:
Related PRs/issues: [Jira TP1-4119](https://mozilla-hub.atlassian.net/browse/TP1-4119) / #16344 
