### PR TITLE
test(percy): add barebones GeneralPage Percy coverage

### DIFF
--- a/foundation_cms/base/utils/helpers.py
+++ b/foundation_cms/base/utils/helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import factory
 from django.core.files.images import ImageFile
+from django.test import Client
 from wagtail.blocks.stream_block import StreamValue
 from wagtail.images import get_image_model
 
@@ -143,3 +144,22 @@ def get_faker():
     Get faker helper function
     """
     return factory.faker.Faker._get_faker(locale="en-US")
+
+
+def prewarm_page_renditions(page):
+    """
+    Render a freshly-generated page once, right now, so every image rendition
+    it needs already exists in the database. Otherwise the first real request
+    to this page has to generate every rendition cold, and if anything else
+    requests the same URL around the same time (e.g. Percy's own
+    asset-discovery crawl) they can race trying to insert the same
+    not-yet-existing rendition rows.
+
+    Call this after publishing any newly-generated page whose images were
+    just created (e.g. via a fresh ImageFactory() per data-generation run),
+    since those are the ones with no pre-existing renditions to fall back on.
+    """
+    try:
+        Client().get(page.url, SERVER_NAME="localhost")
+    except Exception as e:
+        print(f"Warning: failed to pre-warm image renditions for {page}: {e}")

--- a/foundation_cms/core/factories/__init__.py
+++ b/foundation_cms/core/factories/__init__.py
@@ -1,4 +1,6 @@
+from .general_page import GeneralPageFactory
+from .general_page import generate as generate_general_page
 from .homepage import HomePageFactory
 from .homepage import generate as generate_homepage
 
-__all__ = ["HomePageFactory", "generate_homepage"]
+__all__ = ["GeneralPageFactory", "generate_general_page", "HomePageFactory", "generate_homepage"]

--- a/foundation_cms/core/factories/general_page.py
+++ b/foundation_cms/core/factories/general_page.py
@@ -1,8 +1,7 @@
-from django.test import Client
 from wagtail.models import Locale, Page, Site
 from wagtail_factories import PageFactory
 
-from foundation_cms.base.utils.helpers import reseed
+from foundation_cms.base.utils.helpers import prewarm_page_renditions, reseed
 from foundation_cms.core.factories.general_page_data import build_general_page_body
 from foundation_cms.core.models.general_page import GeneralPage
 
@@ -45,21 +44,7 @@ def generate(parent=None, seed=42, slug="general-page-1"):
 
     parent.add_child(instance=page)
     page.save_revision().publish()
-    _prewarm_image_renditions(page)
+    prewarm_page_renditions(page)
 
     print(f"General Page demo created under {parent}.")
     return page
-
-
-def _prewarm_image_renditions(page):
-    """
-    Render the page once, right now, so every image rendition it needs already
-    exists in the database. Otherwise the first real request to this page has
-    to generate every rendition cold, and if anything else requests the same
-    URL around the same time (e.g. Percy's own asset-discovery crawl) they can
-    race trying to insert the same not-yet-existing rendition rows.
-    """
-    try:
-        Client().get(page.url, SERVER_NAME="localhost")
-    except Exception as e:
-        print(f"Warning: failed to pre-warm image renditions for {page}: {e}")

--- a/foundation_cms/core/factories/general_page.py
+++ b/foundation_cms/core/factories/general_page.py
@@ -16,7 +16,7 @@ class GeneralPageFactory(PageFactory):
     show_hero = False
 
 
-def generate(parent=None, seed=42, slug="general-page-demo"):
+def generate(parent=None, seed=42, slug="general-page-1"):
     """
     Generate a GeneralPage with the given parent, seed, and slug.
     Returns the created GeneralPage instance.

--- a/foundation_cms/core/factories/general_page.py
+++ b/foundation_cms/core/factories/general_page.py
@@ -1,0 +1,49 @@
+from wagtail.models import Locale, Page, Site
+from wagtail_factories import PageFactory
+
+from foundation_cms.base.utils.helpers import reseed
+from foundation_cms.core.factories.general_page_data import build_general_page_body
+from foundation_cms.core.models.general_page import GeneralPage
+
+
+class GeneralPageFactory(PageFactory):
+    class Meta:
+        model = GeneralPage
+
+    title = "General Page"
+    seo_title = "General Page"
+    search_description = "A General Page built to exercise body block types that have factories."
+    show_hero = False
+
+
+def generate(parent=None, seed=42, slug="general-page-demo"):
+    """
+    Generate a GeneralPage with the given parent, seed, and slug.
+    Returns the created GeneralPage instance.
+    """
+    reseed(seed)
+
+    if parent is None:
+        site = Site.objects.filter(is_default_site=True).first()
+        parent = site.root_page if site else Page.get_first_root_node()
+        if not parent.pk:
+            parent.save()
+
+    locale = Locale.get_default()
+
+    existing = GeneralPage.objects.filter(slug=slug, locale=locale).first()
+    if existing:
+        print("General Page demo already exists.")
+        return existing
+
+    page = GeneralPageFactory.build(
+        slug=slug,
+        locale=locale,
+        body=build_general_page_body(),
+    )
+
+    parent.add_child(instance=page)
+    page.save_revision().publish()
+
+    print(f"General Page demo created under {parent}.")
+    return page

--- a/foundation_cms/core/factories/general_page.py
+++ b/foundation_cms/core/factories/general_page.py
@@ -1,3 +1,4 @@
+from django.test import Client
 from wagtail.models import Locale, Page, Site
 from wagtail_factories import PageFactory
 
@@ -44,6 +45,21 @@ def generate(parent=None, seed=42, slug="general-page-1"):
 
     parent.add_child(instance=page)
     page.save_revision().publish()
+    _prewarm_image_renditions(page)
 
     print(f"General Page demo created under {parent}.")
     return page
+
+
+def _prewarm_image_renditions(page):
+    """
+    Render the page once, right now, so every image rendition it needs already
+    exists in the database. Otherwise the first real request to this page has
+    to generate every rendition cold, and if anything else requests the same
+    URL around the same time (e.g. Percy's own asset-discovery crawl) they can
+    race trying to insert the same not-yet-existing rendition rows.
+    """
+    try:
+        Client().get(page.url, SERVER_NAME="localhost")
+    except Exception as e:
+        print(f"Warning: failed to pre-warm image renditions for {page}: {e}")

--- a/foundation_cms/core/factories/general_page_data.py
+++ b/foundation_cms/core/factories/general_page_data.py
@@ -1,3 +1,5 @@
+from wagtail.images import get_image_model
+
 from foundation_cms.base.factories import ImageFactory
 from foundation_cms.blocks.factories import (
     ActivationCardBlockFactory,
@@ -18,6 +20,23 @@ from foundation_cms.blocks.factories import (
     VideoBlockFactory,
 )
 
+Image = get_image_model()
+
+# A small, reused image pool rather than a fresh ImageFactory() per card:
+# this page is rendered for the first time in CI right alongside the rest of
+# load_redesign_data, so every distinct image means fresh renditions have to
+# be generated cold. Reusing a couple of titles keeps that cost bounded and
+# matches the pattern homepage_data.py already uses for its own images.
+_SHARED_IMAGE_TITLES = ["General Page placeholder 1", "General Page placeholder 2"]
+
+
+def _get_or_create_shared_images():
+    ids = []
+    for title in _SHARED_IMAGE_TITLES:
+        existing = Image.objects.filter(title=title).first()
+        ids.append(existing.id if existing else ImageFactory(title=title).id)
+    return ids
+
 
 def _pillar_card():
     return dict(
@@ -27,16 +46,18 @@ def _pillar_card():
     )
 
 
-def _activation_card():
-    return {"type": "card", "value": dict(ActivationCardBlockFactory())}
+def _activation_card(image_id):
+    return {"type": "card", "value": dict(ActivationCardBlockFactory(image=image_id))}
 
 
 def build_general_page_body():
     """One instance of each GeneralPage body block type that already has a factory."""
+    image_1, image_2 = _get_or_create_shared_images()
+
     return [
         {"type": "title_block", "value": dict(TitleBlockFactory(title="General page block coverage"))},
         {"type": "quote", "value": dict(QuoteBlockFactory())},
-        {"type": "custom_media", "value": dict(CustomMediaBlockFactory(image=ImageFactory().id))},
+        {"type": "custom_media", "value": dict(CustomMediaBlockFactory(image=image_1))},
         {"type": "video_block", "value": dict(VideoBlockFactory())},
         {"type": "newsletter_signup", "value": dict(NewsletterSignupBlockFactory())},
         {
@@ -58,7 +79,13 @@ def build_general_page_body():
         {
             "type": "timely_activations_cards",
             "value": dict(
-                TimelyActivationsCardsBlockFactory(cards=[_activation_card(), _activation_card(), _activation_card()])
+                TimelyActivationsCardsBlockFactory(
+                    cards=[
+                        _activation_card(image_1),
+                        _activation_card(image_2),
+                        _activation_card(image_1),
+                    ]
+                )
             ),
         },
         {
@@ -66,13 +93,13 @@ def build_general_page_body():
             "value": dict(
                 SpotlightCardSetBlockFactory(
                     cards=[
-                        dict(SpotlightCardBlockFactory()),
-                        dict(SpotlightCardBlockFactory()),
-                        dict(SpotlightCardBlockFactory()),
+                        dict(SpotlightCardBlockFactory(image=image_2)),
+                        dict(SpotlightCardBlockFactory(image=image_1)),
+                        dict(SpotlightCardBlockFactory(image=image_2)),
                     ]
                 )
             ),
         },
-        {"type": "featured_card_block", "value": dict(FeaturedCardBlockFactory())},
+        {"type": "featured_card_block", "value": dict(FeaturedCardBlockFactory(image=image_1))},
         {"type": "link_button_block", "value": dict(LinkButtonBlockFactory())},
     ]

--- a/foundation_cms/core/factories/general_page_data.py
+++ b/foundation_cms/core/factories/general_page_data.py
@@ -1,0 +1,78 @@
+from foundation_cms.base.factories import ImageFactory
+from foundation_cms.blocks.factories import (
+    ActivationCardBlockFactory,
+    CustomMediaBlockFactory,
+    FeaturedCardBlockFactory,
+    ImpactNumberBlockFactory,
+    ImpactStatBlockFactory,
+    LinkBlockFactory,
+    LinkButtonBlockFactory,
+    NewsletterSignupBlockFactory,
+    PillarCardBlockFactory,
+    PillarCardSetBlockFactory,
+    QuoteBlockFactory,
+    SpotlightCardBlockFactory,
+    SpotlightCardSetBlockFactory,
+    TimelyActivationsCardsBlockFactory,
+    TitleBlockFactory,
+    VideoBlockFactory,
+)
+
+
+def _pillar_card():
+    return dict(
+        PillarCardBlockFactory(
+            cta_link=[dict(LinkBlockFactory(link_to="external_url"))],
+        )
+    )
+
+
+def _activation_card():
+    return {"type": "card", "value": dict(ActivationCardBlockFactory())}
+
+
+def build_general_page_body():
+    """One instance of each GeneralPage body block type that already has a factory."""
+    return [
+        {"type": "title_block", "value": dict(TitleBlockFactory(title="General page block coverage"))},
+        {"type": "quote", "value": dict(QuoteBlockFactory())},
+        {"type": "custom_media", "value": dict(CustomMediaBlockFactory(image=ImageFactory().id))},
+        {"type": "video_block", "value": dict(VideoBlockFactory())},
+        {"type": "newsletter_signup", "value": dict(NewsletterSignupBlockFactory())},
+        {
+            "type": "pillar_card_set",
+            "value": dict(PillarCardSetBlockFactory(cards=[_pillar_card(), _pillar_card(), _pillar_card()])),
+        },
+        {
+            "type": "impact_numbers",
+            "value": dict(
+                ImpactNumberBlockFactory(
+                    stats=[
+                        dict(ImpactStatBlockFactory()),
+                        dict(ImpactStatBlockFactory()),
+                        dict(ImpactStatBlockFactory()),
+                    ]
+                )
+            ),
+        },
+        {
+            "type": "timely_activations_cards",
+            "value": dict(
+                TimelyActivationsCardsBlockFactory(cards=[_activation_card(), _activation_card(), _activation_card()])
+            ),
+        },
+        {
+            "type": "spotlight_card_set_block",
+            "value": dict(
+                SpotlightCardSetBlockFactory(
+                    cards=[
+                        dict(SpotlightCardBlockFactory()),
+                        dict(SpotlightCardBlockFactory()),
+                        dict(SpotlightCardBlockFactory()),
+                    ]
+                )
+            ),
+        },
+        {"type": "featured_card_block", "value": dict(FeaturedCardBlockFactory())},
+        {"type": "link_button_block", "value": dict(LinkButtonBlockFactory())},
+    ]

--- a/foundation_cms/core/factories/general_page_data.py
+++ b/foundation_cms/core/factories/general_page_data.py
@@ -55,11 +55,13 @@ def build_general_page_body():
     image_1, image_2 = _get_or_create_shared_images()
 
     return [
+        # Text & headings
         {"type": "title_block", "value": dict(TitleBlockFactory(title="General page block coverage"))},
         {"type": "quote", "value": dict(QuoteBlockFactory())},
+        # Media
         {"type": "custom_media", "value": dict(CustomMediaBlockFactory(image=image_1))},
         {"type": "video_block", "value": dict(VideoBlockFactory())},
-        {"type": "newsletter_signup", "value": dict(NewsletterSignupBlockFactory())},
+        # Cards & grids
         {
             "type": "pillar_card_set",
             "value": dict(PillarCardSetBlockFactory(cards=[_pillar_card(), _pillar_card(), _pillar_card()])),
@@ -101,5 +103,8 @@ def build_general_page_body():
             ),
         },
         {"type": "featured_card_block", "value": dict(FeaturedCardBlockFactory(image=image_1))},
+        # Forms & signups
+        {"type": "newsletter_signup", "value": dict(NewsletterSignupBlockFactory())},
+        # CTAs & embeds
         {"type": "link_button_block", "value": dict(LinkButtonBlockFactory())},
     ]

--- a/foundation_cms/core/management/commands/load_redesign_data.py
+++ b/foundation_cms/core/management/commands/load_redesign_data.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 from wagtail.models import Page, Site
 
 from foundation_cms.base.factories import generate_images, generate_topics
-from foundation_cms.core.factories import generate_homepage
+from foundation_cms.core.factories import generate_general_page, generate_homepage
 from foundation_cms.footer.factories import generate as generate_footer
 from foundation_cms.gallery_hub.factories import generate as generate_gallery
 from foundation_cms.navigation.factories import generate as generate_navigation
@@ -65,6 +65,11 @@ class Command(BaseCommand):
         self.stdout.write("Generating Gallery Hub content...")
         generate_gallery(seed=42)
         self.stdout.write(self.style.SUCCESS("Gallery Hub setup complete."))
+
+        # Generate General Page
+        self.stdout.write("Generating General Page...")
+        general_page = generate_general_page(seed=42)
+        self.stdout.write(self.style.SUCCESS(f'General Page active: "{general_page.title}"'))
 
     def assign_homepage_as_site_root(self, homepage, hostname, port):
         site = Site.objects.get(is_default_site=True)

--- a/frontend/redesign/tests/redesign-urls.js
+++ b/frontend/redesign/tests/redesign-urls.js
@@ -6,6 +6,7 @@ const RedesignURLs = {
   Homepage: "/",
   "Nothing Personal Home": "/nothing-personal/",
   "Nothing Personal Article": "/nothing-personal/expert-profile-article-1/",
+  "General Page": "/general-page-1/",
 };
 
 export default RedesignURLs;

--- a/frontend/redesign/tests/visual.spec.js
+++ b/frontend/redesign/tests/visual.spec.js
@@ -8,8 +8,13 @@ const runTime = Date.now();
 
 function testFoundationURL(path) {
   return async ({ page }, testInfo) => {
+    // page.goto() already waits for the "load" event by default. We deliberately
+    // don't also wait for "networkidle" here: pages with a live embed (e.g. a
+    // Vimeo iframe in a video_block) can keep making background network calls
+    // indefinitely, which means networkidle may never resolve even though the
+    // page is fully rendered. waitForImagesToLoad below is our actual
+    // readiness check before snapshotting.
     await page.goto(`${foundationBaseUrl()}${path}`);
-    await page.waitForLoadState("networkidle");
     await waitForImagesToLoad(page);
     await percySnapshot(page, testInfo.title);
     await page.screenshot({


### PR DESCRIPTION
# Description

Adds barebones Percy coverage for `GeneralPage`, per [TP1-4234](https://mozilla-hub.atlassian.net/browse/TP1-4234).

- New `GeneralPageFactory` + `build_general_page_body()` covering the 11 body block types that already have factories.
- Wired into `load_redesign_data.py` (as a child of the redesign homepage, alongside Expert Hub/Gallery Hub).
- Added a `redesign-urls.js` entry so it gets a Percy snapshot.

The remaining ~18 body block types don't have factories yet, those are being added in [TP1-4233](https://mozilla-hub.atlassian.net/browse/TP1-4233), which will wire each one into this same page as it lands so Percy coverage grows incrementally rather than all at once.


Review app: general page https://foundation-s-tp1-4234-g-gty62l.mofostaging.net/en/general-page-1/
Percy snapshot for general page: [here](https://percy.io/Mozilla-Foundation/web/mozillafoundation.org-Redesign-95a4cbce/builds/53757957/changed/2915832561?browser=safari)
Related PRs/issues: [Jira TP1-4234](https://mozilla-hub.atlassian.net/browse/TP1-4234) / #16605 