### PR TITLE
ci: drop the Chrome apt repo before apt-get update

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -118,6 +118,10 @@ jobs:
             apt-archives-test_backend-gettext-ffmpeg-${{ runner.os }}-${{ matrix.shard }}-
       - name: Install additional tooling
         run: |
+          # The runner image ships Google's Chrome apt repo, which periodically
+          # serves an index whose hash does not match its Release file. None of
+          # these packages come from it, but apt-get update still exits 100.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y gettext ffmpeg
       - name: Prepare test environment
@@ -244,6 +248,10 @@ jobs:
             apt-archives-test_integration-gettext-libgconf-2-4-${{ runner.os }}-
       - name: Install additional tooling
         run: |
+          # The runner image ships Google's Chrome apt repo, which periodically
+          # serves an index whose hash does not match its Release file. None of
+          # these packages come from it, but apt-get update still exits 100.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y gettext libgconf-2-4
       - name: Install Playwright

--- a/.github/workflows/visual-regression-testing-legacy.yml
+++ b/.github/workflows/visual-regression-testing-legacy.yml
@@ -111,6 +111,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Install additional tooling
         run: |
+          # The runner image ships Google's Chrome apt repo, which periodically
+          # serves an index whose hash does not match its Release file. None of
+          # these packages come from it, but apt-get update still exits 100.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y gettext libgconf-2-4
       - name: Install Playwright

--- a/.github/workflows/visual-regression-testing-redesign.yml
+++ b/.github/workflows/visual-regression-testing-redesign.yml
@@ -132,6 +132,10 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Install additional tooling
         run: |
+          # The runner image ships Google's Chrome apt repo, which periodically
+          # serves an index whose hash does not match its Release file. None of
+          # these packages come from it, but apt-get update still exits 100.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update
           sudo apt-get install -y gettext libgconf-2-4
       - name: Install Playwright


### PR DESCRIPTION
The GitHub runner image ships Google's Chrome apt repo. It periodically serves an index whose hash does not match its Release file, and `apt-get update` exits 100 even though none of the packages we install come from that repo.

Removing the repo file before `apt-get update` in the three workflows that install apt packages.

Split out of #16564 at review request, since it addresses a general runner issue rather than that branch's feature.