### PR TITLE
Point How Do I Wagtail at Confluence

### DIFF
--- a/foundation_cms/legacy_apps/templates/pages/styleguide.html
+++ b/foundation_cms/legacy_apps/templates/pages/styleguide.html
@@ -880,7 +880,7 @@
                         </div>
                     {% endif %}
                     {% if block.block_type == 'datawrapper' %}
-                        <p>To learn more about the datawrapper component visit <a href="https://www.mozillafoundation.org/en/docs/how-do-i-wagtail/datawrapper/">here</a></p>
+                        <p>To learn more about the datawrapper component visit <a href="https://mozilla-hub.atlassian.net/wiki/spaces/FOUNDATION/pages/1824489491/How+Do+I+Wagtail">here</a></p>
                     {% endif %}
                 {% endfor %}
 

--- a/foundation_cms/legacy_apps/wagtailpages/tests/test_how_do_i_wagtail.py
+++ b/foundation_cms/legacy_apps/wagtailpages/tests/test_how_do_i_wagtail.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from django.urls import reverse
+
+CONFLUENCE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FOUNDATION/pages/1824489491/How+Do+I+Wagtail"
+
+
+class HowDoIWagtailRedirectTests(TestCase):
+    def test_redirects_to_confluence(self):
+        response = self.client.get(reverse("how-do-i-wagtail"))
+
+        self.assertRedirects(response, CONFLUENCE_URL, fetch_redirect_response=False)

--- a/foundation_cms/urls.py
+++ b/foundation_cms/urls.py
@@ -115,7 +115,9 @@ urlpatterns = list(
             # Wagtail CMS routes
             re_path(
                 r"^how-do-i-wagtail/",
-                RedirectView.as_view(url="/docs/how-do-i-wagtail/"),
+                RedirectView.as_view(
+                    url="https://mozilla-hub.atlassian.net/wiki/spaces/FOUNDATION/pages/1824489491/How+Do+I+Wagtail"
+                ),
                 name="how-do-i-wagtail",
             ),
             path("", include(image_url_tag_urls)),


### PR DESCRIPTION
# Description

The "How Do I Wagtail" link in the admin sidebar now goes to the [How Do I Wagtail Confluence page](https://mozilla-hub.atlassian.net/wiki/spaces/FOUNDATION/pages/1824489491/How+Do+I+Wagtail) instead of `/docs/how-do-i-wagtail/`, so the old CMS docs can be removed. The `/how-do-i-wagtail/` route is kept and now redirects to Confluence, which keeps old bookmarks working. The styleguide datawrapper link also points to Confluence.

## After deploy (manual CMS steps)

The docs pages are CMS content, so they are removed by hand once this is live:

- [ ] Unpublish `/en/docs/how-do-i-wagtail/` with "include descendants" checked.
- [ ] Delete the `how-do-i-wagtail` page in every locale: en, fr, nl, fy-NL, de, pl, pt-BR, es, sw, ca. The localized trees are aliases of the English page, and deleting the English page does not remove them.
- [ ] Add a redirect from `/en/docs/how-do-i-wagtail` to the Confluence page.
- [ ] Confirm `/fr/docs/how-do-i-wagtail/` returns 404 and the rest of `/docs/` (e.g. `/docs/brand/`) still loads.

## Ticket
Jira: https://mozilla-hub.atlassian.net/browse/TP1-4212

## Heroku
Preview app: https://foundation-s-tp1-4212-r-2xnalu.herokuapp.com/

## How to test

Log into `/cms/` and click "How Do I Wagtail" at the bottom of the sidebar. It should open Confluence.

Link to sample test page: `/how-do-i-wagtail/`
Related PRs/issues: [TP1-4212](https://mozilla-hub.atlassian.net/browse/TP1-4212)

# Checklist

**Tests**
- [x] Is the code I'm adding covered by tests?

**Changes in Models:**
- ~~Did I update or add new fake data?~~
- ~~Did I squash my migration?~~
- ~~Are my changes backward-compatible? If not, did I schedule a deploy with the rest of the team?~~

**Documentation:**
- ~~Is my code documented?~~
- ~~Did I update the READMEs or wagtail documentation?~~
